### PR TITLE
record: fix LogWriter's chunk alignment

### DIFF
--- a/internal/record/log_writer.go
+++ b/internal/record/log_writer.go
@@ -273,7 +273,7 @@ func (w *LogWriter) WriteRecord(p []byte) (int64, error) {
 		return -1, w.err
 	}
 
-	for i := 0; len(p) > 0; i++ {
+	for i := 0; i == 0 || len(p) > 0; i++ {
 		p = w.emitFragment(i, p)
 	}
 
@@ -307,7 +307,7 @@ func (w *LogWriter) emitFragment(n int, p []byte) []byte {
 	binary.LittleEndian.PutUint16(b.buf[i+4:i+6], uint16(r))
 	atomic.StoreInt32(&b.written, j)
 
-	if blockSize-b.written <= headerSize {
+	if blockSize-b.written < headerSize {
 		// There is no room for another fragment in the block, so fill the
 		// remaining bytes with zeros and queue the block for flushing.
 		for i := b.written; i < blockSize; i++ {

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -166,6 +166,9 @@ func (r *Reader) nextChunk(wantFirst bool) error {
 					//
 					// Set r.err to be an error so r.Recover actually recovers.
 					r.err = errors.New("pebble/record: block appears to be zeroed")
+					if !r.recovering {
+						return r.err
+					}
 					r.Recover()
 					continue
 				}


### PR DESCRIPTION
Fixes #36.

This commit fixes two bugs in the record.LogWriter and adds tests for the
LogWriter alongside the record.Writer.

The first bug is that a record of length zero were skipped over and not
written. I'm not sure if this behaviour is ever exercised in practice,
but it is exercised by the tests for Writer so fixing it makes testing
simpler.

The second bug is the cause of #36: each chunk header is 7 bytes long,
and no chunk can span block boundaries. When there is insufficient space
left in a block to write an entire record, a "starting" chunk is written
and we move onto the next block to write the rest of it. If there are
exactly seven bytes available in the block, the original Writer would
write the seven byte header despite not having any room to write any
body bytes, while the LogWriter would omit them. This manifested as the
Reader thinking that it was seeing a zeroed out block.  This commit
brings LogWriter's behaviour in line with Writer does, and what the
Reader expects.

I've also made a change suggested by @petermattis to error out in the
case of a zero-block instead of attempting to recover. This required
removing a test, and was also masking the second bug in tests. The log should
probably be truncated here and a log message generated stating that some
data was likely lost (but we have recovered to a consistent point in
time).