### PR TITLE
*: rename InlineKey to AbbreviatedKey

### DIFF
--- a/cmd/pebble/mvcc.go
+++ b/cmd/pebble/mvcc.go
@@ -18,7 +18,7 @@ import (
 var mvccComparer = &db.Comparer{
 	Compare: mvccCompare,
 
-	InlineKey: func(k []byte) uint64 {
+	AbbreviatedKey: func(k []byte) uint64 {
 		key, _, ok := mvccSplitKey(k)
 		if !ok {
 			return 0

--- a/db.go
+++ b/db.go
@@ -121,12 +121,12 @@ type Writer interface {
 //		Comparer: myComparer,
 //	})
 type DB struct {
-	dirname   string
-	opts      *db.Options
-	cmp       db.Compare
-	equal     db.Equal
-	merge     db.Merge
-	inlineKey db.InlineKey
+	dirname        string
+	opts           *db.Options
+	cmp            db.Compare
+	equal          db.Equal
+	merge          db.Merge
+	abbreviatedKey db.AbbreviatedKey
 
 	tableCache tableCache
 	newIters   tableNewIters

--- a/db/comparer.go
+++ b/db/comparer.go
@@ -21,11 +21,12 @@ type Compare func(a, b []byte) int
 // for comparison purposes).
 type Equal func(a, b []byte) bool
 
-// InlineKey returns a fixed length prefix of a user key such that InlineKey(a)
-// < InlineKey(b) iff a < b and InlineKey(a) > InlineKey(b) iff a > b. If
-// InlineKey(a) == InlineKey(b) an additional comparison is required to
-// determine if the two keys are actually equal.
-type InlineKey func(key []byte) uint64
+// AbbreviatedKey returns a fixed length prefix of a user key such that
+// AbbreviatedKey(a) < AbbreviatedKey(b) iff a < b and AbbreviatedKey(a) >
+// AbbreviatedKey(b) iff a > b. If AbbreviatedKey(a) == AbbreviatedKey(b) an
+// additional comparison is required to determine if the two keys are actually
+// equal.
+type AbbreviatedKey func(key []byte) uint64
 
 // Separator appends a sequence of bytes x to dst such that
 // a <= x && x < b, where 'less than' is consistent with Compare.
@@ -52,11 +53,11 @@ type Successor func(dst, a []byte) []byte
 // Comparer defines a total ordering over the space of []byte keys: a 'less
 // than' relationship.
 type Comparer struct {
-	Compare   Compare
-	Equal     Equal
-	InlineKey InlineKey
-	Separator Separator
-	Successor Successor
+	Compare        Compare
+	Equal          Equal
+	AbbreviatedKey AbbreviatedKey
+	Separator      Separator
+	Successor      Successor
 
 	// Name is the name of the comparer.
 	//
@@ -72,7 +73,7 @@ var DefaultComparer = &Comparer{
 	Compare: bytes.Compare,
 	Equal:   bytes.Equal,
 
-	InlineKey: func(key []byte) uint64 {
+	AbbreviatedKey: func(key []byte) uint64 {
 		var v uint64
 		n := 8
 		if n > len(key) {

--- a/internal/batchskl/iterator.go
+++ b/internal/batchskl/iterator.go
@@ -48,7 +48,7 @@ func (it *Iterator) Close() error {
 // equal to the given key. Returns true if the iterator is pointing at a
 // valid entry and false otherwise.
 func (it *Iterator) SeekGE(key []byte) bool {
-	_, it.nd, _ = it.seekForBaseSplice(key, it.list.storage.InlineKey(key))
+	_, it.nd, _ = it.seekForBaseSplice(key, it.list.storage.AbbreviatedKey(key))
 	return it.nd != it.list.tail
 }
 
@@ -56,7 +56,7 @@ func (it *Iterator) SeekGE(key []byte) bool {
 // key. Returns true if the iterator is pointing at a valid entry and false
 // otherwise.
 func (it *Iterator) SeekLT(key []byte) (found bool) {
-	it.nd, _, _ = it.seekForBaseSplice(key, it.list.storage.InlineKey(key))
+	it.nd, _, _ = it.seekForBaseSplice(key, it.list.storage.AbbreviatedKey(key))
 	return it.nd != it.list.head
 }
 
@@ -114,11 +114,11 @@ func (it *Iterator) Valid() bool {
 }
 
 func (it *Iterator) seekForBaseSplice(
-	key []byte, inlineKey uint64,
+	key []byte, abbreviatedKey uint64,
 ) (prev, next uint32, found bool) {
 	prev = it.list.head
 	for level := it.list.height - 1; ; level-- {
-		prev, next, found = it.list.findSpliceForLevel(key, inlineKey, level, prev)
+		prev, next, found = it.list.findSpliceForLevel(key, abbreviatedKey, level, prev)
 		if found {
 			break
 		}

--- a/internal/batchskl/skl_test.go
+++ b/internal/batchskl/skl_test.go
@@ -71,8 +71,8 @@ func (d *testStorage) Get(offset uint32) db.InternalKey {
 	return db.InternalKey{UserKey: d.keys[offset]}
 }
 
-func (d *testStorage) InlineKey(key []byte) uint64 {
-	return db.DefaultComparer.InlineKey(key)
+func (d *testStorage) AbbreviatedKey(key []byte) uint64 {
+	return db.DefaultComparer.AbbreviatedKey(key)
 }
 
 func (d *testStorage) Compare(a []byte, b uint32) int {

--- a/open.go
+++ b/open.go
@@ -65,7 +65,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 		cmp:               opts.Comparer.Compare,
 		equal:             opts.Comparer.Equal,
 		merge:             opts.Merger.Merge,
-		inlineKey:         opts.Comparer.InlineKey,
+		abbreviatedKey:    opts.Comparer.AbbreviatedKey,
 		commitController:  newController(rate.NewLimiter(defaultRateLimit, defaultBurst)),
 		compactController: newController(rate.NewLimiter(defaultRateLimit, defaultBurst)),
 		flushController:   newController(rate.NewLimiter(rate.Inf, defaultBurst)),


### PR DESCRIPTION
The key "abbreviated key" is borrowed from Postgres and more accurately
describes the functionality.