### PR TITLE
Add AbbreviatedKey support to mergingIter

### DIFF
--- a/cmd/pebble/mvcc.go
+++ b/cmd/pebble/mvcc.go
@@ -26,6 +26,8 @@ var mvccComparer = &db.Comparer{
 		return db.DefaultComparer.AbbreviatedKey(key)
 	},
 
+	Equal: bytes.Equal,
+
 	Separator: func(dst, a, b []byte) []byte {
 		return append(dst, a...)
 	},

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -559,7 +559,7 @@ func TestIsBaseLevelForUkey(t *testing.T) {
 
 	for _, tc := range testCases {
 		c := compaction{
-			cmp:     db.DefaultComparer.Compare,
+			cmp:     db.DefaultComparer,
 			version: &tc.version,
 			level:   tc.level,
 		}
@@ -770,7 +770,7 @@ func TestManualCompaction(t *testing.T) {
 }
 
 func TestCompactionShouldStopBefore(t *testing.T) {
-	cmp := db.DefaultComparer.Compare
+	cmp := db.DefaultComparer
 	var grandparents []fileMetadata
 
 	parseMeta := func(s string) fileMetadata {
@@ -806,7 +806,7 @@ func TestCompactionShouldStopBefore(t *testing.T) {
 					}
 					grandparents = append(grandparents, meta)
 				}
-				sort.Sort(bySmallest{grandparents, cmp})
+				sort.Sort(bySmallest{grandparents, cmp.Compare})
 				return ""
 
 			case "compact":
@@ -848,7 +848,7 @@ func TestCompactionShouldStopBefore(t *testing.T) {
 }
 
 func TestCompactionExpandInputs(t *testing.T) {
-	cmp := db.DefaultComparer.Compare
+	cmp := db.DefaultComparer
 	var files []fileMetadata
 
 	parseMeta := func(s string) fileMetadata {
@@ -875,7 +875,7 @@ func TestCompactionExpandInputs(t *testing.T) {
 					meta.fileNum = uint64(len(files))
 					files = append(files, meta)
 				}
-				sort.Sort(bySmallest{files, cmp})
+				sort.Sort(bySmallest{files, cmp.Compare})
 				return ""
 
 			case "expand-inputs":

--- a/db/comparer.go
+++ b/db/comparer.go
@@ -28,10 +28,13 @@ type Compare func(a, b []byte) int
 // Equal is a (potentially faster) specialization of Compare.
 type Equal func(a, b []byte) bool
 
-// AbbreviatedKey returns a fixed length prefix of a user key such that AbbreviatedKey(a)
-// < AbbreviatedKey(b) iff a < b and AbbreviatedKey(a) > AbbreviatedKey(b) iff a > b. If
-// AbbreviatedKey(a) == AbbreviatedKey(b) an additional comparison is required to
-// determine if the two keys are actually equal.
+// AbbreviatedKey returns a fixed length prefix of a user key such that:
+//
+//   AbbreviatedKey(a) < AbbreviatedKey(b) implies a < b and
+//   AbbreviatedKey(a) > AbbreviatedKey(b) implies a > b.
+//
+// If AbbreviatedKey(a) == AbbreviatedKey(b) an additional comparison is
+// required to determine if the two keys are actually equal.
 //
 // This helps optimize indexed batch comparisons for cache locality. If a Split
 // function is specified, AbbreviatedKey usually returns the first eight bytes

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -244,14 +244,14 @@ func TestIterator(t *testing.T) {
 	var vals [][]byte
 
 	newIter := func(seqNum uint64, opts *db.IterOptions) *Iterator {
-		cmp := db.DefaultComparer.Compare
+		cmp := db.DefaultComparer
 		equal := db.DefaultComparer.Equal
 		// NB: Use a mergingIter to filter entries newer than seqNum.
 		iter := newMergingIter(cmp, &fakeIter{keys: keys, vals: vals})
 		iter.snapshot = seqNum
 		return &Iterator{
 			opts:  opts,
-			cmp:   cmp,
+			cmp:   cmp.Compare,
 			equal: equal,
 			merge: db.DefaultMerger.Merge,
 			iter:  iter,

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -201,11 +201,12 @@ func (m *mergingIter) initHeap() {
 	m.heap.items = m.heap.items[:0]
 	for i, t := range m.iters {
 		if t.Valid() {
+			key := t.Key()
 			m.heap.items = append(m.heap.items, mergingIterItem{
-				index: i,
-				key:   t.Key(),
-				value: t.Value(),
-				abbreviatedKey: m.heap.cmp.AbbreviatedKey(t.Key().UserKey),
+				index:          i,
+				key:            key,
+				value:          t.Value(),
+				abbreviatedKey: m.heap.cmp.AbbreviatedKey(key.UserKey),
 			})
 		}
 	}
@@ -344,7 +345,9 @@ func (m *mergingIter) nextEntry(item *mergingIterItem) {
 	oldTopLevel := item.index
 	iter := m.iters[item.index]
 	if iter.Next() {
-		item.key, item.value = iter.Key(), iter.Value()
+		item.key = iter.Key()
+		item.value = iter.Value()
+		item.abbreviatedKey = m.heap.cmp.AbbreviatedKey(item.key.UserKey)
 		if m.heap.len() > 1 {
 			m.heap.fix(0)
 		}
@@ -412,7 +415,9 @@ func (m *mergingIter) prevEntry(item *mergingIterItem) {
 	oldTopLevel := item.index
 	iter := m.iters[item.index]
 	if iter.Prev() {
-		item.key, item.value = iter.Key(), iter.Value()
+		item.key = iter.Key()
+		item.value = iter.Value()
+		item.abbreviatedKey = m.heap.cmp.AbbreviatedKey(item.key.UserKey)
 		if m.heap.len() > 1 {
 			m.heap.fix(0)
 		}

--- a/merging_iter_heap.go
+++ b/merging_iter_heap.go
@@ -10,10 +10,11 @@ type mergingIterItem struct {
 	index int
 	key   db.InternalKey
 	value []byte
+	abbreviatedKey uint64
 }
 
 type mergingIterHeap struct {
-	cmp     db.Compare
+	cmp     *db.Comparer
 	reverse bool
 	items   []mergingIterItem
 }
@@ -24,7 +25,7 @@ func (h *mergingIterHeap) len() int {
 
 func (h *mergingIterHeap) less(i, j int) bool {
 	ikey, jkey := h.items[i].key, h.items[j].key
-	if c := h.cmp(ikey.UserKey, jkey.UserKey); c != 0 {
+	if c := h.cmp.Compare(ikey.UserKey, jkey.UserKey); c != 0 {
 		if h.reverse {
 			return c > 0
 		}

--- a/merging_iter_heap.go
+++ b/merging_iter_heap.go
@@ -4,12 +4,14 @@
 
 package pebble
 
-import "github.com/petermattis/pebble/db"
+import (
+	"github.com/petermattis/pebble/db"
+)
 
 type mergingIterItem struct {
-	index int
-	key   db.InternalKey
-	value []byte
+	index          int
+	key            db.InternalKey
+	value          []byte
 	abbreviatedKey uint64
 }
 
@@ -24,7 +26,14 @@ func (h *mergingIterHeap) len() int {
 }
 
 func (h *mergingIterHeap) less(i, j int) bool {
-	ikey, jkey := h.items[i].key, h.items[j].key
+	iitem, jitem := h.items[i], h.items[j]
+	if iitem.abbreviatedKey < jitem.abbreviatedKey {
+		return !h.reverse
+	}
+	if iitem.abbreviatedKey > jitem.abbreviatedKey {
+		return h.reverse
+	}
+	ikey, jkey := iitem.key, jitem.key
 	if c := h.cmp.Compare(ikey.UserKey, jkey.UserKey); c != 0 {
 		if h.reverse {
 			return c > 0

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestMergingIter(t *testing.T) {
 	newFunc := func(iters ...internalIterator) internalIterator {
-		return newMergingIter(db.DefaultComparer.Compare, iters...)
+		return newMergingIter(db.DefaultComparer, iters...)
 	}
 	testIterator(t, newFunc, func(r *rand.Rand) [][]string {
 		// Shuffle testKeyValuePairs into one or more splits. Each individual
@@ -55,7 +55,7 @@ func TestMergingIterSeek(t *testing.T) {
 				iters = append(iters, f)
 			}
 
-			iter := newMergingIter(db.DefaultComparer.Compare, iters...)
+			iter := newMergingIter(db.DefaultComparer, iters...)
 			defer iter.Close()
 			return runInternalIterCmd(d, iter)
 
@@ -112,7 +112,7 @@ func TestMergingIterNextPrev(t *testing.T) {
 						}
 					}
 
-					iter := newMergingIter(db.DefaultComparer.Compare, iters...)
+					iter := newMergingIter(db.DefaultComparer, iters...)
 					defer iter.Close()
 					return runInternalIterCmd(d, iter)
 
@@ -201,7 +201,7 @@ func BenchmarkMergingIterSeekGE(b *testing.B) {
 							for i := range readers {
 								iters[i] = readers[i].NewIter(nil)
 							}
-							m := newMergingIter(db.DefaultComparer.Compare, iters...)
+							m := newMergingIter(db.DefaultComparer, iters...)
 							rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 							b.ResetTimer()
@@ -228,7 +228,7 @@ func BenchmarkMergingIterNext(b *testing.B) {
 							for i := range readers {
 								iters[i] = readers[i].NewIter(nil)
 							}
-							m := newMergingIter(db.DefaultComparer.Compare, iters...)
+							m := newMergingIter(db.DefaultComparer, iters...)
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
@@ -257,7 +257,7 @@ func BenchmarkMergingIterPrev(b *testing.B) {
 							for i := range readers {
 								iters[i] = readers[i].NewIter(nil)
 							}
-							m := newMergingIter(db.DefaultComparer.Compare, iters...)
+							m := newMergingIter(db.DefaultComparer, iters...)
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {

--- a/open.go
+++ b/open.go
@@ -62,16 +62,11 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 	d := &DB{
 		dirname:           dirname,
 		opts:              opts,
-		cmp:               opts.Comparer.Compare,
-		equal:             opts.Comparer.Equal,
+		cmp:               opts.Comparer,
 		merge:             opts.Merger.Merge,
-		abbreviatedKey:    opts.Comparer.AbbreviatedKey,
 		commitController:  newController(rate.NewLimiter(defaultRateLimit, defaultBurst)),
 		compactController: newController(rate.NewLimiter(defaultRateLimit, defaultBurst)),
 		flushController:   newController(rate.NewLimiter(rate.Inf, defaultBurst)),
-	}
-	if d.equal == nil {
-		d.equal = bytes.Equal
 	}
 	tableCacheSize := opts.MaxOpenFiles - numNonTableCacheFiles
 	if tableCacheSize < minTableCacheSize {


### PR DESCRIPTION
This PR implements the change discussed in #17, and also fixes a few bugs and comments.

The first commit just threads through the entire DB.Comparer to a bunch of places to grant access to the `AbbreviatedKey` function, the second commit actually adds support for making use of it to the mergingIter.

My conclusion is that this is a pessimization. Here's two runs of the `scan` benchmark (on my slow personal laptop):

before:
```
$ pebble scan bench --wipe
wiping bench
dir bench
concurrency 1
_elapsed_______rows/sec_______MB/sec_______ns/row
      1s      5691814.6         43.4        175.7
      2s      6126246.7         46.7        163.2
      3s      6272370.0         47.9        159.4
      4s      6256512.9         47.7        159.8
      5s      6279855.3         47.9        159.2
      6s      6248615.3         47.7        160.0
      7s      6274775.5         47.9        159.4
      8s      6294911.9         48.0        158.9
      9s      6214536.6         47.4        160.9
     10s      6255158.4         47.7        159.9

_elapsed___ops/sec(cum)__MB/sec(cum)__ns/row(avg)
   10.0s      6191469.5         47.2        161.5
```

after:
```
$ pebble scan bench --wipe
wiping bench
dir bench
concurrency 1
_elapsed_______rows/sec_______MB/sec_______ns/row
      1s      5332110.9         40.7        187.5
      2s      5766008.0         44.0        173.4
      3s      5833169.8         44.5        171.4
      4s      5885917.6         44.9        169.9
      5s      5902175.2         45.0        169.4
      6s      5891818.1         45.0        169.7
      7s      5905602.1         45.1        169.3
      8s      5876599.0         44.8        170.2
      9s      5807050.4         44.3        172.2
     10s      5837537.5         44.5        171.3

_elapsed___ops/sec(cum)__MB/sec(cum)__ns/row(avg)
   10.0s      5803635.5         44.3        172.3
```

Looking at the CPU profile, doing the comparisons are indeed faster, but the overhead of computing the abbreviated key outweighs its benefit.

My intuition says that a degradation in this case makes sense: each individual key is relatively short-lived in the mergingIter compared to batchskl (i.e., it will probably only have a handful of comparisons done against it), and so the overhead of computing the abbreviated key outweighs the benefit of having it around.

Posting this to get some more eyes on it to see if there's something I could be doing differently to get some improvements. Perhaps there's a better place to be computing the abbreviated keys.