### PR TITLE
db: fix default AbbreviatedKey implementation

### DIFF
--- a/cmd/pebble/mvcc.go
+++ b/cmd/pebble/mvcc.go
@@ -23,16 +23,7 @@ var mvccComparer = &db.Comparer{
 		if !ok {
 			return 0
 		}
-		var v uint64
-		n := 8
-		if n > len(key) {
-			n = len(key)
-		}
-		for _, b := range key[:n] {
-			v <<= 8
-			v |= uint64(b)
-		}
-		return v
+		return db.DefaultComparer.AbbreviatedKey(key)
 	},
 
 	Separator: func(dst, a, b []byte) []byte {

--- a/db/comparer.go
+++ b/db/comparer.go
@@ -6,6 +6,7 @@ package db
 
 import (
 	"bytes"
+	"encoding/binary"
 )
 
 // TODO(tbg): introduce a FeasibleKey type to make things clearer.
@@ -109,16 +110,15 @@ var DefaultComparer = &Comparer{
 	Equal:   bytes.Equal,
 
 	AbbreviatedKey: func(key []byte) uint64 {
-		var v uint64
-		n := 8
-		if n > len(key) {
-			n = len(key)
+		if len(key) >= 8 {
+			return binary.BigEndian.Uint64(key)
 		}
-		for _, b := range key[:n] {
+		var v uint64
+		for _, b := range key {
 			v <<= 8
 			v |= uint64(b)
 		}
-		return v
+		return v << uint(8*(8-len(key)))
 	},
 
 	Separator: func(dst, a, b []byte) []byte {


### PR DESCRIPTION
The default AbbreviatedKey implementation was failing to generate
properly ordered abbreviated keys when the length of the source key was
less than 8. Add a test which would have caught this bug.

Add a fast-path default AbbreviatedKey implementation when len(key)>=8.

```
name              old time/op  new time/op  delta
AbbreviatedKey-8  14.4ns ± 1%  11.0ns ± 1%  -23.81%  (p=0.000 n=10+10)
```