### PR TITLE
internal/arenaskl: protect against overflow in Arena allocation

### DIFF
--- a/internal/arenaskl/arena_test.go
+++ b/internal/arenaskl/arena_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ * Modifications copyright (C) 2017 Andy Kimball and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package arenaskl
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestArenaSizeOverflow tests that large allocations do not cause Arena's
+// internal size accounting to overflow and produce incorrect results.
+func TestArenaSizeOverflow(t *testing.T) {
+	a := NewArena(math.MaxUint32, 0)
+
+	// Allocating under the limit throws no error.
+	offset, err := a.alloc(math.MaxUint16, 0)
+	require.Nil(t, err)
+	require.Equal(t, uint32(1), offset)
+	require.Equal(t, uint32(math.MaxUint16)+1, a.Size())
+
+	// Allocating over the limit could cause an accounting
+	// overflow if 32-bit arithmetic was used. It shouldn't.
+	_, err = a.alloc(math.MaxUint32, 0)
+	require.Equal(t, ErrArenaFull, err)
+	require.Equal(t, uint32(math.MaxUint32), a.Size())
+
+	// Continuing to allocate continues to throw an error.
+	_, err = a.alloc(math.MaxUint16, 0)
+	require.Equal(t, ErrArenaFull, err)
+	require.Equal(t, uint32(math.MaxUint32), a.Size())
+}


### PR DESCRIPTION
Based on https://github.com/andy-kimball/arenaskl/pull/4:

This change protects against large allocations causing Arena's internal
size accounting to overflow and produce incorrect results.  This
overflow could allow for invalid offsets being returned from
`Arena.alloc`, leading to slice bounds and index out of range panics
when passed to `Arena.getBytes` or `Arena.getPointer`.

Specifically, if `Arena.n` overflowed in `Arena.alloc`, which was
possible because it was a `uint32` and we allow up to `MaxUint32` size
allocations, then `Arena.alloc` could bypass the length check against
`Arena.buf`. The "padded" size would then be subtracted from the offset,
allowing the offset to underflow back around to an offset that was out
of `Arena.buf's` bounds.