### PR TITLE
Fix iterator bug when range tombstone ends after its sstable

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -747,14 +747,7 @@ func TestManualCompaction(t *testing.T) {
 			return b.String()
 
 		case "compact":
-			if len(td.CmdArgs) != 1 {
-				return fmt.Sprintf("%s expects 1 argument", td.Cmd)
-			}
-			parts := strings.Split(td.CmdArgs[0].Key, "-")
-			if len(parts) != 2 {
-				return fmt.Sprintf("malformed test case: %s", td.Input)
-			}
-			if err := d.Compact([]byte(parts[0]), []byte(parts[1])); err != nil {
+			if err := runCompactCommand(td, d); err != nil {
 				return err.Error()
 			}
 

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -34,6 +34,15 @@ func TestRangeDel(t *testing.T) {
 			d.mu.Unlock()
 			return s
 
+		case "compact":
+			if err := runCompactCommand(td, d); err != nil {
+				return err.Error()
+			}
+			d.mu.Lock()
+			s := d.mu.versions.currentVersion().String()
+			d.mu.Unlock()
+			return s
+
 		case "get":
 			snap := Snapshot{
 				db:     d,

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -1127,3 +1127,68 @@ get seq=3
 a
 ----
 pebble: not found
+
+# A range tombstone straddles two SSTs. One is compacted to a lower level. Its
+# keys that are newer than the range tombstone should not disappear.
+#
+# Uses a snapshot to prevent range tombstone from being elided when it gets
+# compacted to the bottommost level.
+
+define target-file-sizes=(100, 1) snapshots=(1)
+L0
+  a.RANGEDEL.1:e
+L0
+  a.SET.2:v
+L0
+  c.SET.3:v
+----
+mem: 1
+0: a-e a-a c-c
+
+compact a-e
+----
+1: a-c c-e
+
+compact d-e
+----
+1: a-c
+2: c-e
+
+iter seq=4
+seek-ge b
+next
+----
+c:v
+.
+
+# Reverse the above test: compact the left file containing the split range
+# tombstone downwards, and iterate from right to left.
+
+define target-file-sizes=(100, 1) snapshots=(1)
+L0
+  a.RANGEDEL.1:e
+L0
+  a.SET.2:v
+L0
+  c.SET.3:v
+----
+mem: 1
+0: a-e a-a c-c
+
+compact a-e
+----
+1: a-c c-e
+
+compact a-b
+----
+1: c-e
+2: a-c
+
+iter seq=4
+seek-lt d
+prev
+prev
+----
+c:v
+a:v
+.


### PR DESCRIPTION
A range tombstone's end key may extend past its containing sstable's
upper bound. In that case, the portion of the range tombstone outside
the sstable's boundaries does not necessarily cover keys in lower levels.
The iterator optimization for seeking past keys covered by a range
tombstone in lower levels should take this into account and limit its
seek to the sstable's upper bound.

The approach taken here is to maintain the sstable upper bounds in
`mergingIter` for the partitioned levels. `levelIter` holds a pointer to
the upper bound for its level and updates it when the current sstable
changes. `mergingIter` then uses this info to prevent seeking too far in
lower levels upon encountering a range tombstone.