### PR TITLE
Prevent sstable boundaries from expanding during compaction

### DIFF
--- a/internal/rangedel/get.go
+++ b/internal/rangedel/get.go
@@ -15,6 +15,9 @@ type iterator interface {
 	// than the given key.
 	SeekLT(key []byte) bool
 
+	// First moves the iterator the the first key/value pair.
+	First() bool
+
 	// Last moves the iterator the the last key/value pair.
 	Last() bool
 

--- a/internal/rangedel/testdata/truncate
+++ b/internal/rangedel/testdata/truncate
@@ -1,0 +1,166 @@
+build
+1:  b-d
+2:  d-f
+3:  f-h
+----
+1:  b-d
+2:    d-f
+3:      f-h
+
+
+truncate a-b
+----
+
+truncate a-c
+----
+1:  bc
+
+truncate a-d
+----
+1:  b-d
+
+truncate a-e
+----
+1:  b-d
+2:    de
+
+truncate a-f
+----
+1:  b-d
+2:    d-f
+
+truncate a-g
+----
+1:  b-d
+2:    d-f
+3:      fg
+
+truncate a-h
+----
+1:  b-d
+2:    d-f
+3:      f-h
+
+
+truncate b-b
+----
+
+truncate b-c
+----
+1:  bc
+
+truncate b-d
+----
+1:  b-d
+
+truncate b-e
+----
+1:  b-d
+2:    de
+
+truncate b-f
+----
+1:  b-d
+2:    d-f
+
+truncate b-g
+----
+1:  b-d
+2:    d-f
+3:      fg
+
+truncate b-h
+----
+1:  b-d
+2:    d-f
+3:      f-h
+
+
+truncate c-c
+----
+
+truncate c-d
+----
+1:   cd
+
+truncate c-e
+----
+1:   cd
+2:    de
+
+truncate c-f
+----
+1:   cd
+2:    d-f
+
+truncate c-g
+----
+1:   cd
+2:    d-f
+3:      fg
+
+truncate c-h
+----
+1:   cd
+2:    d-f
+3:      f-h
+
+
+truncate d-d
+----
+
+truncate d-e
+----
+2:    de
+
+truncate d-f
+----
+2:    d-f
+
+truncate d-g
+----
+2:    d-f
+3:      fg
+
+truncate d-h
+----
+2:    d-f
+3:      f-h
+
+
+truncate e-e
+----
+
+truncate e-f
+----
+2:     ef
+
+truncate e-g
+----
+2:     ef
+3:      fg
+
+truncate e-h
+----
+2:     ef
+3:      f-h
+
+
+truncate f-f
+----
+
+truncate f-g
+----
+3:      fg
+
+truncate f-h
+----
+3:      f-h
+
+
+truncate g-g
+----
+
+truncate g-h
+----
+3:       gh

--- a/internal/rangedel/truncate.go
+++ b/internal/rangedel/truncate.go
@@ -1,0 +1,31 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package rangedel
+
+import (
+	"github.com/petermattis/pebble/db"
+)
+
+// Truncate creates a new iterator where every tombstone in the supplied
+// iterator is truncated to be contained within the range [lower, upper).
+func Truncate(cmp db.Compare, iter iterator, lower, upper []byte) *Iter {
+	var tombstones []Tombstone
+	for valid := iter.First(); valid; valid = iter.Next() {
+		t := Tombstone{
+			Start: iter.Key(),
+			End:   iter.Value(),
+		}
+		if cmp(t.Start.UserKey, lower) < 0 {
+			t.Start.UserKey = lower
+		}
+		if cmp(t.End, upper) > 0 {
+			t.End = upper
+		}
+		if cmp(t.Start.UserKey, t.End) < 0 {
+			tombstones = append(tombstones, t)
+		}
+	}
+	return NewIter(cmp, tombstones)
+}

--- a/internal/rangedel/truncate_test.go
+++ b/internal/rangedel/truncate_test.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package rangedel
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/datadriven"
+)
+
+func TestTruncate(t *testing.T) {
+	cmp := db.DefaultComparer.Compare
+	var iter iterator
+
+	datadriven.RunTest(t, "testdata/truncate", func(d *datadriven.TestData) string {
+		switch d.Cmd {
+		case "build":
+			tombstones := buildTombstones(t, cmp, d.Input)
+			iter = NewIter(cmp, tombstones)
+			return formatTombstones(tombstones)
+
+		case "truncate":
+			if len(d.Input) > 0 {
+				t.Fatalf("unexpected input: %s", d.Input)
+			}
+			if len(d.CmdArgs) != 1 {
+				t.Fatalf("expected 1 argument: %s", d.CmdArgs)
+			}
+			parts := strings.Split(d.CmdArgs[0].String(), "-")
+			if len(parts) != 2 {
+				t.Fatalf("malformed arg: %s", d.CmdArgs[0])
+			}
+			lower := []byte(parts[0])
+			upper := []byte(parts[1])
+
+			truncated := Truncate(cmp, iter, lower, upper)
+			return formatTombstones(truncated.tombstones)
+
+		default:
+			return fmt.Sprintf("unknown command: %s", d.Cmd)
+		}
+	})
+}

--- a/testdata/compaction_atomic_unit_bounds
+++ b/testdata/compaction_atomic_unit_bounds
@@ -1,0 +1,62 @@
+define
+a.SET.1-b.SET.2
+----
+
+atomic-unit-bounds 0
+----
+a-b
+
+define
+a.SET.1-b.SET.2
+c.SET.3-d.SET.4
+e.SET.5-f.SET.6
+----
+
+atomic-unit-bounds 0
+----
+a-b
+
+atomic-unit-bounds 1
+----
+c-d
+
+atomic-unit-bounds 2
+----
+e-f
+
+define
+a.SET.1-b.RANGEDEL.3
+b.SET.2-c.RANGEDEL.5
+c.SET.4-d.SET.6
+----
+
+atomic-unit-bounds 0
+----
+a-d
+
+atomic-unit-bounds 1
+----
+a-d
+
+atomic-unit-bounds 2
+----
+a-d
+
+define
+a.SET.1-b.RANGEDEL.72057594037927935
+b.SET.2-c.RANGEDEL.5
+c.SET.4-d.SET.6
+----
+
+atomic-unit-bounds 0
+----
+a-b
+
+atomic-unit-bounds 1
+----
+b-d
+
+atomic-unit-bounds 2
+----
+b-d
+

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -1192,3 +1192,100 @@ prev
 c:v
 a:v
 .
+
+# A range tombstone straddles two sstables. One is compacted two
+# levels lower. The other is compacted one level lower. The one that
+# is compacted one level lower should not see its boundaries expand
+# causing it to delete more keys. A snapshot is used to prevent range
+# tombstone from being elided when it gets compacted to the bottommost
+# level.
+
+define target-file-sizes=(100, 1) snapshots=(1)
+L0
+  a.RANGEDEL.1:e
+L0
+  a.SET.2:v
+L0
+  c.SET.3:v
+L2
+  d.SET.0:v
+----
+mem: 1
+0: a-e a-a c-c
+2: d-d
+
+compact a-b
+----
+1: a-c c-e
+2: d-d
+
+compact d-e
+----
+1: a-c
+3: c-d d-e
+
+get seq=4
+c
+----
+v
+
+compact a-b L1
+----
+2: a-c
+3: c-d d-e
+
+get seq=4
+c
+----
+v
+
+# A slight variation on the scenario above where a range tombstone is
+# expanded past the boundaries of its "atomic compaction unit".
+
+define target-file-sizes=(100, 1) snapshots=(1)
+L0
+  a.RANGEDEL.1:e
+L0
+  a.SET.2:v
+L0
+  c.SET.3:v
+L0
+  f.SET.4:v
+L2
+  d.SET.0:v
+----
+mem: 1
+0: a-e a-a c-c f-f
+2: d-d
+
+compact a-b
+----
+0: f-f
+1: a-c c-e
+2: d-d
+
+compact d-e
+----
+0: f-f
+1: a-c
+3: c-d d-e
+
+get seq=4
+c
+----
+v
+
+compact f-f L0
+----
+1: a-c f-f
+3: c-d d-e
+
+compact a-f L1
+----
+2: a-c c-f
+3: c-d d-e
+
+get seq=4
+c
+----
+v


### PR DESCRIPTION
Enforce the invariant that the boundaries of the output of a compaction
can be larger than the boundaries of the input. This fixes a problem
where a compaction can cause a range tombstone to expand to cover a
newer key at a lower level in the LSM.

Fixes #26
Closes #27