### PR TITLE
Add syncingFile

### DIFF
--- a/db.go
+++ b/db.go
@@ -726,6 +726,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 					newLogFile.Close()
 				}
 			}
+			newLogFile = storage.NewSyncingFile(newLogFile, d.opts.BytesPerSync)
 
 			d.mu.Lock()
 			d.mu.mem.switching = false

--- a/open.go
+++ b/open.go
@@ -173,6 +173,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	logFile = storage.NewSyncingFile(logFile, d.opts.BytesPerSync)
 	d.mu.log.LogWriter = record.NewLogWriter(logFile)
 
 	// Write a new manifest to disk.

--- a/storage/syncing_file.go
+++ b/storage/syncing_file.go
@@ -1,0 +1,85 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package storage
+
+type syncingFile struct {
+	File
+	fd           int
+	useSyncRange bool
+	bytesPerSync int64
+	offset       int64
+	syncOffset   int64
+	syncTo       func(offset int64) error
+}
+
+// NewSyncingFile wraps a writable file and ensures that data is synced
+// periodically as it is written. The syncing does not provide persistency
+// guarantees, but is used to avoid latency spikes if the OS automatically
+// decides to write out a large chunk of dirty filesystem buffers. If
+// bytesPerSync is zero, the original file is returned as no syncing is
+// requested.
+func NewSyncingFile(f File, bytesPerSync int) File {
+	if bytesPerSync <= 0 {
+		return f
+	}
+	s := &syncingFile{
+		File:         f,
+		fd:           -1,
+		bytesPerSync: int64(bytesPerSync),
+	}
+	s.init()
+	return s
+}
+
+// NB: syncingFile.Write is unsafe for concurrent use!
+func (f *syncingFile) Write(p []byte) (n int, err error) {
+	n, err = f.File.Write(p)
+	if err != nil {
+		return n, err
+	}
+	f.offset += int64(n)
+	if err := f.maybeSync(); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (f *syncingFile) Sync() error {
+	// Do not update syncingFile.syncOffset. This method can be called
+	// concurrently with Write, so any update to syncOffset and access to offset
+	// would need to be done atomically. But even with atomic operations, we'd
+	// still need to call to the underlying file's Sync because sync_file_range
+	// does not provide any persistence guarantees. We could possibly avoid a few
+	// calls to sync_file_range if there was a recent explicit Sync call, but
+	// those calls should be super-fast if there is no dirty data in the file.
+	return f.File.Sync()
+}
+
+func (f *syncingFile) maybeSync() error {
+	// From the RocksDB source:
+	//
+	//   We try to avoid sync to the last 1MB of data. For two reasons:
+	//   (1) avoid rewrite the same page that is modified later.
+	//   (2) for older version of OS, write can block while writing out
+	//       the page.
+	//   Xfs does neighbor page flushing outside of the specified ranges. We
+	//   need to make sure sync range is far from the write offset.
+	const syncRangeBuffer = 1 << 20 // 1 MB
+	if f.offset <= syncRangeBuffer {
+		return nil
+	}
+
+	const syncRangeAlignment = 4 << 10 // 4 KB
+	syncToOffset := f.offset - syncRangeBuffer
+	syncToOffset -= syncToOffset % syncRangeAlignment
+	if syncToOffset < 0 || (syncToOffset-f.syncOffset) < f.bytesPerSync {
+		return nil
+	}
+
+	if f.fd < 0 {
+		return f.Sync()
+	}
+	return f.syncTo(syncToOffset)
+}

--- a/storage/syncing_file_generic.go
+++ b/storage/syncing_file_generic.go
@@ -1,0 +1,15 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !linux
+
+package storage
+
+func (f *syncingFile) init() {
+	f.syncTo = f.syncToGeneric
+}
+
+func (f *syncingFile) syncToGeneric(_ int64) error {
+	return f.Sync()
+}

--- a/storage/syncing_file_linux.go
+++ b/storage/syncing_file_linux.go
@@ -1,0 +1,61 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build linux
+
+package storage
+
+import (
+	"os"
+	"syscall"
+)
+
+func isSyncRangeSupported(fd int) bool {
+	var stat syscall.Statfs_t
+	if err := syscall.Fstatfs(fd, &stat); err != nil {
+		return false
+	}
+
+	// Whitelist which filesystems we allow using sync_file_range with as some
+	// filesystems treat that syscall as a noop (notably ZFS). A whitelist is
+	// used instead of a blacklist in order to have a more graceful failure mode
+	// in case a filesystem we haven't tested is encountered. Currently only
+	// ext2/3/4 are known to work properly.
+	const extMagic = 0xef53
+	switch stat.Type {
+	case extMagic:
+		return true
+	}
+	return false
+}
+
+func (f *syncingFile) init() {
+	t, ok := f.File.(*os.File)
+	if !ok {
+		return
+	}
+	f.fd = int(t.Fd())
+	f.useSyncRange = isSyncRangeSupported(f.fd)
+	if f.useSyncRange {
+		f.syncTo = f.syncToRange
+	} else {
+		f.syncTo = f.syncToFdatasync
+	}
+}
+
+func (f *syncingFile) syncToFdatasync(_ int64) error {
+	f.syncOffset = f.offset
+	return syscall.Fdatasync(f.fd)
+}
+
+func (f *syncingFile) syncToRange(offset int64) error {
+	const (
+		// waitAfter = 0x1
+		write      = 0x2
+		waitBefore = 0x4
+	)
+
+	f.syncOffset = offset
+	return syscall.SyncFileRange(f.fd, 0, offset, write|waitBefore)
+}

--- a/storage/syncing_file_test.go
+++ b/storage/syncing_file_test.go
@@ -1,0 +1,60 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package storage
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestSyncingFile(t *testing.T) {
+	const mb = 1 << 20
+
+	tmpf, err := ioutil.TempFile("", "pebble-db-syncing-file-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	filename := tmpf.Name()
+	defer os.Remove(filename)
+
+	f, err := Default.Create(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewSyncingFile(f, 0)
+	if s != f {
+		t.Fatalf("unexpected wrapping: %p != %p", f, s)
+	}
+	s = NewSyncingFile(f, 8<<10 /* 8 KB */)
+	s.(*syncingFile).fd = 1
+	s.(*syncingFile).syncTo = func(offset int64) error {
+		s.(*syncingFile).syncOffset = offset
+		return nil
+	}
+
+	t.Logf("sync_file_range=%t", s.(*syncingFile).useSyncRange)
+
+	testCases := []struct {
+		n              int64
+		expectedSyncTo int64
+	}{
+		{mb, 0},
+		{mb, mb},
+		{4 << 10, mb},
+		{4 << 10, mb + 8<<10},
+		{8 << 10, mb + 16<<10},
+		{16 << 10, mb + 32<<10},
+	}
+	for i, c := range testCases {
+		if _, err := s.Write(make([]byte, c.n)); err != nil {
+			t.Fatal(err)
+		}
+		syncTo := s.(*syncingFile).syncOffset
+		if c.expectedSyncTo != syncTo {
+			t.Fatalf("%d: expected sync to %d, but found %d", i, c.expectedSyncTo, syncTo)
+		}
+	}
+}


### PR DESCRIPTION
Encapsulate the logic to periodically sync a file as it is written to in
a new `syncingFile` object. Add support for using `sync_file_range` when
possible so that this periodic syncing can be performed asynchronously.

Use `syncingFile` for both sstable creation and WAL writing.

Fixes #69
Fixes #70