### PR TITLE
Do not leak batchStorage methods into Batch

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -98,7 +98,7 @@ func TestBatchIncrement(t *testing.T) {
 		var buf [12]byte
 		binary.LittleEndian.PutUint32(buf[8:12], tc)
 		var b Batch
-		b.data = buf[:]
+		b.storage.data = buf[:]
 		b.increment()
 		got := binary.LittleEndian.Uint32(buf[8:12])
 		want := tc + 1

--- a/commit.go
+++ b/commit.go
@@ -275,7 +275,7 @@ func (p *commitPipeline) Close() {
 // WAL, and applying the batch to the memtable. Upon successful return the
 // batch's mutations will be visible for reading.
 func (p *commitPipeline) Commit(b *Batch, syncWAL bool) error {
-	if len(b.data) == 0 {
+	if len(b.storage.data) == 0 {
 		return nil
 	}
 
@@ -319,7 +319,7 @@ func (p *commitPipeline) AllocateSeqNum(prepare func(), apply func(seqNum uint64
 
 	// Give the batch a count of 1 so that the log and visible sequence number
 	// are incremented correctly.
-	b.data = make([]byte, batchHeaderLen)
+	b.storage.data = make([]byte, batchHeaderLen)
 	b.setCount(1)
 	b.commit.Add(1)
 

--- a/commit_test.go
+++ b/commit_test.go
@@ -53,7 +53,7 @@ func (e *testCommitEnv) sync() error {
 }
 
 func (e *testCommitEnv) write(b *Batch) (*memTable, error) {
-	n := int64(len(b.data))
+	n := int64(len(b.storage.data))
 	atomic.AddInt64(&e.writePos, n)
 	atomic.AddUint64(&e.writeCount, 1)
 	return nil, nil
@@ -163,7 +163,7 @@ func BenchmarkCommitPipeline(b *testing.B) {
 						break
 					}
 
-					_, err := wal.WriteRecord(b.data)
+					_, err := wal.WriteRecord(b.storage.data)
 					return mem, err
 				},
 			}

--- a/db.go
+++ b/db.go
@@ -312,7 +312,7 @@ func (d *DB) Apply(batch *Batch, opts *db.WriteOptions) error {
 		// If this is a large batch, we need to clear the batch contents as the
 		// flushable batch may still be present in the flushables queue.
 		if batch.flushable != nil {
-			batch.data = nil
+			batch.storage.data = nil
 		}
 	}
 	return err
@@ -369,7 +369,7 @@ func (d *DB) commitWrite(b *Batch) (*memTable, error) {
 		return d.mu.mem.mutable, nil
 	}
 
-	_, err := d.mu.log.WriteRecord(b.data)
+	_, err := d.mu.log.WriteRecord(b.storage.data)
 	if err != nil {
 		panic(err)
 	}

--- a/open.go
+++ b/open.go
@@ -243,7 +243,7 @@ func (d *DB) replayWAL(
 		// TODO(peter): If the batch is too large to fit in the memtable, flush the
 		// existing memtable and write the batch as a separate L0 table.
 		b = Batch{}
-		b.data = buf.Bytes()
+		b.storage.data = buf.Bytes()
 		b.refreshMemTableSize()
 		seqNum := b.seqNum()
 		maxSeqNum = seqNum + uint64(b.count())


### PR DESCRIPTION
Noticed in passing. This was a mechanical change and makes access of the
batchStorage fields slightly more verbose, but prevents the
`batchStorage` methods from leaking into `Batch`. There is no other
effect (the `Batch` struct layout remains unchanged).