### PR TITLE
Add support for WAL preallocation

### DIFF
--- a/open.go
+++ b/open.go
@@ -165,7 +165,10 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	logFile = storage.NewSyncingFile(logFile, d.opts.BytesPerSync)
+	logFile = storage.NewSyncingFile(logFile, storage.SyncingFileOptions{
+		BytesPerSync:    d.opts.BytesPerSync,
+		PreallocateSize: d.walPreallocateSize(),
+	})
 	d.mu.log.LogWriter = record.NewLogWriter(logFile)
 
 	// Write a new manifest to disk.

--- a/sstable/writer.go
+++ b/sstable/writer.go
@@ -537,7 +537,9 @@ func NewWriter(f storage.File, o *db.Options, lo db.LevelOptions) *Writer {
 	lo = *lo.EnsureDefaults()
 
 	if f != nil {
-		f = storage.NewSyncingFile(f, o.BytesPerSync)
+		f = storage.NewSyncingFile(f, storage.SyncingFileOptions{
+			BytesPerSync: o.BytesPerSync,
+		})
 	}
 
 	w := &Writer{

--- a/storage/preallocate_darwin.go
+++ b/storage/preallocate_darwin.go
@@ -1,0 +1,64 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build darwin
+
+package storage
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func preallocExtend(fd uintptr, offset, length int64) error {
+	if err := preallocFixed(fd, offset, length); err != nil {
+		return err
+	}
+	return syscall.Ftruncate(int(fd), offset+length)
+}
+
+func preallocFixed(fd uintptr, offset, length int64) error {
+	// allocate all requested space or no space at all
+	// TODO: allocate contiguous space on disk with F_ALLOCATECONTIG flag
+	fstore := &syscall.Fstore_t{
+		Flags:   syscall.F_ALLOCATEALL,
+		Posmode: syscall.F_PEOFPOSMODE,
+		Length:  length}
+	p := unsafe.Pointer(fstore)
+	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fd, uintptr(syscall.F_PREALLOCATE), uintptr(p))
+	if errno == 0 || errno == syscall.ENOTSUP {
+		return nil
+	}
+
+	// wrong argument to fallocate syscall
+	if errno == syscall.EINVAL {
+		// filesystem "st_blocks" are allocated in the units of
+		// "Allocation Block Size" (run "diskutil info /" command)
+		var stat syscall.Stat_t
+		syscall.Fstat(int(fd), &stat)
+
+		// syscall.Statfs_t.Bsize is "optimal transfer block size"
+		// and contains matching 4096 value when latest OS X kernel
+		// supports 4,096 KB filesystem block size
+		var statfs syscall.Statfs_t
+		syscall.Fstatfs(int(fd), &statfs)
+		blockSize := int64(statfs.Bsize)
+
+		if stat.Blocks*blockSize >= offset+length {
+			// enough blocks are already allocated
+			return nil
+		}
+	}
+	return errno
+}

--- a/storage/preallocate_linux.go
+++ b/storage/preallocate_linux.go
@@ -1,0 +1,34 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package storage
+
+import (
+	"syscall"
+)
+
+func preallocExtend(fd uintptr, offset, length int64) error {
+	err := syscall.Fallocate(int(fd), 0 /* mode */, offset, length)
+	if err != nil {
+		errno, ok := err.(syscall.Errno)
+		// not supported; fallback
+		// fallocate EINTRs frequently in some environments; fallback
+		if ok && (errno == syscall.ENOTSUP || errno == syscall.EINTR) {
+			return syscall.Ftruncate(int(fd), offset+length)
+		}
+	}
+	return err
+}

--- a/storage/syncing_file_linux_test.go
+++ b/storage/syncing_file_linux_test.go
@@ -1,0 +1,81 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build linux
+
+package storage
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+func BenchmarkDirectIOWrite(b *testing.B) {
+	const targetSize = 16 << 20
+	const alignment = 4096
+
+	var wsizes []int
+	if testing.Verbose() {
+		wsizes = []int{4 << 10, 8 << 10, 16 << 10, 32 << 10}
+	} else {
+		wsizes = []int{4096}
+	}
+
+	for _, wsize := range wsizes {
+		b.Run(fmt.Sprintf("wsize=%d", wsize), func(b *testing.B) {
+			tmpf, err := ioutil.TempFile("", "pebble-db-syncing-file-")
+			if err != nil {
+				b.Fatal(err)
+			}
+			filename := tmpf.Name()
+			_ = tmpf.Close()
+			defer os.Remove(filename)
+
+			var f *os.File
+			var size int
+			buf := make([]byte, wsize+alignment)
+			if a := uintptr(unsafe.Pointer(&buf[0])) & uintptr(alignment-1); a != 0 {
+				buf = buf[alignment-a:]
+			}
+			buf = buf[:wsize]
+			init := true
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if f == nil {
+					b.StopTimer()
+					f, err = os.OpenFile(filename, syscall.O_DIRECT|os.O_RDWR, 0666)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if init {
+						for size = 0; size < targetSize; size += len(buf) {
+							if _, err := f.WriteAt(buf, int64(size)); err != nil {
+								b.Fatal(err)
+							}
+						}
+					}
+					if err := f.Sync(); err != nil {
+						b.Fatal(err)
+					}
+					size = 0
+					b.StartTimer()
+				}
+				if _, err := f.WriteAt(buf, int64(size)); err != nil {
+					b.Fatal(err)
+				}
+				size += len(buf)
+				if size >= targetSize {
+					_ = f.Close()
+					f = nil
+				}
+			}
+			b.StopTimer()
+		})
+	}
+}

--- a/storage/syncing_file_test.go
+++ b/storage/syncing_file_test.go
@@ -5,6 +5,7 @@
 package storage
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"sync/atomic"
@@ -25,11 +26,11 @@ func TestSyncingFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := NewSyncingFile(f, 0)
-	if s != f {
-		t.Fatalf("unexpected wrapping: %p != %p", f, s)
+	s := NewSyncingFile(f, SyncingFileOptions{})
+	if s == f {
+		t.Fatalf("failed to wrap: %p != %p", f, s)
 	}
-	s = NewSyncingFile(f, 8<<10 /* 8 KB */)
+	s = NewSyncingFile(f, SyncingFileOptions{BytesPerSync: 8 << 10 /* 8 KB */})
 	s.(*syncingFile).fd = 1
 	s.(*syncingFile).syncTo = func(offset int64) error {
 		s.(*syncingFile).ratchetSyncOffset(offset)
@@ -58,4 +59,112 @@ func TestSyncingFile(t *testing.T) {
 			t.Fatalf("%d: expected sync to %d, but found %d", i, c.expectedSyncTo, syncTo)
 		}
 	}
+}
+
+func BenchmarkSyncWrite(b *testing.B) {
+	const targetSize = 16 << 20
+
+	var wsizes []int
+	if testing.Verbose() {
+		wsizes = []int{64, 512, 1 << 10, 2 << 10, 4 << 10, 8 << 10, 16 << 10, 32 << 10}
+	} else {
+		wsizes = []int{64}
+	}
+
+	run := func(b *testing.B, wsize int, newFile func(string) File) {
+		tmpf, err := ioutil.TempFile("", "pebble-db-syncing-file-")
+		if err != nil {
+			b.Fatal(err)
+		}
+		filename := tmpf.Name()
+		_ = tmpf.Close()
+		defer os.Remove(filename)
+
+		var f File
+		var size int
+		buf := make([]byte, wsize)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if f == nil {
+				b.StopTimer()
+				f = newFile(filename)
+				size = 0
+				b.StartTimer()
+			}
+			if _, err := f.Write(buf); err != nil {
+				b.Fatal(err)
+			}
+			if err := f.Sync(); err != nil {
+				b.Fatal(err)
+			}
+			size += len(buf)
+			if size >= targetSize {
+				_ = f.Close()
+				f = nil
+			}
+		}
+		b.StopTimer()
+	}
+
+	b.Run("no-prealloc", func(b *testing.B) {
+		for _, wsize := range wsizes {
+			b.Run(fmt.Sprintf("wsize=%d", wsize), func(b *testing.B) {
+				run(b, wsize, func(filename string) File {
+					_ = os.Remove(filename)
+					t, err := os.Create(filename)
+					if err != nil {
+						b.Fatal(err)
+					}
+					return NewSyncingFile(t, SyncingFileOptions{PreallocateSize: 0})
+				})
+			})
+		}
+	})
+
+	b.Run("prealloc-4MB", func(b *testing.B) {
+		for _, wsize := range wsizes {
+			b.Run(fmt.Sprintf("wsize=%d", wsize), func(b *testing.B) {
+				run(b, wsize, func(filename string) File {
+					_ = os.Remove(filename)
+					t, err := os.Create(filename)
+					if err != nil {
+						b.Fatal(err)
+					}
+					return NewSyncingFile(t, SyncingFileOptions{PreallocateSize: 4 << 20})
+				})
+			})
+		}
+	})
+
+	b.Run("reuse", func(b *testing.B) {
+		for _, wsize := range wsizes {
+			b.Run(fmt.Sprintf("wsize=%d", wsize), func(b *testing.B) {
+				init := true
+				run(b, wsize, func(filename string) File {
+					if init {
+						init = false
+
+						t, err := os.OpenFile(filename, os.O_RDWR, 0755)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if _, err := t.Write(make([]byte, targetSize)); err != nil {
+							b.Fatal(err)
+						}
+						if err := t.Sync(); err != nil {
+							b.Fatal(err)
+						}
+						t.Close()
+					}
+
+					t, err := os.OpenFile(filename, os.O_RDWR, 0755)
+					if err != nil {
+						b.Fatal(err)
+					}
+					return NewSyncingFile(t, SyncingFileOptions{PreallocateSize: 0})
+				})
+			})
+		}
+	})
 }


### PR DESCRIPTION
On Linux, preallocation makes a huge difference in sync performance.

```
name                         time/op
SyncPreallocFile/size=0MB-4  503µs ± 6%
SyncPreallocFile/size=4MB-4  303µs ± 2%
SyncReuseFile-4              291µs ± 1%
```

The effect is much more mutated on Darwin, but still present:

```
name                         time/op
SyncPreallocFile/size=0MB-8  50.4µs ±14%
SyncPreallocFile/size=4MB-8  46.4µs ± 2%
SyncReuseFile-8              46.7µs ± 2%
```

Note that the `SyncReuseFile` benchmark is an attempt to measure the win from reusing WAL files. WAL file reuse is not actually implemented  yet.

See #41