### PR TITLE
Avoid holding DB.mu during log writes

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 type testCommitEnv struct {
-	mu            sync.Mutex
 	logSeqNum     uint64
 	visibleSeqNum uint64
 	writePos      int64
@@ -32,7 +31,6 @@ type testCommitEnv struct {
 
 func (e *testCommitEnv) env() commitEnv {
 	return commitEnv{
-		mu:            &e.mu,
 		logSeqNum:     &e.logSeqNum,
 		visibleSeqNum: &e.visibleSeqNum,
 		apply:         e.apply,
@@ -136,7 +134,6 @@ func BenchmarkCommitPipeline(b *testing.B) {
 			wal := record.NewLogWriter(ioutil.Discard)
 
 			nullCommitEnv := commitEnv{
-				mu:            new(sync.Mutex),
 				logSeqNum:     new(uint64),
 				visibleSeqNum: new(uint64),
 				apply: func(b *Batch, mem *memTable) error {

--- a/open.go
+++ b/open.go
@@ -73,7 +73,6 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 	d.tableCache.init(dirname, opts.Storage, d.opts, tableCacheSize)
 	d.newIters = d.tableCache.newIters
 	d.commit = newCommitPipeline(commitEnv{
-		mu:            &d.mu.Mutex,
 		logSeqNum:     &d.mu.versions.logSeqNum,
 		visibleSeqNum: &d.mu.versions.visibleSeqNum,
 		apply:         d.commitApply,


### PR DESCRIPTION
Change `commitPipeline` to use a separate mutex rather than `DB.mu` for
serializing writing to the WAL. The use of `DB.mu` was a potential
performance problem because `DB.mu` is used for reads and holding it
during a log write meant that it was potentially held during disk
IO. There was also a super subtle bug here: `DB.makeRoomForWrite`
releases and then reacquires `DB.mu`. This behavior is necessary when
rotating the log, but the effect was that all of the careful ordering
guarantees in `commitePipeline` could be violated.

Fixes #44