### PR TITLE
Acquire state for reading without using DB.mu

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -480,6 +480,7 @@ func (d *DB) flush1() error {
 			close(d.mu.mem.queue[i].flushed())
 		}
 		d.mu.mem.queue = d.mu.mem.queue[n:]
+		d.updateReadStateLocked()
 		return nil
 	}
 
@@ -506,6 +507,7 @@ func (d *DB) flush1() error {
 		close(d.mu.mem.queue[i].flushed())
 	}
 	d.mu.mem.queue = d.mu.mem.queue[n:]
+	d.updateReadStateLocked()
 
 	// var newDirty int
 	// for _, mem := range d.mu.mem.queue {
@@ -747,6 +749,7 @@ func (d *DB) compact1() (err error) {
 	if err != nil {
 		return err
 	}
+	d.updateReadStateLocked()
 	d.deleteObsoleteFiles(jobID)
 	return nil
 }

--- a/data_test.go
+++ b/data_test.go
@@ -273,6 +273,7 @@ func runDBDefineCmd(td *datadriven.TestData) (*DB, error) {
 				if !d.mu.mem.mutable.empty() {
 					d.mu.mem.mutable = newMemTable(d.opts)
 					d.mu.mem.queue = append(d.mu.mem.queue, d.mu.mem.mutable)
+					d.updateReadStateLocked()
 				}
 				mem = d.mu.mem.mutable
 				fields = fields[1:]
@@ -307,6 +308,7 @@ func runDBDefineCmd(td *datadriven.TestData) (*DB, error) {
 		if err := d.mu.versions.logAndApply(ve); err != nil {
 			return nil, err
 		}
+		d.updateReadStateLocked()
 		for i := range ve.newFiles {
 			meta := &ve.newFiles[i].meta
 			delete(d.mu.compact.pendingOutputs, meta.fileNum)

--- a/ingest.go
+++ b/ingest.go
@@ -357,5 +357,6 @@ func (d *DB) ingestApply(meta []*fileMetadata) (*versionEdit, error) {
 	if err := d.mu.versions.logAndApply(ve); err != nil {
 		return nil, err
 	}
+	d.updateReadStateLocked()
 	return ve, nil
 }

--- a/iterator.go
+++ b/iterator.go
@@ -36,7 +36,7 @@ type Iterator struct {
 	equal     db.Equal
 	merge     db.Merge
 	iter      internalIterator
-	version   *version
+	readState *readState
 	err       error
 	key       []byte
 	keyBuf    []byte
@@ -373,9 +373,9 @@ func (i *Iterator) Error() error {
 // It is valid to call Close multiple times. Other methods should not be
 // called after the iterator has been closed.
 func (i *Iterator) Close() error {
-	if i.version != nil {
-		i.version.unref()
-		i.version = nil
+	if i.readState != nil {
+		i.readState.unref()
+		i.readState = nil
 	}
 	if err := i.iter.Close(); err != nil && i.err != nil {
 		i.err = err

--- a/open.go
+++ b/open.go
@@ -174,6 +174,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 	if err := d.mu.versions.logAndApply(&ve); err != nil {
 		return nil, err
 	}
+	d.updateReadStateLocked()
 
 	// Write the current options to disk.
 	d.optionsFileNum = d.mu.versions.nextFileNum()

--- a/read_state.go
+++ b/read_state.go
@@ -1,0 +1,82 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"sync/atomic"
+)
+
+// readState encapsulates the state needed for reading (the current version and
+// list of memtables). Loading the readState is done without grabbing
+// DB.mu. Instead, a separate DB.readState.RWMutex is used for
+// synchronization. This mutex solely covers the current readState object which
+// means it is rarely or ever contended.
+//
+// Note that various fancy lock-free mechanisms can be imagined for loading the
+// readState, but benchmarking showed the ones considered to purely be
+// pessimizations. The RWMutex version is a single atomic increment for the
+// RLock and an atomic decrement for the RUnlock. It is difficult to do better
+// than that without something like thread-local storage which isn't available
+// in Go.
+type readState struct {
+	refcnt    int32
+	current   *version
+	memtables []flushable
+}
+
+// ref adds a reference to the readState.
+func (s *readState) ref() {
+	atomic.AddInt32(&s.refcnt, 1)
+}
+
+// unref removes a reference to the readState. If this was the last reference,
+// the reference the readState holds on the version is released. Requires DB.mu
+// is NOT held as version.unref() will acquire it. See unrefLocked() if DB.mu
+// is held by the caller.
+func (s *readState) unref() {
+	if atomic.AddInt32(&s.refcnt, -1) == 0 {
+		s.current.unref()
+	}
+}
+
+// unrefLocked removes a reference to the readState. If this was the last
+// reference, the reference the readState holds on the version is
+// released. Requires DB.mu is held as version.unrefLocked() requires it. See
+// unref() if DB.mu is NOT held by the caller.
+func (s *readState) unrefLocked() {
+	if atomic.AddInt32(&s.refcnt, -1) == 0 {
+		s.current.unrefLocked()
+	}
+}
+
+// loadReadState returns the current readState. The returned readState must be
+// unreferenced when the caller is finished with it.
+func (d *DB) loadReadState() *readState {
+	d.readState.RLock()
+	state := d.readState.val
+	state.ref()
+	d.readState.RUnlock()
+	return state
+}
+
+// updateReadStateLocked creates a new readState from the current version and
+// list of memtables. Requires DB.mu is held.
+func (d *DB) updateReadStateLocked() {
+	s := &readState{
+		refcnt:    1,
+		current:   d.mu.versions.currentVersion(),
+		memtables: d.mu.mem.queue,
+	}
+	s.current.ref()
+
+	d.readState.Lock()
+	old := d.readState.val
+	d.readState.val = s
+	d.readState.Unlock()
+
+	if old != nil {
+		old.unrefLocked()
+	}
+}

--- a/read_state_test.go
+++ b/read_state_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/storage"
+)
+
+func BenchmarkReadState(b *testing.B) {
+	d, err := Open("", &db.Options{
+		Storage: storage.NewMem(),
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for _, updateFrac := range []float32{0, 0.1, 0.5} {
+		b.Run(fmt.Sprintf("updates=%.0f", updateFrac*100), func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+				for pb.Next() {
+					if rng.Float32() < updateFrac {
+						d.mu.Lock()
+						d.updateReadStateLocked()
+						d.mu.Unlock()
+					} else {
+						s := d.loadReadState()
+						s.unref()
+					}
+				}
+			})
+		})
+	}
+
+	if err := d.Close(); err != nil {
+		b.Fatal(err)
+	}
+}


### PR DESCRIPTION
Add a `readState` struct which holds the current version and memtable
slice. A `DB.readState` pointer is updated whenever the current version
or memtable slice changes.

```
name                    time/op
ReadState/updates=0-8   49.7ns ± 1%
ReadState/updates=10-8  89.9ns ± 2%
ReadState/updates=50-8   115ns ± 1%
```

Note that the `updates={10,50}` benchmarks are unrealistic. It is
extremely unlikely that 10% or 50% of the operations in a real workload
will be calls to `updateReadStateLocked`.

Fixes #45