### PR TITLE
Trim {Lower,Upper}Bound for table iteration

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -468,7 +468,7 @@ func (b *Batch) newInternalIter(o *db.IterOptions) internalIterator {
 	return &batchIter{
 		cmp:   b.storage.cmp,
 		batch: b,
-		iter:  b.index.NewIter(),
+		iter:  b.index.NewIter(o.GetLowerBound(), o.GetUpperBound()),
 	}
 }
 
@@ -493,7 +493,7 @@ func (b *Batch) newRangeDelIter(o *db.IterOptions) internalIterator {
 		it := &batchIter{
 			cmp:   b.storage.cmp,
 			batch: b,
-			iter:  b.rangeDelIndex.NewIter(),
+			iter:  b.rangeDelIndex.NewIter(nil, nil),
 		}
 		for it.Next() {
 			frag.Add(it.Key(), it.Value())

--- a/compaction.go
+++ b/compaction.go
@@ -306,8 +306,10 @@ func (c *compaction) newInputIter(
 	// levelIters per level, one which iterates over the point operations, and
 	// one which iterates over the range deletions. These two iterators are
 	// combined with a mergingIter.
-	newRangeDelIter := func(f *fileMetadata) (internalIterator, internalIterator, error) {
-		iter, rangeDelIter, err := newIters(f)
+	newRangeDelIter := func(
+		f *fileMetadata, _ *db.IterOptions,
+	) (internalIterator, internalIterator, error) {
+		iter, rangeDelIter, err := newIters(f, nil /* iter options */)
 		if err == nil {
 			// TODO(peter): It is mildly wasteful to open the point iterator only to
 			// immediately close it. One way to solve this would be to add new
@@ -336,7 +338,7 @@ func (c *compaction) newInputIter(
 	} else {
 		for i := range c.inputs[0] {
 			f := &c.inputs[0][i]
-			iter, rangeDelIter, err := newIters(f)
+			iter, rangeDelIter, err := newIters(f, nil /* iter options */)
 			if err != nil {
 				return nil, fmt.Errorf("pebble: could not open table %d: %v", f.fileNum, err)
 			}

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -615,7 +615,7 @@ func TestCompaction(t *testing.T) {
 				defer f.Close()
 				r := sstable.NewReader(f, meta.fileNum, nil)
 				defer r.Close()
-				ss = append(ss, get1(r.NewIter(nil))+".")
+				ss = append(ss, get1(r.NewIter(nil /* lower */, nil /* upper */))+".")
 			}
 		}
 		sort.Strings(ss)

--- a/db.go
+++ b/db.go
@@ -429,10 +429,6 @@ func (d *DB) newIterInternal(
 	memtables := readState.memtables
 	for i := len(memtables) - 1; i >= 0; i-- {
 		mem := memtables[i]
-		// TODO(peter):
-		// if o.GetLowerBound() != nil || o.GetUpperBound() != nil {
-		// 	panic("not reached")
-		// }
 		iters = append(iters, mem.newIter(o))
 		rangeDelIters = append(rangeDelIters, mem.newRangeDelIter(o))
 		largestUserKeys = append(largestUserKeys, nil)

--- a/db.go
+++ b/db.go
@@ -429,6 +429,10 @@ func (d *DB) newIterInternal(
 	memtables := readState.memtables
 	for i := len(memtables) - 1; i >= 0; i-- {
 		mem := memtables[i]
+		// TODO(peter):
+		// if o.GetLowerBound() != nil || o.GetUpperBound() != nil {
+		// 	panic("not reached")
+		// }
 		iters = append(iters, mem.newIter(o))
 		rangeDelIters = append(rangeDelIters, mem.newRangeDelIter(o))
 		largestUserKeys = append(largestUserKeys, nil)
@@ -438,7 +442,7 @@ func (d *DB) newIterInternal(
 	current := readState.current
 	for i := len(current.files[0]) - 1; i >= 0; i-- {
 		f := &current.files[0][i]
-		iter, rangeDelIter, err := d.newIters(f)
+		iter, rangeDelIter, err := d.newIters(f, o)
 		if err != nil {
 			dbi.err = err
 			return dbi

--- a/get_iter.go
+++ b/get_iter.go
@@ -129,7 +129,7 @@ func (g *getIter) Next() bool {
 			// Create iterators from L0 from newest to oldest.
 			if n := len(g.l0); n > 0 {
 				l := &g.l0[n-1]
-				g.iter, g.rangeDelIter, g.err = g.newIters(l)
+				g.iter, g.rangeDelIter, g.err = g.newIters(l, nil /* iter options */)
 				if g.err != nil {
 					return false
 				}

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -440,7 +440,9 @@ func TestGetIter(t *testing.T) {
 
 		// m is a map from file numbers to DBs.
 		m := map[uint64]*memTable{}
-		newIter := func(meta *fileMetadata) (internalIterator, internalIterator, error) {
+		newIter := func(
+			meta *fileMetadata, _ *db.IterOptions,
+		) (internalIterator, internalIterator, error) {
 			d, ok := m[meta.fileNum]
 			if !ok {
 				return nil, nil, errors.New("no such file")

--- a/ingest.go
+++ b/ingest.go
@@ -50,7 +50,7 @@ func ingestLoad1(opts *db.Options, path string, fileNum uint64) (*fileMetadata, 
 		}
 	}
 
-	if iter := r.NewRangeDelIter(nil); iter != nil {
+	if iter := r.NewRangeDelIter(); iter != nil {
 		defer iter.Close()
 		if iter.First() {
 			key := iter.Key()

--- a/ingest.go
+++ b/ingest.go
@@ -35,7 +35,7 @@ func ingestLoad1(opts *db.Options, path string, fileNum uint64) (*fileMetadata, 
 	smallestSet, largestSet := false, false
 
 	{
-		iter := r.NewIter(nil)
+		iter := r.NewIter(nil /* lower */, nil /* upper */)
 		defer iter.Close()
 		if iter.First() {
 			meta.smallest = iter.Key().Clone()

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -37,8 +37,10 @@ func (s *splice) init(prev, next *node) {
 // to construct an iterator. The current state of the iterator can be cloned by
 // simply value copying the struct. All iterator methods are thread-safe.
 type Iterator struct {
-	list *Skiplist
-	nd   *node
+	list  *Skiplist
+	nd    *node
+	lower []byte
+	upper []byte
 }
 
 // Close resets the iterator.
@@ -54,47 +56,98 @@ func (it *Iterator) Error() error {
 }
 
 // SeekGE moves the iterator to the first entry whose key is greater than or
-// equal to the given key. Returns true if the iterator is pointing at a
-// valid entry and false otherwise.
+// equal to the given key. Returns true if the iterator is pointing at a valid
+// entry and false otherwise. Note that SeekGE only checks the upper bound. It
+// is up to the caller to ensure that key is greater than or equal to the lower
+// bound.
 func (it *Iterator) SeekGE(key []byte) bool {
 	_, it.nd, _ = it.seekForBaseSplice(key)
-	return it.nd != it.list.tail
+	if it.nd == it.list.tail {
+		return false
+	}
+	if it.upper != nil && it.list.cmp(it.upper, it.Key().UserKey) <= 0 {
+		it.nd = it.list.tail
+		return false
+	}
+	return true
 }
 
 // SeekLT moves the iterator to the last entry whose key is less than the given
 // key. Returns true if the iterator is pointing at a valid entry and false
-// otherwise.
+// otherwise. Note that SeekLT only checks the lower bound. It is up to the
+// caller to ensure that key is less than the upper bound.
 func (it *Iterator) SeekLT(key []byte) bool {
+	// NB: the top-level Iterator has already adjusted key based on
+	// the upper-bound.
 	it.nd, _, _ = it.seekForBaseSplice(key)
-	return it.nd != it.list.head
+	if it.nd == it.list.head {
+		return false
+	}
+	if it.lower != nil && it.list.cmp(it.lower, it.Key().UserKey) > 0 {
+		it.nd = it.list.head
+		return false
+	}
+	return true
 }
 
 // First seeks position at the first entry in list. Final state of iterator is
-// Valid() iff list is not empty.
+// Valid() iff list is not empty. Note that First only checks the upper
+// bound. It is up to the caller to ensure that key is greater than or equal to
+// the lower bound (e.g. via a call to SeekGE(lower)).
 func (it *Iterator) First() bool {
 	it.nd = it.list.getNext(it.list.head, 0)
-	return it.nd != it.list.tail
+	if it.nd == it.list.tail {
+		return false
+	}
+	if it.upper != nil && it.list.cmp(it.upper, it.Key().UserKey) <= 0 {
+		it.nd = it.list.tail
+		return false
+	}
+	return true
 }
 
 // Last seeks position at the last entry in list. Final state of iterator is
-// Valid() iff list is not empty.
+// Valid() iff list is not empty. Note that Last only checks the lower
+// bound. It is up to the caller to ensure that key is less than the upper
+// bound (e.g. via a call to SeekLT(upper)).
 func (it *Iterator) Last() bool {
 	it.nd = it.list.getPrev(it.list.tail, 0)
-	return it.nd != it.list.head
+	if it.nd == it.list.head {
+		return false
+	}
+	if it.lower != nil && it.list.cmp(it.lower, it.Key().UserKey) > 0 {
+		it.nd = it.list.head
+		return false
+	}
+	return true
 }
 
 // Next advances to the next position. If there are no following nodes, then
 // Valid() will be false after this call.
 func (it *Iterator) Next() bool {
 	it.nd = it.list.getNext(it.nd, 0)
-	return it.nd != it.list.tail
+	if it.nd == it.list.tail {
+		return false
+	}
+	if it.upper != nil && it.list.cmp(it.upper, it.Key().UserKey) <= 0 {
+		it.nd = it.list.tail
+		return false
+	}
+	return true
 }
 
 // Prev moves to the previous position. If there are no previous nodes, then
 // Valid() will be false after this call.
 func (it *Iterator) Prev() bool {
 	it.nd = it.list.getPrev(it.nd, 0)
-	return it.nd != it.list.head
+	if it.nd == it.list.head {
+		return false
+	}
+	if it.lower != nil && it.list.cmp(it.lower, it.Key().UserKey) > 0 {
+		it.nd = it.list.head
+		return false
+	}
+	return true
 }
 
 // Key returns the key at the current position.
@@ -145,6 +198,11 @@ func (it *Iterator) seekForBaseSplice(key []byte) (prev, next *node, found bool)
 		prev, next, found = it.list.findSpliceForLevel(ikey, level, prev)
 
 		if found {
+			if level != 0 {
+				// next is pointing at the target node, but we need to find previous on
+				// the bottom level.
+				prev = it.list.getPrev(next, 0)
+			}
 			break
 		}
 

--- a/internal/arenaskl/skl.go
+++ b/internal/arenaskl/skl.go
@@ -301,10 +301,14 @@ func (s *Skiplist) addInternal(key db.InternalKey, value []byte, ins *Inserter) 
 	return nil
 }
 
-// NewIter returns a new Iterator object. Note that it is safe for an
-// iterator to be copied by value.
-func (s *Skiplist) NewIter() Iterator {
-	return Iterator{list: s, nd: s.head}
+// NewIter returns a new Iterator object. The lower and upper bound parameters
+// control the range of keys the iterator will return. Specifying for nil for
+// lower or upper bound disables the check for that boundary. Note that lower
+// bound is not checked on {SeekGE,First} and upper bound is not check on
+// {SeekLT,Last}. The user is expected to perform that check. Note that it is
+// safe for an iterator to be copied by value.
+func (s *Skiplist) NewIter(lower, upper []byte) Iterator {
+	return Iterator{list: s, nd: s.head, lower: lower, upper: upper}
 }
 
 func (s *Skiplist) newNode(

--- a/internal/batchskl/skl.go
+++ b/internal/batchskl/skl.go
@@ -222,10 +222,14 @@ func (s *Skiplist) Add(keyOffset uint32) error {
 	return nil
 }
 
-// NewIter returns a new Iterator object. Note that it is safe for an iterator
-// to be copied by value.
-func (s *Skiplist) NewIter() Iterator {
-	return Iterator{list: s}
+// NewIter returns a new Iterator object. The lower and upper bound parameters
+// control the range of keys the iterator will return. Specifying for nil for
+// lower or upper bound disables the check for that boundary. Note that lower
+// bound is not checked on {SeekGE,First} and upper bound is not check on
+// {SeekLT,Last}. The user is expected to perform that check. Note that it is
+// safe for an iterator to be copied by value.
+func (s *Skiplist) NewIter(lower, upper []byte) Iterator {
+	return Iterator{list: s, lower: lower, upper: upper}
 }
 
 func (s *Skiplist) newNode(height, key uint32, abbreviatedKey uint64) uint32 {

--- a/iterator.go
+++ b/iterator.go
@@ -55,6 +55,8 @@ func (i *Iterator) findNextEntry() bool {
 
 	for i.iterValid {
 		key := i.iter.Key()
+		// TODO(peter): push the upper-bound check down into internalIterator as we
+		// can elide the check in many cases.
 		if upperBound != nil && i.cmp(key.UserKey, upperBound) >= 0 {
 			break
 		}
@@ -113,6 +115,8 @@ func (i *Iterator) findPrevEntry() bool {
 
 	for i.iterValid {
 		key := i.iter.Key()
+		// TODO(peter): push the lower-bound check down into internalIterator as we
+		// can elide the check in many cases.
 		if lowerBound != nil && i.cmp(key.UserKey, lowerBound) < 0 {
 			break
 		}

--- a/level_iter.go
+++ b/level_iter.go
@@ -86,7 +86,7 @@ func (l *levelIter) initLargestUserKey(largestUserKey *[]byte) {
 func (l *levelIter) findFileGE(key []byte) int {
 	// Find the earliest file whose largest key is >= ikey. Note that the range
 	// deletion sentinel key is handled specially and a search for K will not
-	// find a table for K<range-del-sentinel> is the largest key. This prevents
+	// find a table where K<range-del-sentinel> is the largest key. This prevents
 	// loading untruncated range deletions from a table which can't possibly
 	// contain the target key and is required for correctness by DB.Get.
 	//

--- a/level_iter.go
+++ b/level_iter.go
@@ -12,7 +12,9 @@ import (
 
 // tableNewIters creates a new point and range-del iterator for the given file
 // number.
-type tableNewIters func(meta *fileMetadata) (internalIterator, internalIterator, error)
+type tableNewIters func(
+	meta *fileMetadata, opts *db.IterOptions,
+) (internalIterator, internalIterator, error)
 
 // levelIter provides a merged view of the sstables in a level.
 //
@@ -153,7 +155,7 @@ func (l *levelIter) loadFile(index, dir int) bool {
 		}
 
 		var rangeDelIter internalIterator
-		l.iter, rangeDelIter, l.err = l.newIters(f)
+		l.iter, rangeDelIter, l.err = l.newIters(f, l.opts)
 		if l.err != nil || l.iter == nil {
 			return false
 		}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -24,7 +24,9 @@ func TestLevelIter(t *testing.T) {
 	var iters []*fakeIter
 	var files []fileMetadata
 
-	newIters := func(meta *fileMetadata) (internalIterator, internalIterator, error) {
+	newIters := func(
+		meta *fileMetadata, _ *db.IterOptions,
+	) (internalIterator, internalIterator, error) {
 		f := *iters[meta.fileNum]
 		return &f, nil, nil
 	}
@@ -86,7 +88,9 @@ func TestLevelIterBoundaries(t *testing.T) {
 	var readers []*sstable.Reader
 	var files []fileMetadata
 
-	newIters := func(meta *fileMetadata) (internalIterator, internalIterator, error) {
+	newIters := func(
+		meta *fileMetadata, _ *db.IterOptions,
+	) (internalIterator, internalIterator, error) {
 		return readers[meta.fileNum].NewIter(nil), nil, nil
 	}
 
@@ -243,7 +247,9 @@ func BenchmarkLevelIterSeekGE(b *testing.B) {
 					b.Run(fmt.Sprintf("count=%d", count),
 						func(b *testing.B) {
 							readers, files, keys := buildLevelIterTables(b, blockSize, restartInterval, count)
-							newIters := func(meta *fileMetadata) (internalIterator, internalIterator, error) {
+							newIters := func(
+								meta *fileMetadata, _ *db.IterOptions,
+							) (internalIterator, internalIterator, error) {
 								return readers[meta.fileNum].NewIter(nil), nil, nil
 							}
 							l := newLevelIter(nil, db.DefaultComparer.Compare, newIters, files)
@@ -269,7 +275,9 @@ func BenchmarkLevelIterNext(b *testing.B) {
 					b.Run(fmt.Sprintf("count=%d", count),
 						func(b *testing.B) {
 							readers, files, _ := buildLevelIterTables(b, blockSize, restartInterval, count)
-							newIters := func(meta *fileMetadata) (internalIterator, internalIterator, error) {
+							newIters := func(
+								meta *fileMetadata, _ *db.IterOptions,
+							) (internalIterator, internalIterator, error) {
 								return readers[meta.fileNum].NewIter(nil), nil, nil
 							}
 							l := newLevelIter(nil, db.DefaultComparer.Compare, newIters, files)
@@ -297,7 +305,9 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 					b.Run(fmt.Sprintf("count=%d", count),
 						func(b *testing.B) {
 							readers, files, _ := buildLevelIterTables(b, blockSize, restartInterval, count)
-							newIters := func(meta *fileMetadata) (internalIterator, internalIterator, error) {
+							newIters := func(
+								meta *fileMetadata, _ *db.IterOptions,
+							) (internalIterator, internalIterator, error) {
 								return readers[meta.fileNum].NewIter(nil), nil, nil
 							}
 							l := newLevelIter(nil, db.DefaultComparer.Compare, newIters, files)

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -129,7 +129,7 @@ func TestLevelIterBoundaries(t *testing.T) {
 	newIters := func(
 		meta *fileMetadata, _ *db.IterOptions,
 	) (internalIterator, internalIterator, error) {
-		return readers[meta.fileNum].NewIter(nil), nil, nil
+		return readers[meta.fileNum].NewIter(nil /* lower */, nil /* upper */), nil, nil
 	}
 
 	datadriven.RunTest(t, "testdata/level_iter_boundaries", func(d *datadriven.TestData) string {
@@ -265,7 +265,7 @@ func buildLevelIterTables(
 
 	meta := make([]fileMetadata, len(readers))
 	for i := range readers {
-		iter := readers[i].NewIter(nil)
+		iter := readers[i].NewIter(nil /* lower */, nil /* upper */)
 		iter.First()
 		meta[i].fileNum = uint64(i)
 		meta[i].smallest = iter.Key()
@@ -288,7 +288,7 @@ func BenchmarkLevelIterSeekGE(b *testing.B) {
 							newIters := func(
 								meta *fileMetadata, _ *db.IterOptions,
 							) (internalIterator, internalIterator, error) {
-								return readers[meta.fileNum].NewIter(nil), nil, nil
+								return readers[meta.fileNum].NewIter(nil /* lower */, nil /* upper */), nil, nil
 							}
 							l := newLevelIter(nil, db.DefaultComparer.Compare, newIters, files)
 							rng := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -316,7 +316,7 @@ func BenchmarkLevelIterNext(b *testing.B) {
 							newIters := func(
 								meta *fileMetadata, _ *db.IterOptions,
 							) (internalIterator, internalIterator, error) {
-								return readers[meta.fileNum].NewIter(nil), nil, nil
+								return readers[meta.fileNum].NewIter(nil /* lower */, nil /* upper */), nil, nil
 							}
 							l := newLevelIter(nil, db.DefaultComparer.Compare, newIters, files)
 
@@ -346,7 +346,7 @@ func BenchmarkLevelIterPrev(b *testing.B) {
 							newIters := func(
 								meta *fileMetadata, _ *db.IterOptions,
 							) (internalIterator, internalIterator, error) {
-								return readers[meta.fileNum].NewIter(nil), nil, nil
+								return readers[meta.fileNum].NewIter(nil /* lower */, nil /* upper */), nil, nil
 							}
 							l := newLevelIter(nil, db.DefaultComparer.Compare, newIters, files)
 

--- a/mem_table.go
+++ b/mem_table.go
@@ -97,7 +97,7 @@ func (m *memTable) readyForFlush() bool {
 // Get gets the value for the given key. It returns ErrNotFound if the DB does
 // not contain the key.
 func (m *memTable) get(key []byte) (value []byte, err error) {
-	it := m.skl.NewIter()
+	it := m.skl.NewIter(nil, nil)
 	if !it.SeekGE(key) {
 		return nil, db.ErrNotFound
 	}
@@ -167,8 +167,8 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 // newIter returns an iterator that is unpositioned (Iterator.Valid() will
 // return false). The iterator can be positioned via a call to SeekGE,
 // SeekLT, First or Last.
-func (m *memTable) newIter(*db.IterOptions) internalIterator {
-	it := m.skl.NewIter()
+func (m *memTable) newIter(o *db.IterOptions) internalIterator {
+	it := m.skl.NewIter(o.GetLowerBound(), o.GetUpperBound())
 	return &it
 }
 
@@ -216,7 +216,7 @@ func (f *rangeTombstoneFrags) get(m *memTable) []rangedel.Tombstone {
 				f.tombstones = append(f.tombstones, fragmented...)
 			},
 		}
-		for it := m.rangeDelSkl.NewIter(); it.Next(); {
+		for it := m.rangeDelSkl.NewIter(nil, nil); it.Next(); {
 			frag.Add(it.Key(), it.Value())
 		}
 		frag.Finish()

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -199,7 +199,7 @@ func BenchmarkMergingIterSeekGE(b *testing.B) {
 							readers, keys := buildMergingIterTables(b, blockSize, restartInterval, count)
 							iters := make([]internalIterator, len(readers))
 							for i := range readers {
-								iters[i] = readers[i].NewIter(nil)
+								iters[i] = readers[i].NewIter(nil /* lower */, nil /* upper */)
 							}
 							m := newMergingIter(db.DefaultComparer.Compare, iters...)
 							rng := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -226,7 +226,7 @@ func BenchmarkMergingIterNext(b *testing.B) {
 							readers, _ := buildMergingIterTables(b, blockSize, restartInterval, count)
 							iters := make([]internalIterator, len(readers))
 							for i := range readers {
-								iters[i] = readers[i].NewIter(nil)
+								iters[i] = readers[i].NewIter(nil /* lower */, nil /* upper */)
 							}
 							m := newMergingIter(db.DefaultComparer.Compare, iters...)
 
@@ -255,7 +255,7 @@ func BenchmarkMergingIterPrev(b *testing.B) {
 							readers, _ := buildMergingIterTables(b, blockSize, restartInterval, count)
 							iters := make([]internalIterator, len(readers))
 							for i := range readers {
-								iters[i] = readers[i].NewIter(nil)
+								iters[i] = readers[i].NewIter(nil /* lower */, nil /* upper */)
 							}
 							m := newMergingIter(db.DefaultComparer.Compare, iters...)
 

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -361,7 +361,7 @@ func (r *Reader) Close() error {
 
 // get is a testing helper that simulates a read and helps verify bloom filters
 // until they are available through iterators.
-func (r *Reader) get(key []byte, o *db.IterOptions) (value []byte, err error) {
+func (r *Reader) get(key []byte) (value []byte, err error) {
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -414,7 +414,7 @@ func (r *Reader) NewIter(o *db.IterOptions) *Iterator {
 // NewRangeDelIter returns an internal iterator for the contents of the
 // range-del block for the table. Returns nil if the table does not contain any
 // range deletions.
-func (r *Reader) NewRangeDelIter(o *db.IterOptions) *blockIter {
+func (r *Reader) NewRangeDelIter() *blockIter {
 	if r.rangeDel.bh.length == 0 {
 		return nil
 	}

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -167,7 +167,7 @@ func runTestReader(t *testing.T, o db.Options) {
 			case "get":
 				var b bytes.Buffer
 				for _, k := range strings.Split(d.Input, "\n") {
-					v, err := r.get([]byte(k), nil)
+					v, err := r.get([]byte(k))
 					if err != nil {
 						fmt.Fprintf(&b, "<err: %s>\n", err)
 					} else {

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -122,7 +122,7 @@ func runTestReader(t *testing.T, o db.Options) {
 					}
 				}
 
-				iter := r.NewIter(nil)
+				iter := r.NewIter(nil /* lower */, nil /* upper */)
 				if err := iter.Error(); err != nil {
 					t.Fatal(err)
 				}
@@ -227,7 +227,7 @@ func BenchmarkTableIterSeekGE(b *testing.B) {
 		b.Run(fmt.Sprintf("restart=%d", restartInterval),
 			func(b *testing.B) {
 				r, keys := buildBenchmarkTable(b, blockSize, restartInterval)
-				it := r.NewIter(nil)
+				it := r.NewIter(nil /* lower */, nil /* upper */)
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 				b.ResetTimer()
@@ -245,7 +245,7 @@ func BenchmarkTableIterSeekLT(b *testing.B) {
 		b.Run(fmt.Sprintf("restart=%d", restartInterval),
 			func(b *testing.B) {
 				r, keys := buildBenchmarkTable(b, blockSize, restartInterval)
-				it := r.NewIter(nil)
+				it := r.NewIter(nil /* lower */, nil /* upper */)
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 				b.ResetTimer()
@@ -263,7 +263,7 @@ func BenchmarkTableIterNext(b *testing.B) {
 		b.Run(fmt.Sprintf("restart=%d", restartInterval),
 			func(b *testing.B) {
 				r, _ := buildBenchmarkTable(b, blockSize, restartInterval)
-				it := r.NewIter(nil)
+				it := r.NewIter(nil /* lower */, nil /* upper */)
 
 				b.ResetTimer()
 				var sum int64
@@ -288,7 +288,7 @@ func BenchmarkTableIterPrev(b *testing.B) {
 		b.Run(fmt.Sprintf("restart=%d", restartInterval),
 			func(b *testing.B) {
 				r, _ := buildBenchmarkTable(b, blockSize, restartInterval)
-				it := r.NewIter(nil)
+				it := r.NewIter(nil /* lower */, nil /* upper */)
 
 				b.ResetTimer()
 				var sum int64

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -121,7 +121,7 @@ func check(f storage.File, comparer *db.Comparer, fp db.FilterPolicy) error {
 	// Check that each key/value pair in wordCount is also in the table.
 	for k, v := range wordCount {
 		// Check using Get.
-		if v1, err := r.get([]byte(k), nil); string(v1) != string(v) || err != nil {
+		if v1, err := r.get([]byte(k)); string(v1) != string(v) || err != nil {
 			return fmt.Errorf("Get %q: got (%q, %v), want (%q, %v)", k, v1, err, v, error(nil))
 		} else if len(v1) != cap(v1) {
 			return fmt.Errorf("Get %q: len(v1)=%d, cap(v1)=%d", k, len(v1), cap(v1))
@@ -169,7 +169,7 @@ func check(f storage.File, comparer *db.Comparer, fp db.FilterPolicy) error {
 	// Check that nonsense words are not in the table.
 	for _, s := range nonsenseWords {
 		// Check using Get.
-		if _, err := r.get([]byte(s), nil); err != db.ErrNotFound {
+		if _, err := r.get([]byte(s)); err != db.ErrNotFound {
 			return fmt.Errorf("Get %q: got %v, want ErrNotFound", s, err)
 		}
 
@@ -386,7 +386,7 @@ func TestBloomFilterFalsePositiveRate(t *testing.T) {
 	key := []byte("m!....")
 	for i := 0; i < n; i++ {
 		binary.LittleEndian.PutUint32(key[2:6], uint32(i))
-		r.get(key, nil)
+		r.get(key)
 	}
 
 	if c.truePositives != 0 {

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -139,7 +139,7 @@ func TestWriter(t *testing.T) {
 			return buf.String()
 
 		case "scan-range-del":
-			iter := r.NewRangeDelIter(nil)
+			iter := r.NewRangeDelIter()
 			if iter == nil {
 				return ""
 			}

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -129,7 +129,7 @@ func TestWriter(t *testing.T) {
 				meta.SmallestSeqNum, meta.LargestSeqNum)
 
 		case "scan":
-			iter := r.NewIter(nil)
+			iter := r.NewIter(nil /* lower */, nil /* upper */)
 			defer iter.Close()
 
 			var buf bytes.Buffer

--- a/table_cache.go
+++ b/table_cache.go
@@ -49,7 +49,9 @@ func (c *tableCache) init(dirname string, fs storage.Storage, opts *db.Options, 
 	}
 }
 
-func (c *tableCache) newIters(meta *fileMetadata) (internalIterator, internalIterator, error) {
+func (c *tableCache) newIters(
+	meta *fileMetadata, opts *db.IterOptions,
+) (internalIterator, internalIterator, error) {
 	// Calling findNode gives us the responsibility of decrementing n's
 	// refCount. If opening the underlying table resulted in error, then we
 	// decrement this straight away. Otherwise, we pass that responsibility to
@@ -67,7 +69,7 @@ func (c *tableCache) newIters(meta *fileMetadata) (internalIterator, internalIte
 	}
 	n.result <- x
 
-	iter := x.reader.NewIter(nil)
+	iter := x.reader.NewIter(opts)
 	atomic.AddInt32(&c.mu.iterCount, 1)
 	if raceEnabled {
 		c.mu.Lock()

--- a/table_cache.go
+++ b/table_cache.go
@@ -92,7 +92,7 @@ func (c *tableCache) newIters(meta *fileMetadata) (internalIterator, internalIte
 
 	// NB: range-del iterator does not maintain a reference to the table, nor
 	// does it need to read from it after creation.
-	if rangeDelIter := x.reader.NewRangeDelIter(nil); rangeDelIter != nil {
+	if rangeDelIter := x.reader.NewRangeDelIter(); rangeDelIter != nil {
 		return iter, rangeDelIter, nil
 	}
 	// NB: Translate a nil range-del iterator into a nil interface.

--- a/table_cache.go
+++ b/table_cache.go
@@ -69,7 +69,7 @@ func (c *tableCache) newIters(
 	}
 	n.result <- x
 
-	iter := x.reader.NewIter(opts)
+	iter := x.reader.NewIter(opts.GetLowerBound(), opts.GetUpperBound())
 	atomic.AddInt32(&c.mu.iterCount, 1)
 	if raceEnabled {
 		c.mu.Lock()

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -169,7 +169,7 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 			rngMu.Lock()
 			fileNum, sleepTime := rng.Intn(tableCacheTestNumTables), rng.Intn(1000)
 			rngMu.Unlock()
-			iter, _, err := c.newIters(&fileMetadata{fileNum: uint64(fileNum)})
+			iter, _, err := c.newIters(&fileMetadata{fileNum: uint64(fileNum)}, nil /* iter options */)
 			if err != nil {
 				errc <- fmt.Errorf("i=%d, fileNum=%d: find: %v", i, fileNum, err)
 				return
@@ -228,7 +228,7 @@ func TestTableCacheFrequentlyUsed(t *testing.T) {
 
 	for i := 0; i < N; i++ {
 		for _, j := range [...]int{pinned0, i % tableCacheTestNumTables, pinned1} {
-			iter, _, err := c.newIters(&fileMetadata{fileNum: uint64(j)})
+			iter, _, err := c.newIters(&fileMetadata{fileNum: uint64(j)}, nil /* iter options */)
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 			}
@@ -263,7 +263,7 @@ func TestTableCacheEvictions(t *testing.T) {
 	rng := rand.New(rand.NewSource(2))
 	for i := 0; i < N; i++ {
 		j := rng.Intn(tableCacheTestNumTables)
-		iter, _, err := c.newIters(&fileMetadata{fileNum: uint64(j)})
+		iter, _, err := c.newIters(&fileMetadata{fileNum: uint64(j)}, nil /* iter options */)
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 		}
@@ -303,7 +303,7 @@ func TestTableCacheIterLeak(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := c.newIters(&fileMetadata{fileNum: 0}); err != nil {
+	if _, _, err := c.newIters(&fileMetadata{fileNum: 0}, nil /* iter options */); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.Close(); err == nil {

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -100,6 +100,27 @@ first
 a:1
 a:1
 
+# levelIter trims lower/upper bound in the options passed to sstables.
+load a
+----
+[,]
+
+load a lower=a upper=b
+----
+[a,b]
+
+load a lower=a upper=c
+----
+[a,]
+
+load c lower=b upper=d
+----
+[,d]
+
+load c lower=b upper=e
+----
+[,]
+
 # levelIter only checks lower bound when loading sstables.
 iter lower=b
 seek-ge a


### PR DESCRIPTION
NB: this change is in anticipation of pushing lower/upper bound checks down into `sstable.Reader`.

Trim `IterOptions.{Lower,Upper}Bound` when loading a table to avoid requiring lower/upper bounds checks if all of the keys within the table pass the checks.

See #28