### PR TITLE
Zero seqnums in sstables where possible

### DIFF
--- a/compaction_iter_test.go
+++ b/compaction_iter_test.go
@@ -58,6 +58,7 @@ func TestCompactionIter(t *testing.T) {
 			db.DefaultMerger.Merge,
 			&fakeIter{keys: keys, vals: vals},
 			snapshots,
+			false, /* allowZeroSeqNum */
 			func([]byte) bool {
 				return elideTombstones
 			},

--- a/iterator.go
+++ b/iterator.go
@@ -87,15 +87,17 @@ func (i *Iterator) findNextEntry() bool {
 
 func (i *Iterator) nextUserKey() {
 	if i.iterKey != nil {
+		done := i.iterKey.SeqNum() == 0
 		if !i.valid {
 			i.keyBuf = append(i.keyBuf[:0], i.iterKey.UserKey...)
 			i.key = i.keyBuf
 		}
 		for {
 			i.iterKey, i.iterValue = i.iter.Next()
-			if i.iterKey == nil || !i.equal(i.key, i.iterKey.UserKey) {
+			if done || i.iterKey == nil || !i.equal(i.key, i.iterKey.UserKey) {
 				break
 			}
+			done = i.iterKey.SeqNum() == 0
 		}
 	} else {
 		i.iterKey, i.iterValue = i.iter.First()
@@ -174,6 +176,8 @@ func (i *Iterator) findPrevEntry() bool {
 func (i *Iterator) prevUserKey() {
 	if i.iterKey != nil {
 		if !i.valid {
+			// If we're going to compare against the prev key, we need to save the
+			// current key.
 			i.keyBuf = append(i.keyBuf[:0], i.iterKey.UserKey...)
 			i.key = i.keyBuf
 		}

--- a/testdata/compaction_allow_zero_seqnum
+++ b/testdata/compaction_allow_zero_seqnum
@@ -1,0 +1,35 @@
+define
+L2
+  c.SET.2:2
+----
+2: c-c
+
+allow-zero-seqnum
+L0:b-b
+L0:c-c
+L0:d-d
+----
+true
+false
+true
+
+allow-zero-seqnum
+L0:c-c L0:d-d
+L0:c-c L1:d-d
+L0:b-b L0:b-c
+L0:b-b L1:b-c
+----
+false
+false
+false
+false
+
+# We only look for overlaps at L<N+2> as it isn't valid for a
+# compaction rooted at L<N> to not include overlapping tables at
+# L<N+1>.
+
+allow-zero-seqnum
+L1:c-c
+----
+true
+

--- a/testdata/manual_flush
+++ b/testdata/manual_flush
@@ -3,9 +3,10 @@ set a 1
 set b 2
 ----
 
+# The first L0 table can have its seqnums zeroed.
 flush
 ----
-0: a#0,1-b#1,1
+0: a#0,1-b#0,1
 
 reset
 ----
@@ -20,6 +21,24 @@ del b
 flush
 ----
 0: a#2,0-b#3,0
+
+batch
+set a 3
+----
+
+# A second (overlapping) L0 table will have non-zero seqnums.
+flush
+----
+0: a#2,0-b#3,0 a#4,1-a#4,1
+
+batch
+set c 4
+----
+
+# A third (non-overlapping) L0 table will have non-zero seqnums.
+flush
+----
+0: a#2,0-b#3,0 a#4,1-a#4,1 c#5,1-c#5,1
 
 reset
 ----
@@ -43,4 +62,4 @@ set b 2
 
 async-flush
 ----
-0: a#0,1-b#1,1
+0: a#0,1-b#0,1

--- a/version.go
+++ b/version.go
@@ -249,6 +249,9 @@ func (v *version) overlaps(
 	upper := sort.Search(len(files), func(i int) bool {
 		return cmp(files[i].smallest.UserKey, end) > 0
 	})
+	if lower >= upper {
+		return nil
+	}
 	return files[lower:upper]
 }
 


### PR DESCRIPTION
Zero seqnums in sstables in order to improve sstable compression and
enable an optimization to avoid a user-key comparison during forward
iteration. The seqnum for an entry can be zeroed if the key does not
exist at lower levels in the tree and if the entry is in the last
snapshot stripe. Rather than performing the check on a per-key basis, a
single check is done to see if the bounds of a compaction overlaps with
any sstables at lower-levels in the tree. This is slightly
pessimistic (it disallows zeroing of some keys when they could be
zeroed), but fast.

Forward iteration normally requires a user-key comparison to determine
if we've moved to the next user-key. We can skip this comparison if the
seqnum for an entry is 0 as that is the oldest seqnum for a particular
user-key which guarantees the next entry is for a different
user-key. This produces a ~5% speedup in forward iteration performance
when iterating over data contained in the bottommost sstables. Note the
rule of thumb is that ~90% of data in an LSM is in the bottommost level.

Fixes #87