### PR TITLE
Return key and value from internalIterator positioning methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GO = go
 GOFLAGS =
 PKG = ./...
+BENCH_PKGS = internal/arenaskl internal/batchskl internal/record sstable .
 TESTS = .
 
 .PHONY: all
@@ -34,7 +35,7 @@ stressrace: stress
 
 .PHONY: bench
 bench: GOFLAGS += -timeout 1h
-bench: $(patsubst %,%.bench,internal/arenaskl internal/batchskl internal/record sstable .)
+bench: $(patsubst %,%.bench,$(if $(findstring ./...,${PKG}),${BENCH_PKGS},${PKG}))
 
 internal/arenaskl.bench: GOFLAGS += -cpu 1,8
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -231,7 +231,7 @@ func TestBatchDeleteRange(t *testing.T) {
 			return ""
 
 		case "scan":
-			var iter internalIterator
+			var iter internalIterAdapter
 			if len(td.CmdArgs) > 1 {
 				return fmt.Sprintf("%s expects at most 1 argument", td.Cmd)
 			}
@@ -239,9 +239,9 @@ func TestBatchDeleteRange(t *testing.T) {
 				if td.CmdArgs[0].String() != "range-del" {
 					return fmt.Sprintf("%s unknown argument %s", td.Cmd, td.CmdArgs[0])
 				}
-				iter = b.newRangeDelIter(nil)
+				iter.internalIterator = b.newRangeDelIter(nil)
 			} else {
-				iter = b.newInternalIter(nil)
+				iter.internalIterator = b.newInternalIter(nil)
 			}
 			defer iter.Close()
 
@@ -317,7 +317,7 @@ func TestFlushableBatchSeqNum(t *testing.T) {
 			}
 			b.seqNum = uint64(seqNum)
 
-			iter := b.newIter(nil)
+			iter := internalIterAdapter{b.newIter(nil)}
 			var buf bytes.Buffer
 			for valid := iter.First(); valid; valid = iter.Next() {
 				fmt.Fprintf(&buf, "%s:%s\n", iter.Key(), iter.Value())
@@ -356,7 +356,7 @@ func TestFlushableBatchDeleteRange(t *testing.T) {
 			return ""
 
 		case "scan":
-			var iter internalIterator
+			var iter internalIterAdapter
 			if len(td.CmdArgs) > 1 {
 				return fmt.Sprintf("%s expects at most 1 argument", td.Cmd)
 			}
@@ -364,9 +364,9 @@ func TestFlushableBatchDeleteRange(t *testing.T) {
 				if td.CmdArgs[0].String() != "range-del" {
 					return fmt.Sprintf("%s unknown argument %s", td.Cmd, td.CmdArgs[0])
 				}
-				iter = fb.newRangeDelIter(nil)
+				iter.internalIterator = fb.newRangeDelIter(nil)
 			} else {
-				iter = fb.newIter(nil)
+				iter.internalIterator = fb.newIter(nil)
 			}
 			defer iter.Close()
 

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -589,8 +589,8 @@ func TestCompaction(t *testing.T) {
 
 	get1 := func(iter internalIterator) (ret string) {
 		b := &bytes.Buffer{}
-		for valid := iter.First(); valid; valid = iter.Next() {
-			b.Write(iter.Key().UserKey)
+		for key, _ := iter.First(); key != nil; key, _ = iter.Next() {
+			b.Write(key.UserKey)
 		}
 		if err := iter.Close(); err != nil {
 			t.Fatalf("iterator Close: %v", err)

--- a/error_iter.go
+++ b/error_iter.go
@@ -16,32 +16,32 @@ func newErrorIter(err error) *errorIter {
 	return &errorIter{err: err}
 }
 
-func (c *errorIter) SeekGE(key []byte) bool {
-	return false
+func (c *errorIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
+	return nil, nil
 }
 
-func (c *errorIter) SeekLT(key []byte) bool {
-	return false
+func (c *errorIter) SeekLT(key []byte) (*db.InternalKey, []byte) {
+	return nil, nil
 }
 
-func (c *errorIter) First() bool {
-	return false
+func (c *errorIter) First() (*db.InternalKey, []byte) {
+	return nil, nil
 }
 
-func (c *errorIter) Last() bool {
-	return false
+func (c *errorIter) Last() (*db.InternalKey, []byte) {
+	return nil, nil
 }
 
-func (c *errorIter) Next() bool {
-	return false
+func (c *errorIter) Next() (*db.InternalKey, []byte) {
+	return nil, nil
 }
 
-func (c *errorIter) Prev() bool {
-	return false
+func (c *errorIter) Prev() (*db.InternalKey, []byte) {
+	return nil, nil
 }
 
-func (c *errorIter) Key() db.InternalKey {
-	return db.InvalidInternalKey
+func (c *errorIter) Key() *db.InternalKey {
+	return nil
 }
 
 func (c *errorIter) Value() []byte {

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -503,10 +503,10 @@ func TestIngest(t *testing.T) {
 					if iter == nil {
 						continue
 					}
-					for valid := iter.First(); valid; valid = iter.Next() {
-						key := iter.Key()
-						key.SetSeqNum(10000)
-						if err := w.Add(key, iter.Value()); err != nil {
+					for key, val := iter.First(); key != nil; key, val = iter.Next() {
+						tmp := *key
+						tmp.SetSeqNum(10000)
+						if err := w.Add(tmp, val); err != nil {
 							return err.Error()
 						}
 					}

--- a/internal.go
+++ b/internal.go
@@ -28,35 +28,39 @@ import (
 // at a particular point in time.
 type internalIterator interface {
 	// SeekGE moves the iterator to the first key/value pair whose key is greater
-	// than or equal to the given key. Returns true if the iterator is pointing
-	// at a valid entry and false otherwise.
-	SeekGE(key []byte) bool
+	// than or equal to the given key. Returns the key and value if the iterator
+	// is pointing at a valid entry, and (nil, nil) otherwise.
+	SeekGE(key []byte) (*db.InternalKey, []byte)
 
 	// SeekLT moves the iterator to the last key/value pair whose key is less
-	// than the given key. Returns true if the iterator is pointing at a valid
-	// entry and false otherwise.
-	SeekLT(key []byte) bool
+	// than the given key. Returns the key and value if the iterator is pointing
+	// at a valid entry, and (nil, nil) otherwise.
+	SeekLT(key []byte) (*db.InternalKey, []byte)
 
-	// First moves the iterator the the first key/value pair. Returns true if the
-	// iterator is pointing at a valid entry and false otherwise.
-	First() bool
+	// First moves the iterator the the first key/value pair. Returns the key and
+	// value if the iterator is pointing at a valid entry, and (nil, nil)
+	// otherwise.
+	First() (*db.InternalKey, []byte)
 
-	// Last moves the iterator the the last key/value pair. Returns true if the
-	// iterator is pointing at a valid entry and false otherwise.
-	Last() bool
+	// Last moves the iterator the the last key/value pair. Returns the key and
+	// value if the iterator is pointing at a valid entry, and (nil, nil)
+	// otherwise.
+	Last() (*db.InternalKey, []byte)
 
-	// Next moves the iterator to the next key/value pair. Returns true if the
-	// iterator is pointing at a valid entry and false otherwise.
-	Next() bool
+	// Next moves the iterator to the next key/value pair. Returns the key and
+	// value if the iterator is pointing at a valid entry, and (nil, nil)
+	// otherwise.
+	Next() (*db.InternalKey, []byte)
 
-	// Prev moves the iterator to the previous key/value pair. Returns true if the
-	// iterator is pointing at a valid entry and false otherwise.
-	Prev() bool
+	// Prev moves the iterator to the previous key/value pair. Returns the key
+	// and value if the iterator is pointing at a valid entry, and (nil, nil)
+	// otherwise.
+	Prev() (*db.InternalKey, []byte)
 
 	// Key returns the encoded internal key of the current key/value pair, or nil
-	// if done. The caller should not modify the contents of the returned slice,
+	// if done. The caller should not modify the contents of the returned key,
 	// and its contents may change on the next call to Next.
-	Key() db.InternalKey
+	Key() *db.InternalKey
 
 	// Value returns the value of the current key/value pair, or nil if done.
 	// The caller should not modify the contents of the returned slice, and

--- a/internal/rangedel/truncate.go
+++ b/internal/rangedel/truncate.go
@@ -12,10 +12,10 @@ import (
 // iterator is truncated to be contained within the range [lower, upper).
 func Truncate(cmp db.Compare, iter iterator, lower, upper []byte) *Iter {
 	var tombstones []Tombstone
-	for valid := iter.First(); valid; valid = iter.Next() {
+	for key, value := iter.First(); key != nil; key, value = iter.Next() {
 		t := Tombstone{
-			Start: iter.Key(),
-			End:   iter.Value(),
+			Start: *key,
+			End:   value,
 		}
 		if cmp(t.Start.UserKey, lower) < 0 {
 			t.Start.UserKey = lower

--- a/internal_test.go
+++ b/internal_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/petermattis/pebble/db"
+)
+
+// internalIterAdapter adapts the new internalIterator interface which returns
+// the key and value from positioning methods (Seek*, First, Last, Next, Prev)
+// to the old interface which returned a boolean corresponding to Valid. Only
+// used by test code.
+type internalIterAdapter struct {
+	internalIterator
+}
+
+func (i *internalIterAdapter) verify(key *db.InternalKey, val []byte) bool {
+	valid := key != nil
+	if valid != i.Valid() {
+		panic(fmt.Sprintf("inconsistent valid: %t != %t", valid, i.Valid()))
+	}
+	if valid {
+		if db.InternalCompare(bytes.Compare, *key, i.Key()) != 0 {
+			panic(fmt.Sprintf("inconsistent key: %s != %s", *key, i.Key()))
+		}
+		if !bytes.Equal(val, i.Value()) {
+			panic(fmt.Sprintf("inconsistent value: [% x] != [% x]", val, i.Value()))
+		}
+	}
+	return valid
+}
+
+func (i *internalIterAdapter) SeekGE(key []byte) bool {
+	return i.verify(i.internalIterator.SeekGE(key))
+}
+
+func (i *internalIterAdapter) SeekLT(key []byte) bool {
+	return i.verify(i.internalIterator.SeekLT(key))
+}
+
+func (i *internalIterAdapter) First() bool {
+	return i.verify(i.internalIterator.First())
+}
+
+func (i *internalIterAdapter) Last() bool {
+	return i.verify(i.internalIterator.Last())
+}
+
+func (i *internalIterAdapter) Next() bool {
+	return i.verify(i.internalIterator.Next())
+}
+
+func (i *internalIterAdapter) Prev() bool {
+	return i.verify(i.internalIterator.Prev())
+}
+
+func (i *internalIterAdapter) Key() db.InternalKey {
+	return *i.internalIterator.Key()
+}

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -266,11 +266,11 @@ func buildLevelIterTables(
 	meta := make([]fileMetadata, len(readers))
 	for i := range readers {
 		iter := readers[i].NewIter(nil /* lower */, nil /* upper */)
-		iter.First()
+		key, _ := iter.First()
 		meta[i].fileNum = uint64(i)
-		meta[i].smallest = iter.Key()
-		iter.Last()
-		meta[i].largest = iter.Key()
+		meta[i].smallest = *key
+		key, _ = iter.Last()
+		meta[i].largest = *key
 	}
 	return readers, meta, keys
 }

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -232,10 +232,11 @@ func BenchmarkMergingIterNext(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								if !m.Next() {
-									m.First()
+								key, _ := m.Next()
+								if key == nil {
+									key, _ = m.First()
 								}
-								_, _ = m.Key(), m.Value()
+								_ = key
 							}
 						})
 				}
@@ -261,10 +262,11 @@ func BenchmarkMergingIterPrev(b *testing.B) {
 
 							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
-								if !m.Prev() {
-									m.Last()
+								key, _ := m.Prev()
+								if key == nil {
+									key, _ = m.Last()
 								}
-								_, _ = m.Key(), m.Value()
+								_ = key
 							}
 						})
 				}

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -132,7 +132,7 @@ func check(f storage.File, comparer *db.Comparer, fp db.FilterPolicy) error {
 		}
 
 		// Check using SeekGE.
-		i := r.NewIter(nil /* lower */, nil /* upper */)
+		i := iterAdapter{r.NewIter(nil /* lower */, nil /* upper */)}
 		if !i.SeekGE([]byte(k)) || string(i.Key().UserKey) != k {
 			return fmt.Errorf("Find %q: key was not in the table", k)
 		}
@@ -178,7 +178,7 @@ func check(f storage.File, comparer *db.Comparer, fp db.FilterPolicy) error {
 		}
 
 		// Check using Find.
-		i := r.NewIter(nil /* lower */, nil /* upper */)
+		i := iterAdapter{r.NewIter(nil /* lower */, nil /* upper */)}
 		if i.SeekGE([]byte(s)) && s == string(i.Key().UserKey) {
 			return fmt.Errorf("Find %q: unexpectedly found key in the table", s)
 		}
@@ -204,7 +204,7 @@ func check(f storage.File, comparer *db.Comparer, fp db.FilterPolicy) error {
 		{0, "~"},
 	}
 	for _, ct := range countTests {
-		n, i := 0, r.NewIter(nil /* lower */, nil /* upper */)
+		n, i := 0, iterAdapter{r.NewIter(nil /* lower */, nil /* upper */)}
 		for valid := i.SeekGE([]byte(ct.start)); valid; valid = i.Next() {
 			n++
 		}
@@ -253,7 +253,7 @@ func check(f storage.File, comparer *db.Comparer, fp db.FilterPolicy) error {
 			upper = []byte(words[upperIdx])
 		}
 
-		i := r.NewIter(lower, upper)
+		i := iterAdapter{r.NewIter(lower, upper)}
 
 		{
 			// NB: the semantics of First are that it starts iteration from the
@@ -582,7 +582,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 				continue
 			}
 			r := NewReader(rf, 0, nil)
-			i := r.NewIter(nil /* lower */, nil /* upper */)
+			i := iterAdapter{r.NewIter(nil /* lower */, nil /* upper */)}
 			for valid := i.First(); valid; valid = i.Next() {
 				got++
 			}
@@ -614,7 +614,7 @@ func TestReaderGlobalSeqNum(t *testing.T) {
 	const globalSeqNum = 42
 	r.Properties.GlobalSeqNum = globalSeqNum
 
-	i := r.NewIter(nil /* lower */, nil /* upper */)
+	i := iterAdapter{r.NewIter(nil /* lower */, nil /* upper */)}
 	for valid := i.First(); valid; valid = i.Next() {
 		if globalSeqNum != i.Key().SeqNum() {
 			t.Fatalf("expected %d, but found %d", globalSeqNum, i.Key().SeqNum())

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -129,7 +129,7 @@ func TestWriter(t *testing.T) {
 				meta.SmallestSeqNum, meta.LargestSeqNum)
 
 		case "scan":
-			iter := r.NewIter(nil /* lower */, nil /* upper */)
+			iter := iterAdapter{r.NewIter(nil /* lower */, nil /* upper */)}
 			defer iter.Close()
 
 			var buf bytes.Buffer
@@ -146,8 +146,8 @@ func TestWriter(t *testing.T) {
 			defer iter.Close()
 
 			var buf bytes.Buffer
-			for valid := iter.First(); valid; valid = iter.Next() {
-				fmt.Fprintf(&buf, "%s:%s\n", iter.Key(), iter.Value())
+			for key, val := iter.First(); key != nil; key, val = iter.Next() {
+				fmt.Fprintf(&buf, "%s:%s\n", key, val)
 			}
 			return buf.String()
 

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -186,7 +186,7 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 				errc <- fmt.Errorf("i=%d, fileNum=%d: value: got %d bytes, want %d", i, fileNum, got, fileNum)
 				return
 			}
-			if iter.Next() {
+			if key, _ := iter.Next(); key != nil {
 				errc <- fmt.Errorf("i=%d, fileNum=%d: next.1: got true, want false", i, fileNum)
 				return
 			}


### PR DESCRIPTION
Change the `internalIterator` positioning methods (`SeekGE`, `SeekLT`,
`First`, `Last`, `Next`, and `Prev`) to return the key and value if the
iterator is pointing at a valid entry, and (nil, nil)
otherwise. Previously, these methods were returning a boolean indicating
whether the iterator was pointing at a valid entry. Returning the key
and value allows the caller to omit calling `Key()` and `Value()`
afterwards which is done in the majority of uses. This saves 2 indirect
function calls per positioning call.

Reduces the `pebble scan --rows=1000` average latency by ~10% on my
laptop.

Fixes #86