### PR TITLE
Pool allocate pebble.Iterator, sstable.Iterator, and arenaskl.Iterator

### DIFF
--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -19,6 +19,7 @@ package arenaskl
 
 import (
 	"encoding/binary"
+	"sync"
 
 	"github.com/petermattis/pebble/db"
 )
@@ -44,10 +45,19 @@ type Iterator struct {
 	upper []byte
 }
 
+var iterPool = sync.Pool{
+	New: func() interface{} {
+		return &Iterator{}
+	},
+}
+
 // Close resets the iterator.
 func (it *Iterator) Close() error {
 	it.list = nil
 	it.nd = nil
+	it.lower = nil
+	it.upper = nil
+	iterPool.Put(it)
 	return nil
 }
 

--- a/internal/arenaskl/skl.go
+++ b/internal/arenaskl/skl.go
@@ -307,8 +307,10 @@ func (s *Skiplist) addInternal(key db.InternalKey, value []byte, ins *Inserter) 
 // bound is not checked on {SeekGE,First} and upper bound is not check on
 // {SeekLT,Last}. The user is expected to perform that check. Note that it is
 // safe for an iterator to be copied by value.
-func (s *Skiplist) NewIter(lower, upper []byte) Iterator {
-	return Iterator{list: s, nd: s.head, lower: lower, upper: upper}
+func (s *Skiplist) NewIter(lower, upper []byte) *Iterator {
+	it := iterPool.Get().(*Iterator)
+	*it = Iterator{list: s, nd: s.head, lower: lower, upper: upper}
+	return it
 }
 
 func (s *Skiplist) newNode(

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -38,7 +38,7 @@ const arenaSize = 1 << 20
 // positioning methods (Seek*, First, Last, Next, Prev) to the old API which
 // returned a boolean corresponding to Valid. Only used by test code.
 type iterAdapter struct {
-	Iterator
+	*Iterator
 }
 
 func (i *iterAdapter) verify(key *db.InternalKey, val []byte) bool {

--- a/iterator.go
+++ b/iterator.go
@@ -47,6 +47,7 @@ type Iterator struct {
 	iterKey   *db.InternalKey
 	iterValue []byte
 	pos       iterPos
+	alloc     *iterAlloc
 }
 
 func (i *Iterator) findNextEntry() bool {
@@ -391,5 +392,10 @@ func (i *Iterator) Close() error {
 	if err := i.iter.Close(); err != nil && i.err != nil {
 		i.err = err
 	}
-	return i.err
+	err := i.err
+	if alloc := i.alloc; alloc != nil {
+		*i = Iterator{}
+		iterAllocPool.Put(alloc)
+	}
+	return err
 }

--- a/mem_table.go
+++ b/mem_table.go
@@ -168,8 +168,7 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 // return false). The iterator can be positioned via a call to SeekGE,
 // SeekLT, First or Last.
 func (m *memTable) newIter(o *db.IterOptions) internalIterator {
-	it := m.skl.NewIter(o.GetLowerBound(), o.GetUpperBound())
-	return &it
+	return m.skl.NewIter(o.GetLowerBound(), o.GetUpperBound())
 }
 
 func (m *memTable) newRangeDelIter(*db.IterOptions) internalIterator {

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -112,6 +112,7 @@ type blockIter struct {
 	ptr          unsafe.Pointer
 	data         []byte
 	key, val     []byte
+	keyBuf       [256]byte
 	ikey         db.InternalKey
 	cached       []blockEntry
 	cachedBuf    []byte
@@ -135,7 +136,7 @@ func (i *blockIter) init(cmp db.Compare, block block, globalSeqNum uint64) error
 	i.ptr = unsafe.Pointer(&block[0])
 	i.data = block
 	if i.key == nil {
-		i.key = make([]byte, 0, 256)
+		i.key = i.keyBuf[:0]
 	} else {
 		i.key = i.key[:0]
 	}


### PR DESCRIPTION
Pool allocating these iterator structures removes a significant source of allocations during short range scans, improving average latency of `pebble scan --rows=1` by ~15%.