### PR TITLE
Fix the trimming of the upper-bound for sstable iteration

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -94,9 +94,9 @@ func (i *Iterator) initBounds() {
 		}
 	}
 	i.blockUpper = i.upper
-	if i.blockUpper != nil && i.cmp(i.blockUpper, i.index.Key().UserKey) >= 0 {
-		// The upper-bound is greater than or equal to the index key which
-		// itself is greater than every key in the block. No need to check the
+	if i.blockUpper != nil && i.cmp(i.blockUpper, i.index.Key().UserKey) > 0 {
+		// The upper-bound is greater than the index key which itself is greater
+		// than or equal to every key in the block. No need to check the
 		// upper-bound again for this block.
 		i.blockUpper = nil
 	}


### PR DESCRIPTION
Previously we were trimming the upper-bound comparison of the
upper-bound was >= the index key. As the comments already note: The
separator (the index key) between blocks i and i+1 is a key that is >=
every key in block i and is < every key i block i+1.

The existing `TestReader*` tests caught this problem when stressed,
failing with the error:

  table_test.go:376: expected 777, but found 778.

This occurred whenever the upper-bound `king` was selected, as that is
both an index key and the entry in a block.