### PR TITLE
Implement WAL recycling

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -493,31 +493,29 @@ func (d *DB) flush1() error {
 		d.opts.EventListener.FlushEnd(info)
 	}
 
-	if err == errEmptyTable {
-		// The flush succeed, but produced an empty sstable. Mark all the
-		// memtables we flushed as flushed.
-		for i := 0; i < n; i++ {
-			close(d.mu.mem.queue[i].flushed())
-		}
-		d.mu.mem.queue = d.mu.mem.queue[n:]
-		d.updateReadStateLocked()
-		return nil
-	}
-
-	if err != nil {
+	if err != nil && err != errEmptyTable {
 		return err
 	}
 
-	err = d.mu.versions.logAndApply(&versionEdit{
+	// The flush succeeded or it produced an empty sstable. In either case we
+	// want to bump the log number.
+	ve := &versionEdit{
 		logNumber: d.mu.log.number,
-		newFiles: []newFileEntry{
-			{level: 0, meta: meta},
-		},
-	})
-	if _, ok := d.mu.compact.pendingOutputs[meta.fileNum]; !ok {
-		panic("pebble: expected pending output not present")
 	}
-	delete(d.mu.compact.pendingOutputs, meta.fileNum)
+	if err != errEmptyTable {
+		ve.newFiles = []newFileEntry{
+			{level: 0, meta: meta},
+		}
+	}
+
+	err = d.mu.versions.logAndApply(ve)
+	for i := range ve.newFiles {
+		f := &ve.newFiles[i]
+		if _, ok := d.mu.compact.pendingOutputs[f.meta.fileNum]; !ok {
+			panic("pebble: expected pending output not present")
+		}
+		delete(d.mu.compact.pendingOutputs, f.meta.fileNum)
+	}
 	if err != nil {
 		return err
 	}
@@ -970,10 +968,20 @@ func (d *DB) compactDiskTables(c *compaction) (ve *versionEdit, pendingOutputs [
 // d.mu must be held when calling this, but the mutex may be dropped and
 // re-acquired during the course of this method.
 func (d *DB) deleteObsoleteFiles(jobID int) {
+	// Only allow a single delete obsolete files job to run at a time.
+	for d.mu.cleaner.cleaning {
+		d.mu.cleaner.cond.Wait()
+	}
+	d.mu.cleaner.cleaning = true
+
 	// Release d.mu while doing I/O
 	// Note the unusual order: Unlock and then Lock.
 	d.mu.Unlock()
-	defer d.mu.Lock()
+	defer func() {
+		d.mu.Lock()
+		d.mu.cleaner.cleaning = false
+		d.mu.cleaner.cond.Signal()
+	}()
 
 	fs := d.opts.Storage
 	list, err := fs.List(d.dirname)
@@ -1008,6 +1016,9 @@ func (d *DB) deleteObsoleteFiles(jobID int) {
 		case fileTypeLog:
 			// TODO(peter): also look at prevLogNumber?
 			keep = fileNum >= logNumber
+			if !keep {
+				keep = d.logRecycler.add(fileNum)
+			}
 		case fileTypeManifest:
 			keep = fileNum >= manifestFileNumber
 		case fileTypeOptions:

--- a/db.go
+++ b/db.go
@@ -144,6 +144,8 @@ type DB struct {
 		val *readState
 	}
 
+	logRecycler logRecycler
+
 	// TODO(peter): describe exactly what this mutex protects. So far: every
 	// field in the struct.
 	mu struct {
@@ -179,6 +181,11 @@ type DB struct {
 			compacting     bool
 			pendingOutputs map[uint64]struct{}
 			manual         []*manualCompaction
+		}
+
+		cleaner struct {
+			cond     sync.Cond
+			cleaning bool
 		}
 
 		// The list of active snapshots.
@@ -744,17 +751,39 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			d.mu.mem.switching = true
 			d.mu.Unlock()
 
-			newLogFile, err = d.opts.Storage.Create(dbFilename(d.dirname, fileTypeLog, newLogNumber))
+			newLogName := dbFilename(d.dirname, fileTypeLog, newLogNumber)
+
+			// Try to use a recycled log file. Recycling log files is an important
+			// performance optimization as it is faster to sync a file that has
+			// already been written, than one which is being written for the first
+			// time. This is due to the need to sync file metadata when a file is
+			// being written for the first time. Note this is true even if file
+			// preallocation is performed (e.g. fallocate).
+			recycleLogNumber := d.logRecycler.peek()
+			if recycleLogNumber > 0 {
+				recycleLogName := dbFilename(d.dirname, fileTypeLog, recycleLogNumber)
+				err = d.opts.Storage.Rename(recycleLogName, newLogName)
+			}
+
+			if err == nil {
+				newLogFile, err = d.opts.Storage.Create(newLogName)
+			}
+
 			if err == nil {
 				err = d.mu.log.Close()
 				if err != nil {
 					newLogFile.Close()
+				} else {
+					newLogFile = storage.NewSyncingFile(newLogFile, storage.SyncingFileOptions{
+						BytesPerSync:    d.opts.BytesPerSync,
+						PreallocateSize: d.walPreallocateSize(),
+					})
 				}
 			}
-			newLogFile = storage.NewSyncingFile(newLogFile, storage.SyncingFileOptions{
-				BytesPerSync:    d.opts.BytesPerSync,
-				PreallocateSize: d.walPreallocateSize(),
-			})
+
+			if recycleLogNumber > 0 {
+				err = d.logRecycler.pop(recycleLogNumber)
+			}
 
 			d.mu.Lock()
 			d.mu.mem.switching = false
@@ -777,15 +806,7 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			d.mu.log.number = newLogNumber
 			d.mu.log.LogWriter = record.NewLogWriter(newLogFile, newLogNumber)
 		}
-		imm := d.mu.mem.mutable
-		if imm.empty() {
-			// If the mutable memtable is empty, then remove it from the queue. We'll
-			// reuse the memtable by leaving d.mu.mem.mutable non nil.
-			d.mu.mem.queue = d.mu.mem.queue[:len(d.mu.mem.queue)-1]
-			imm = nil
-		} else {
-			d.mu.mem.mutable = nil
-		}
+
 		var scheduleFlush bool
 		if b != nil && b.flushable != nil {
 			// The batch is too large to fit in the memtable so add it directly to
@@ -793,11 +814,16 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			d.mu.mem.queue = append(d.mu.mem.queue, b.flushable)
 			scheduleFlush = true
 		}
-		if d.mu.mem.mutable == nil {
-			// Create a new memtable if we are flushing the previous mutable
-			// memtable.
-			d.mu.mem.mutable = newMemTable(d.opts)
-		}
+
+		// Create a new memtable, scheduling the previous one for flushing. We do
+		// this even if the previous memtable was empty because the DB.Flush
+		// mechanism is dependent on being able to wait for the empty memtable to
+		// flush. We can't just mark the empty memtable as flushed here because we
+		// also have to wait for all previous immutable tables to
+		// flush. Additionally, the memtable is tied to particular WAL file and we
+		// want to go through the flush path in order to recycle that WAL file.
+		imm := d.mu.mem.mutable
+		d.mu.mem.mutable = newMemTable(d.opts)
 		d.mu.mem.queue = append(d.mu.mem.queue, d.mu.mem.mutable)
 		d.updateReadStateLocked()
 		if (imm != nil && imm.unref()) || scheduleFlush {

--- a/db/event.go
+++ b/db/event.go
@@ -79,6 +79,28 @@ type TableIngestInfo struct {
 	Err          error
 }
 
+// WALCreateInfo contains info about a WAL creation event.
+type WALCreateInfo struct {
+	// JobID is the ID of the job the caused the WAL to be created.
+	JobID int
+	Path  string
+	// The file number of the new WAL.
+	FileNum uint64
+	// The file number of a previous WAL which was recycled to create this
+	// one. Zero if recycling did not take place.
+	RecycledFileNum uint64
+	Err             error
+}
+
+// WALDeleteInfo contains the info for a WAL deletion event.
+type WALDeleteInfo struct {
+	// JobID is the ID of the job the caused the WAL to be deleted.
+	JobID   int
+	Path    string
+	FileNum uint64
+	Err     error
+}
+
 // EventListener contains a set of functions that will be invoked when various
 // significant DB events occur. Note that the functions should not run for an
 // excessive amount of time as they are invokved synchronously by the DB and
@@ -111,4 +133,10 @@ type EventListener struct {
 	// TableIngested is invoked after an externally created table has been
 	// ingested via a call to DB.Ingest().
 	TableIngested func(TableIngestInfo)
+
+	// WALCreated is invoked after a WAL has been created.
+	WALCreated func(WALCreateInfo)
+
+	// WALDeleted is invoked after a WAL has been delete.
+	WALDeleted func(WALDeleteInfo)
 }

--- a/db_test.go
+++ b/db_test.go
@@ -598,3 +598,19 @@ func TestCacheEvict(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestFlushEmpty(t *testing.T) {
+	d, err := Open("", &db.Options{
+		Storage: storage.NewMem(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Flushing an empty memtable should not fail.
+	if err := d.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -57,6 +57,13 @@ func TestEventListener(t *testing.T) {
 			TableIngested: func(info db.TableIngestInfo) {
 				fmt.Fprintf(&buf, "#%d: table ingested\n", info.JobID)
 			},
+			WALCreated: func(info db.WALCreateInfo) {
+				fmt.Fprintf(&buf, "#%d: WAL created: %d recycled=%d\n",
+					info.JobID, info.FileNum, info.RecycledFileNum)
+			},
+			WALDeleted: func(info db.WALDeleteInfo) {
+				fmt.Fprintf(&buf, "#%d: WAL deleted: %d\n", info.JobID, info.FileNum)
+			},
 		},
 	})
 	if err != nil {
@@ -82,16 +89,18 @@ func TestEventListener(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := `#2: flush begin
-#2: flush end: 6
-#3: compaction begin: L0 -> L1
-#3: compaction end: L0 -> L1
-#4: flush begin
-#4: flush end: 8
-#5: compaction begin: L0 -> L1
-#5: compaction end: L0 -> L1
-#5: table deleted: 6
-#5: table deleted: 8
+	expected := `#2: WAL created: 5 recycled=0
+#3: flush begin
+#3: flush end: 6
+#4: compaction begin: L0 -> L1
+#4: compaction end: L0 -> L1
+#5: WAL created: 7 recycled=3
+#6: flush begin
+#6: flush end: 8
+#7: compaction begin: L0 -> L1
+#7: compaction end: L0 -> L1
+#7: table deleted: 6
+#7: table deleted: 8
 `
 	if v := buf.String(); expected != v {
 		t.Fatalf("expected\n%s\nbut found\n%s", expected, v)

--- a/log_recycler.go
+++ b/log_recycler.go
@@ -1,0 +1,73 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"fmt"
+	"sync"
+)
+
+type logRecycler struct {
+	limit int
+	mu    struct {
+		sync.Mutex
+		logNums   []uint64
+		maxLogNum uint64
+	}
+}
+
+// add attempts to recycle the log file specified by logNum. Returns true if
+// the log file should not be deleted (i.e. the log is being recycled), and
+// false otherwise.
+func (r *logRecycler) add(logNum uint64) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if logNum <= r.mu.maxLogNum {
+		// The log file number was already considered for recycling. Don't consider
+		// it again. This avoids a race between adding the same log file for
+		// recycling multiple times, and removing the log file for actual
+		// reuse. Note that we return true because the log was already considered
+		// for recycling and either it was deleted on the previous attempt (which
+		// means we shouldn't get here) or it was recycled and thus the file
+		// shouldn't be deleted.
+		return true
+	}
+	r.mu.maxLogNum = logNum
+	if len(r.mu.logNums) >= r.limit {
+		return false
+	}
+	r.mu.logNums = append(r.mu.logNums, logNum)
+	return true
+}
+
+// peek returns the log number at the head of the recycling queue, or zero if
+// the queue is empty.
+func (r *logRecycler) peek() uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.mu.logNums) == 0 {
+		return 0
+	}
+	return r.mu.logNums[0]
+}
+
+// pop removes the log number at the head of the recycling queue, enforcing
+// that it matches the specifed logNum. An error is returned of the recycling
+// queue is empty or the head log number does not match the specified one.
+func (r *logRecycler) pop(logNum uint64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.mu.logNums) == 0 {
+		return fmt.Errorf("pebble: log recycler empty")
+	}
+	if r.mu.logNums[0] != logNum {
+		return fmt.Errorf("pebble: log recycler invalid %d vs %d", logNum, r.mu.logNums)
+	}
+	r.mu.logNums = r.mu.logNums[1:]
+	return nil
+}

--- a/log_recycler_test.go
+++ b/log_recycler_test.go
@@ -1,0 +1,112 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"testing"
+
+	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func (r *logRecycler) logNums() []uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]uint64(nil), r.mu.logNums...)
+}
+
+func (r *logRecycler) maxLogNum() uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.mu.maxLogNum
+}
+
+func TestLogRecycler(t *testing.T) {
+	r := logRecycler{limit: 3}
+
+	// Logs are recycled up to the limit.
+	require.True(t, r.add(1))
+	require.EqualValues(t, []uint64{1}, r.logNums())
+	require.EqualValues(t, 1, r.maxLogNum())
+	require.EqualValues(t, 1, r.peek())
+	require.True(t, r.add(2))
+	require.EqualValues(t, []uint64{1, 2}, r.logNums())
+	require.EqualValues(t, 2, r.maxLogNum())
+	require.True(t, r.add(3))
+	require.EqualValues(t, []uint64{1, 2, 3}, r.logNums())
+	require.EqualValues(t, 3, r.maxLogNum())
+
+	// Trying to add a file past the limit fails.
+	require.False(t, r.add(4))
+	require.EqualValues(t, []uint64{1, 2, 3}, r.logNums())
+	require.EqualValues(t, 4, r.maxLogNum())
+
+	// Trying to add a previously recycled file returns success, but the internal
+	// state is unchanged.
+	require.True(t, r.add(1))
+	require.EqualValues(t, []uint64{1, 2, 3}, r.logNums())
+	require.EqualValues(t, 4, r.maxLogNum())
+
+	// An error is returned if we try to pop an element other than the first.
+	require.Regexp(t, `invalid 2 vs \[1 2 3\]`, r.pop(2))
+
+	require.NoError(t, r.pop(1))
+	require.EqualValues(t, []uint64{2, 3}, r.logNums())
+
+	// Log number 4 was already considered, so it won't be recycled.
+	require.True(t, r.add(4))
+	require.EqualValues(t, []uint64{2, 3}, r.logNums())
+
+	require.True(t, r.add(5))
+	require.EqualValues(t, []uint64{2, 3, 5}, r.logNums())
+	require.EqualValues(t, 5, r.maxLogNum())
+
+	require.NoError(t, r.pop(2))
+	require.EqualValues(t, []uint64{3, 5}, r.logNums())
+	require.NoError(t, r.pop(3))
+	require.EqualValues(t, []uint64{5}, r.logNums())
+	require.NoError(t, r.pop(5))
+	require.EqualValues(t, []uint64(nil), r.logNums())
+
+	require.Regexp(t, `empty`, r.pop(6))
+}
+
+func TestRecycleLogs(t *testing.T) {
+	d, err := Open("", &db.Options{
+		Storage: storage.NewMem(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logNum := func() uint64 {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		return d.mu.log.number
+	}
+
+	// Flush the memtable a few times, forcing rotation of the WAL. We should see
+	// the recycled logs change as expected.
+	require.EqualValues(t, []uint64(nil), d.logRecycler.logNums())
+	curLog := logNum()
+
+	if err := d.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	require.EqualValues(t, []uint64{curLog}, d.logRecycler.logNums())
+	curLog = logNum()
+
+	if err := d.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	require.EqualValues(t, []uint64{curLog}, d.logRecycler.logNums())
+
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/open.go
+++ b/open.go
@@ -62,6 +62,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 		equal:          opts.Comparer.Equal,
 		merge:          opts.Merger.Merge,
 		abbreviatedKey: opts.Comparer.AbbreviatedKey,
+		logRecycler:    logRecycler{limit: opts.MemTableStopWritesThreshold + 1},
 	}
 	if d.equal == nil {
 		d.equal = bytes.Equal
@@ -83,6 +84,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 	d.mu.mem.cond.L = &d.mu.Mutex
 	d.mu.mem.mutable = newMemTable(d.opts)
 	d.mu.mem.queue = append(d.mu.mem.queue, d.mu.mem.mutable)
+	d.mu.cleaner.cond.L = &d.mu.Mutex
 	d.mu.compact.cond.L = &d.mu.Mutex
 	d.mu.compact.pendingOutputs = make(map[uint64]struct{})
 	d.mu.snapshots.init()

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -84,7 +84,7 @@ var Default Storage = defaultFS{}
 type defaultFS struct{}
 
 func (defaultFS) Create(name string) (File, error) {
-	return os.Create(name)
+	return os.OpenFile(name, os.O_RDWR|os.O_CREATE, 0666)
 }
 
 func (defaultFS) Link(oldname, newname string) error {


### PR DESCRIPTION
WAL recycling is an important performance optimization as it is faster
to sync a file that has already been written, than one which is being
written for the first time. This is due to the need to sync file
metadata when a file is being written for the first time. Note this is
true even if file preallocation is performed (e.g. fallocate).

Fixes #41