### PR TITLE
Rework DB.deleteObsoleteFiles

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -846,6 +846,8 @@ type flushableBatch struct {
 	tombstones []rangedel.Tombstone
 
 	flushedCh chan struct{}
+
+	logNum uint64
 }
 
 var _ flushable = (*flushableBatch)(nil)
@@ -970,6 +972,10 @@ func (b *flushableBatch) flushed() chan struct{} {
 
 func (b *flushableBatch) readyForFlush() bool {
 	return true
+}
+
+func (b *flushableBatch) logNumber() uint64 {
+	return b.logNum
 }
 
 // Note: flushableBatchIter mirrors the implementation of batchIter. Keep the

--- a/log_recycler_test.go
+++ b/log_recycler_test.go
@@ -85,7 +85,7 @@ func TestRecycleLogs(t *testing.T) {
 	logNum := func() uint64 {
 		d.mu.Lock()
 		defer d.mu.Unlock()
-		return d.mu.log.number
+		return d.mu.log.queue[len(d.mu.log.queue)-1]
 	}
 
 	// Flush the memtable a few times, forcing rotation of the WAL. We should see

--- a/mem_table.go
+++ b/mem_table.go
@@ -53,6 +53,7 @@ type memTable struct {
 	refs        int32
 	flushedCh   chan struct{}
 	tombstones  rangeTombstoneCache
+	logNum      uint64
 }
 
 // newMemTable returns a new MemTable.
@@ -92,6 +93,10 @@ func (m *memTable) flushed() chan struct{} {
 
 func (m *memTable) readyForFlush() bool {
 	return atomic.LoadInt32(&m.refs) == 0
+}
+
+func (m *memTable) logNumber() uint64 {
+	return m.logNum
 }
 
 // Get gets the value for the given key. It returns ErrNotFound if the DB does

--- a/version_test.go
+++ b/version_test.go
@@ -257,7 +257,7 @@ func TestVersionUnref(t *testing.T) {
 		mu: &sync.Mutex{},
 	}
 	list.init()
-	v := &version{}
+	v := &version{vs: &versionSet{}}
 	v.ref()
 	list.pushBack(v)
 	v.unref()


### PR DESCRIPTION
Previously, `deleteObsoleteFiles` would perform a directory listing to
find obsolete files. The directory listing is fairly expensive,
especially as the number of tables gets large. Switch to an approach
that is similar to RocksDB, where in steady state we keep track of
obsolete logs and tables as memtables are flushed and versions are
unreferenced.

Fix a bug in handling of `versionSet.logNumber`. Previously that field
was being bumped to the most recent log file number any time a flush was
performed, but we can only bump it to the most recent log file that
hasn't been flushed.

Fixes #96