### PR TITLE
Add support for capping the size of the MANIFEST

### DIFF
--- a/db/options.go
+++ b/db/options.go
@@ -243,6 +243,11 @@ type Options struct {
 	// The default logger uses the Go standard library log package.
 	Logger Logger
 
+	// MaxManifestFileSize is the maximum size the MANIFEST file is allowed to
+	// become. When the MANIFEST exceeds this size it is rolled over and a new
+	// MANIFEST is created.
+	MaxManifestFileSize int64
+
 	// MaxOpenFiles is a soft limit on the number of open files that can be
 	// used by the DB.
 	//
@@ -322,6 +327,9 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Logger == nil {
 		o.Logger = defaultLogger{}
 	}
+	if o.MaxManifestFileSize == 0 {
+		o.MaxManifestFileSize = 128 << 20 // 128 MB
+	}
 	if o.MaxOpenFiles == 0 {
 		o.MaxOpenFiles = 1000
 	}
@@ -368,6 +376,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  l0_slowdown_writes_threshold=%d\n", o.L0SlowdownWritesThreshold)
 	fmt.Fprintf(&buf, "  l0_stop_writes_threshold=%d\n", o.L0StopWritesThreshold)
 	fmt.Fprintf(&buf, "  l1_max_bytes=%d\n", o.L1MaxBytes)
+	fmt.Fprintf(&buf, "  max_manifest_file_size=%d\n", o.MaxManifestFileSize)
 	fmt.Fprintf(&buf, "  max_open_files=%d\n", o.MaxOpenFiles)
 	fmt.Fprintf(&buf, "  mem_table_size=%d\n", o.MemTableSize)
 	fmt.Fprintf(&buf, "  mem_table_stop_writes_threshold=%d\n", o.MemTableStopWritesThreshold)

--- a/db/options_test.go
+++ b/db/options_test.go
@@ -48,6 +48,7 @@ func TestOptionsString(t *testing.T) {
   l0_slowdown_writes_threshold=8
   l0_stop_writes_threshold=12
   l1_max_bytes=67108864
+  max_manifest_file_size=134217728
   max_open_files=1000
   mem_table_size=4194304
   mem_table_stop_writes_threshold=2

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -94,7 +94,7 @@ func TestEventListener(t *testing.T) {
 #3: flush end: 6
 #4: compaction begin: L0 -> L1
 #4: compaction end: L0 -> L1
-#5: WAL created: 7 recycled=3
+#5: WAL created: 7 recycled=2
 #6: flush begin
 #6: flush end: 8
 #7: compaction begin: L0 -> L1

--- a/filenames.go
+++ b/filenames.go
@@ -95,6 +95,9 @@ func setCurrentFile(dirname string, fs vfs.FS, fileNum uint64) error {
 	if _, err := fmt.Fprintf(f, "MANIFEST-%06d\n", fileNum); err != nil {
 		return err
 	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
 	if err := f.Close(); err != nil {
 		return err
 	}

--- a/internal/record/record.go
+++ b/internal/record/record.go
@@ -543,6 +543,11 @@ func (w *Writer) WriteRecord(p []byte) (int64, error) {
 	return offset, w.err
 }
 
+// Size returns the current size of the file.
+func (w *Writer) Size() int64 {
+	return w.blockNumber*blockSize + int64(w.j)
+}
+
 // LastRecordOffset returns the offset in the underlying io.Writer of the last
 // record so far - the one created by the most recent Next call. It is the
 // offset of the first chunk header, suitable to pass to Reader.SeekRecord.

--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -818,6 +818,27 @@ func TestInvalidLogNum(t *testing.T) {
 	}
 }
 
+func TestSize(t *testing.T) {
+	var buf bytes.Buffer
+	zeroes := make([]byte, 8<<10)
+	w := NewWriter(&buf)
+	for i := 0; i < 100; i++ {
+		n := rand.Intn(len(zeroes))
+		if _, err := w.WriteRecord(zeroes[:n]); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Flush(); err != nil {
+			t.Fatal(err)
+		}
+		if buf.Len() != int(w.Size()) {
+			t.Fatalf("expected %d, but found %d", buf.Len(), w.Size())
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func BenchmarkRecordWrite(b *testing.B) {
 	for _, size := range []int{8, 16, 32, 64, 128} {
 		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {

--- a/open_test.go
+++ b/open_test.go
@@ -67,9 +67,9 @@ func TestNewDBFilenames(t *testing.T) {
 	sort.Strings(got)
 	// TODO(peter): should there be a LOCK file here?
 	want := []string{
-		"000003.log",
+		"000002.log",
 		"CURRENT",
-		"MANIFEST-000002",
+		"MANIFEST-000003",
 		"OPTIONS-000004",
 	}
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
The MANIFEST is a log (in `internal/record` format) containing a
sequence of version edits. A version edit is created whenever a flush or
compaction occurs. The actual current version is obtained by replaying
the log at startup (the current version is also maintained in memory, of
course). In order to avoid the MANIFEST growing excessively large, it is
"rolled" whenever its size exceeds
`Options.MaxManifestFileSize` (default 128 MB). The new MANIFEST is
completely self-contained with the version entry being a snapshot of the
entire state (essentially a delta from the empty state).

Re-jiggered the way the MANIFEST is initially created which resulted in
slightly different file numbering at database creation: the first log
now gets file number 2, and the manifest file number 3.

Fixes #42