### PR TITLE
Add basic support for "log data"

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -13,7 +13,9 @@ import (
 
 var (
 	concurrency int
+	disableWAL  bool
 	duration    time.Duration
+	walOnly     bool
 	wipe        bool
 )
 
@@ -33,10 +35,14 @@ func main() {
 	for _, cmd := range []*cobra.Command{scanCmd, syncCmd} {
 		cmd.Flags().IntVarP(
 			&concurrency, "concurrency", "c", 1, "number of concurrent workers")
+		cmd.Flags().BoolVar(
+			&disableWAL, "disable-wal", false, "disable the WAL (voiding persistence guarantees)")
 		cmd.Flags().DurationVarP(
 			&duration, "duration", "d", 10*time.Second, "the duration to run (0, run forever)")
 		cmd.Flags().BoolVarP(
 			&wipe, "wipe", "w", false, "wipe the database before starting")
+		cmd.Flags().BoolVar(
+			&walOnly, "wal-only", false, "write data only to the WAL")
 	}
 
 	scanCmd.Flags().BoolVarP(

--- a/cmd/pebble/scan.go
+++ b/cmd/pebble/scan.go
@@ -39,6 +39,11 @@ func runScan(cmd *cobra.Command, args []string) {
 		lastElapsed time.Duration
 	)
 
+	opts := db.Sync
+	if disableWAL {
+		opts = db.NoSync
+	}
+
 	runTest(args[0], test{
 		init: func(d *pebble.DB, wg *sync.WaitGroup) {
 			const count = 100000
@@ -63,7 +68,7 @@ func runScan(cmd *cobra.Command, args []string) {
 						log.Fatal(err)
 					}
 				}
-				if err := b.Commit(db.Sync); err != nil {
+				if err := b.Commit(opts); err != nil {
 					log.Fatal(err)
 				}
 			}

--- a/cmd/pebble/test.go
+++ b/cmd/pebble/test.go
@@ -193,6 +193,7 @@ func runTest(dir string, t test) {
 	db, err := pebble.Open(dir, &db.Options{
 		Cache:                       cache.New(1 << 30),
 		Comparer:                    mvccComparer,
+		DisableWAL:                  disableWAL,
 		MemTableSize:                64 << 20,
 		MemTableStopWritesThreshold: 4,
 		L0CompactionThreshold:       2,

--- a/db/internal.go
+++ b/db/internal.go
@@ -18,10 +18,10 @@ type InternalKeyKind uint8
 
 // These constants are part of the file format, and should not be changed.
 const (
-	InternalKeyKindDelete InternalKeyKind = 0
-	InternalKeyKindSet                    = 1
-	InternalKeyKindMerge                  = 2
-	// InternalKeyKindLogData                                  = 3
+	InternalKeyKindDelete  InternalKeyKind = 0
+	InternalKeyKindSet                     = 1
+	InternalKeyKindMerge                   = 2
+	InternalKeyKindLogData                 = 3
 	// InternalKeyKindColumnFamilyDeletion                     = 4
 	// InternalKeyKindColumnFamilyValue                        = 5
 	// InternalKeyKindColumnFamilyMerge                        = 6
@@ -70,6 +70,7 @@ var internalKeyKindNames = []string{
 	InternalKeyKindDelete:      "DEL",
 	InternalKeyKindSet:         "SET",
 	InternalKeyKindMerge:       "MERGE",
+	InternalKeyKindLogData:     "LOGDATA",
 	InternalKeyKindRangeDelete: "RANGEDEL",
 	InternalKeyKindMax:         "MAX",
 	InternalKeyKindInvalid:     "INVALID",

--- a/mem_table.go
+++ b/mem_table.go
@@ -145,10 +145,12 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 		}
 		var err error
 		ikey := db.MakeInternalKey(ukey, seqNum, kind)
-		if kind == db.InternalKeyKindRangeDelete {
+		switch kind {
+		case db.InternalKeyKindRangeDelete:
 			err = m.rangeDelSkl.Add(ikey, value)
 			tombstoneCount++
-		} else {
+		case db.InternalKeyKindLogData:
+		default:
 			err = ins.Add(&m.skl, ikey, value)
 		}
 		if err != nil {


### PR DESCRIPTION
Log data is a batch entry that gets written to the WAL, but is not
added to the database state. RocksDB uses log data to implement 2PC. It
is also useful for performance testing the WAL in isolation from other
the other parts of the system.

Add `--disable-wal` and `--wal-only` flags to the `pebble` tool.