### PR TITLE
Optimize applying version edits

### DIFF
--- a/version_edit.go
+++ b/version_edit.go
@@ -401,6 +401,15 @@ func (b *bulkVersionEdit) apply(
 ) (*version, error) {
 	v := new(version)
 	for level := range v.files {
+		if len(b.added[level]) == 0 && len(b.deleted[level]) == 0 {
+			// There are no edits on this level.
+			if base == nil {
+				continue
+			}
+			v.files[level] = base.files[level]
+			continue
+		}
+
 		combined := [2][]fileMetadata{
 			nil,
 			b.added[level],


### PR DESCRIPTION
Replace O(n) work with O(1) work on levels which do not have any
edits. In steady state operation, an edit will only operate on 2 levels
of the LSM (which usually has 7 levels).