### PR TITLE
Fix replaying of the WAL when preallocation is active

### DIFF
--- a/internal/record/record_test.go
+++ b/internal/record/record_test.go
@@ -812,8 +812,8 @@ func TestInvalidLogNum(t *testing.T) {
 
 	{
 		r := NewReader(bytes.NewReader(buf.Bytes()), 2)
-		if _, err := r.Next(); err != ErrInvalidLogNum {
-			t.Fatalf("expected %s, but found %s\n", ErrInvalidLogNum, err)
+		if _, err := r.Next(); err != io.EOF {
+			t.Fatalf("expected %s, but found %s\n", io.EOF, err)
 		}
 	}
 }


### PR DESCRIPTION
Previously, replaying of a preallocated WAL would encounter the error:
`pebble/record: block appears to be zeroed`. This occurred because the
tail of the log was all zeroes. Now we treat the zeroed records error
similar to EOF.