### PR TITLE
Add ycsb benchmark

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"math"
 	"os"
 	"time"
 
@@ -30,9 +31,10 @@ func main() {
 	rootCmd.AddCommand(
 		scanCmd,
 		syncCmd,
+		ycsbCmd,
 	)
 
-	for _, cmd := range []*cobra.Command{scanCmd, syncCmd} {
+	for _, cmd := range []*cobra.Command{scanCmd, syncCmd, ycsbCmd} {
 		cmd.Flags().IntVarP(
 			&concurrency, "concurrency", "c", 1, "number of concurrent workers")
 		cmd.Flags().BoolVar(
@@ -51,6 +53,37 @@ func main() {
 		&scanRows, "rows", scanRows, "number of rows to scan in each operation")
 	scanCmd.Flags().IntVar(
 		&scanValueSize, "value", scanValueSize, "size of values to scan")
+
+	ycsbCmd.Flags().IntVar(
+		&ycsbConfig.batch, "batch", 1,
+		"Number of keys to read/insert in each operation")
+	ycsbCmd.Flags().Int64Var(
+		&ycsbConfig.cycleLength, "cycle-length", math.MaxInt64,
+		"Number of keys repeatedly accessed by each writer")
+	ycsbCmd.Flags().IntVar(
+		&ycsbConfig.minBlockBytes, "min-block-bytes", 1,
+		"Minimum amount of raw data written with each insertion")
+	ycsbCmd.Flags().IntVar(
+		&ycsbConfig.maxBlockBytes, "max-block-bytes", 1,
+		"Maximum amount of raw data written with each insertion")
+	ycsbCmd.Flags().Uint64VarP(
+		&ycsbConfig.numOps, "num-ops", "n", 0, "maximum number of operations (0 means unlimited)")
+	ycsbCmd.Flags().IntVar(
+		&ycsbConfig.readPercent, "read-percent", 0,
+		"Percent (0-100) of operations that are reads of existing keys")
+	ycsbCmd.Flags().Int64Var(
+		&ycsbConfig.seed, "seed", 1, "Key hash seed")
+	ycsbCmd.Flags().BoolVar(
+		&ycsbConfig.sequential, "sequential", false,
+		"Pick keys sequentially instead of uniformly at random")
+	ycsbCmd.Flags().StringVar(
+		&ycsbConfig.writeSeq, "write-seq", "",
+		"Initial write sequence value. Can be used to use the data produced by a previous run. "+
+			"It has to be of the form (R|S)<number>, where S implies that it was taken from a "+
+			"previous --sequential run and R implies a previous random run.")
+	ycsbCmd.Flags().Float64Var(
+		&ycsbConfig.targetCompressionRatio, "target-compression-ratio", 1.0,
+		"Target compression ratio for data blocks. Must be >= 1.0")
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra has already printed the error message.

--- a/cmd/pebble/random.go
+++ b/cmd/pebble/random.go
@@ -1,0 +1,144 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package main
+
+import (
+	"crypto/sha1"
+	"encoding/binary"
+	"hash"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/exp/rand"
+)
+
+func randomBlock(
+	r *rand.Rand, minBlockBytes, maxBlockBytes int, targetCompressionRatio float64,
+) []byte {
+	size := r.Intn(maxBlockBytes-minBlockBytes+1) + minBlockBytes
+	uniqueSize := int(float64(size) / targetCompressionRatio)
+	if uniqueSize < 1 {
+		uniqueSize = 1
+	}
+	data := make([]byte, size)
+	offset := 0
+	for offset+8 <= uniqueSize {
+		binary.LittleEndian.PutUint64(data[offset:], r.Uint64())
+		offset += 8
+	}
+	word := r.Uint64()
+	for offset < uniqueSize {
+		data[offset] = byte(word)
+		word >>= 8
+		offset++
+	}
+	for offset < size {
+		data[offset] = data[offset-uniqueSize]
+		offset++
+	}
+	return data
+}
+
+type sequence struct {
+	val         int64
+	cycleLength int64
+	seed        int64
+}
+
+func (s *sequence) write() int64 {
+	return (atomic.AddInt64(&s.val, 1) - 1) % s.cycleLength
+}
+
+// read returns the last key index that has been written. Note that the returned
+// index might not actually have been written yet, so a read operation cannot
+// require that the key is present.
+func (s *sequence) read() int64 {
+	return atomic.LoadInt64(&s.val) % s.cycleLength
+}
+
+// keyGenerator generates read and write keys. Read keys may not yet exist and
+// write keys may already exist.
+type keyGenerator interface {
+	writeKey() int64
+	readKey() int64
+	rand() *rand.Rand
+	sequence() int64
+}
+
+type hashGenerator struct {
+	seq    *sequence
+	random *rand.Rand
+	hasher hash.Hash
+	buf    [sha1.Size]byte
+}
+
+func newHashGenerator(seq *sequence) *hashGenerator {
+	return &hashGenerator{
+		seq:    seq,
+		random: rand.New(rand.NewSource(uint64(time.Now().UnixNano()))),
+		hasher: sha1.New(),
+	}
+}
+
+func (g *hashGenerator) hash(v int64) int64 {
+	binary.BigEndian.PutUint64(g.buf[:8], uint64(v))
+	binary.BigEndian.PutUint64(g.buf[8:16], uint64(g.seq.seed))
+	g.hasher.Reset()
+	_, _ = g.hasher.Write(g.buf[:16])
+	g.hasher.Sum(g.buf[:0])
+	return int64(binary.BigEndian.Uint64(g.buf[:8]))
+}
+
+func (g *hashGenerator) writeKey() int64 {
+	return g.hash(g.seq.write())
+}
+
+func (g *hashGenerator) readKey() int64 {
+	v := g.seq.read()
+	if v == 0 {
+		return 0
+	}
+	return g.hash(g.random.Int63n(v))
+}
+
+func (g *hashGenerator) rand() *rand.Rand {
+	return g.random
+}
+
+func (g *hashGenerator) sequence() int64 {
+	return atomic.LoadInt64(&g.seq.val)
+}
+
+type sequentialGenerator struct {
+	seq    *sequence
+	random *rand.Rand
+}
+
+func newSequentialGenerator(seq *sequence) *sequentialGenerator {
+	return &sequentialGenerator{
+		seq:    seq,
+		random: rand.New(rand.NewSource(uint64(time.Now().UnixNano()))),
+	}
+}
+
+func (g *sequentialGenerator) writeKey() int64 {
+	return g.seq.write()
+}
+
+func (g *sequentialGenerator) readKey() int64 {
+	v := g.seq.read()
+	if v == 0 {
+		return 0
+	}
+	return g.random.Int63n(v)
+}
+
+func (g *sequentialGenerator) rand() *rand.Rand {
+	return g.random
+}
+
+func (g *sequentialGenerator) sequence() int64 {
+	return atomic.LoadInt64(&g.seq.val)
+}

--- a/cmd/pebble/sync.go
+++ b/cmd/pebble/sync.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"encoding/binary"
 	"fmt"
 	"log"
 	"sync"
@@ -46,28 +45,12 @@ func runSync(cmd *cobra.Command, args []string) {
 					rand := rand.New(rand.NewSource(uint64(time.Now().UnixNano())))
 					var raw []byte
 					var buf []byte
-
-					randBlock := func(min, max int) []byte {
-						data := make([]byte, rand.Intn(max-min)+min)
-						tmp := data
-						for len(tmp) >= 8 {
-							binary.LittleEndian.PutUint64(tmp, rand.Uint64())
-							tmp = tmp[8:]
-						}
-						r := rand.Uint64()
-						for i := 0; i < len(tmp); i++ {
-							tmp[i] = byte(r)
-							r >>= 8
-						}
-						return data
-					}
-
 					for {
 						start := time.Now()
 						b := d.NewBatch()
 						var n uint64
 						for j := 0; j < 5; j++ {
-							block := randBlock(60, 80)
+							block := randomBlock(rand, 60, 80, 1.0)
 
 							if walOnly {
 								if err := b.LogData(block, nil); err != nil {

--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -1,0 +1,196 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/petermattis/pebble"
+	pebble_db "github.com/petermattis/pebble/db"
+	"github.com/spf13/cobra"
+)
+
+var ycsbConfig struct {
+	batch                  int
+	cycleLength            int64
+	minBlockBytes          int
+	maxBlockBytes          int
+	numOps                 uint64
+	readPercent            int
+	seed                   int64
+	sequential             bool
+	writeSeq               string
+	targetCompressionRatio float64
+}
+
+var ycsbCmd = &cobra.Command{
+	Use:   "ycsb <dir>",
+	Short: "Run customizable YCSB-like workload. Does not yet offer the standard workloads.",
+	Long:  "",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runYcsb,
+}
+
+func runYcsb(cmd *cobra.Command, args []string) error {
+	// benchmark-wide state
+	var (
+		reg             *histogramRegistry
+		seq             sequence
+		numSuccess      uint64
+		numEmptyResults int64
+	)
+
+	if ycsbConfig.maxBlockBytes < ycsbConfig.minBlockBytes {
+		return fmt.Errorf("Value of 'max-block-bytes' (%d) must be greater than or equal to value of 'min-block-bytes' (%d)",
+			ycsbConfig.maxBlockBytes, ycsbConfig.minBlockBytes)
+	}
+	if ycsbConfig.readPercent > 100 || ycsbConfig.readPercent < 0 {
+		return fmt.Errorf("'read-percent' must be in range [0, 100]")
+	}
+	if ycsbConfig.targetCompressionRatio < 1.0 || math.IsNaN(ycsbConfig.targetCompressionRatio) {
+		return fmt.Errorf("'target-compression-ratio' must be a number >= 1.0")
+	}
+	if ycsbConfig.writeSeq != "" {
+		first := ycsbConfig.writeSeq[0]
+		if len(ycsbConfig.writeSeq) < 2 || (first != 'R' && first != 'S') {
+			return fmt.Errorf("--write-seq has to be of the form '(R|S)<num>'")
+		}
+		rest := ycsbConfig.writeSeq[1:]
+		var err error
+		seq.val, err = strconv.ParseInt(rest, 10, 64)
+		if err != nil {
+			return fmt.Errorf("--write-seq has to be of the form '(R|S)<num>'")
+		}
+		if first == 'R' && ycsbConfig.sequential {
+			return fmt.Errorf("--sequential incompatible with a Random --write-seq")
+		}
+		if first == 'S' && !ycsbConfig.sequential {
+			return fmt.Errorf("--sequential=false incompatible with a Sequential --write-seq")
+		}
+	}
+
+	seq.cycleLength = ycsbConfig.cycleLength
+	seq.seed = ycsbConfig.seed
+	reg = newHistogramRegistry()
+	runTest(args[0], test{
+		init: func(db *pebble.DB, wg *sync.WaitGroup) {
+			wg.Add(concurrency)
+			for i := 0; i < concurrency; i++ {
+				// per-worker goroutine state
+				var gen keyGenerator
+				if ycsbConfig.sequential {
+					gen = newSequentialGenerator(&seq)
+				} else {
+					gen = newHashGenerator(&seq)
+				}
+				readLatency := reg.Register("read")
+				writeLatency := reg.Register("write")
+
+				go func() {
+					defer wg.Done()
+					var raw, buf []byte
+					for {
+						if gen.rand().Intn(100) < ycsbConfig.readPercent {
+							num := gen.readKey()
+							raw = encodeUint64Ascending(raw[:0], uint64(num))
+							key := mvccEncode(buf[:0], raw, 0, 0)
+							start := time.Now()
+							iter := db.NewIter(nil)
+							found := 0
+							for iter.SeekGE(key); iter.Valid(); iter.Next() {
+								found++
+								if found == ycsbConfig.batch {
+									break
+								}
+							}
+							if err := iter.Close(); err != nil {
+								log.Fatal(err)
+							}
+							elapsed := time.Since(start)
+							readLatency.Record(elapsed)
+							if found == 0 {
+								atomic.AddInt64(&numEmptyResults, 1)
+							}
+						} else {
+							start := time.Now()
+							b := db.NewBatch()
+							for i := 0; i < ycsbConfig.batch; i++ {
+								num := gen.writeKey()
+								val := randomBlock(
+									gen.rand(), ycsbConfig.minBlockBytes,
+									ycsbConfig.maxBlockBytes,
+									ycsbConfig.targetCompressionRatio,
+								)
+								raw = encodeUint64Ascending(raw[:0], uint64(num))
+								key := mvccEncode(buf[:0], raw, 0, 0)
+								b.Set(key, val, nil)
+							}
+							err := b.Commit(pebble_db.Sync)
+							if err != nil {
+								log.Fatal(err)
+							}
+							elapsed := time.Since(start)
+							writeLatency.Record(elapsed)
+						}
+						if atomic.AddUint64(&numSuccess, 1) >= ycsbConfig.numOps {
+							break
+						}
+					}
+				}()
+			}
+		},
+		tick: func(elapsed time.Duration, i int) {
+			if i%20 == 0 {
+				fmt.Println("optype__elapsed____ops/sec__p50(ms)__p95(ms)__p99(ms)_pMax(ms)")
+			}
+			reg.Tick(func(tick histogramTick) {
+				h := tick.Hist
+				fmt.Printf("%6s %8s %10.1f %8.1f %8.1f %8.1f %8.1f\n",
+					tick.Name,
+					time.Duration(elapsed.Seconds()+0.5)*time.Second,
+					float64(h.TotalCount())/tick.Elapsed.Seconds(),
+					time.Duration(h.ValueAtQuantile(50)).Seconds()*1000,
+					time.Duration(h.ValueAtQuantile(95)).Seconds()*1000,
+					time.Duration(h.ValueAtQuantile(99)).Seconds()*1000,
+					time.Duration(h.ValueAtQuantile(100)).Seconds()*1000,
+				)
+			})
+		},
+		done: func(elapsed time.Duration) {
+			fmt.Println("\noptype__elapsed_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)")
+			reg.Tick(func(tick histogramTick) {
+				h := tick.Cumulative
+				fmt.Printf("%6s %7.1fs %14d %14.1f %8.1f %8.1f %8.1f %8.1f %8.1f\n",
+					tick.Name, elapsed.Seconds(), h.TotalCount(),
+					float64(h.TotalCount())/elapsed.Seconds(),
+					time.Duration(h.Mean()).Seconds()*1000,
+					time.Duration(h.ValueAtQuantile(50)).Seconds()*1000,
+					time.Duration(h.ValueAtQuantile(95)).Seconds()*1000,
+					time.Duration(h.ValueAtQuantile(99)).Seconds()*1000,
+					time.Duration(h.ValueAtQuantile(100)).Seconds()*1000)
+			})
+
+			if empty := atomic.LoadInt64(&numEmptyResults); empty != 0 {
+				fmt.Printf("Number of reads that didn't return any results: %d.\n", empty)
+			}
+			seq := atomic.LoadInt64(&seq.val)
+			var ch string
+			if ycsbConfig.sequential {
+				ch = "S"
+			} else {
+				ch = "R"
+			}
+			fmt.Printf("Highest sequence written: %d. Can be passed as --write-seq=%s%d to the next run.\n",
+				seq, ch, seq)
+		},
+	})
+	return nil
+}


### PR DESCRIPTION
This PR adapts the logic from Cockroach repo's `workload kv` and
integrates it into a Pebble subcommand, `ycsb`. It can be run as
follows:

`go run ./cmd/pebble/ ycsb --wipe ./tmp --read-percent 50 --min-block-bytes 4096 --max-block-bytes 4096 --duration 3600s`

Not all of the options are included. In particular, these ones are
omitted: `--tolerate-errors`, `--max-rate`, `--max-op`, `--ramp`,
`--pprof-port`, `--histograms`, and `--zipfian`. We can add them later
if needed.