### PR TITLE
Fix dynamic-level-bytes heuristic

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -181,9 +181,8 @@ func runCompactCommand(td *datadriven.TestData, d *DB) error {
 			start: iStart,
 			end:   iEnd,
 		})
-	} else {
-		return d.Compact([]byte(parts[0]), []byte(parts[1]))
 	}
+	return d.Compact([]byte(parts[0]), []byte(parts[1]))
 }
 
 func runDBDefineCmd(td *datadriven.TestData) (*DB, error) {
@@ -227,6 +226,7 @@ func runDBDefineCmd(td *datadriven.TestData) (*DB, error) {
 		return nil, err
 	}
 	d.mu.Lock()
+	d.mu.versions.dynamicBaseLevel = false
 	for i := range snapshots {
 		s := &Snapshot{db: d}
 		s.seqNum = snapshots[i]

--- a/internal/datadriven/datadriven.go
+++ b/internal/datadriven/datadriven.go
@@ -18,9 +18,11 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -65,7 +67,31 @@ var (
 // actual results of the case, which this function compares with the expected
 // results, and either succeeds or fails the test.
 func RunTest(t *testing.T, path string, f func(d *TestData) string) {
-	r := newTestDataReader(t, path)
+	t.Helper()
+	file, err := os.OpenFile(path, os.O_RDWR, 0644 /* irrelevant */)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	runTestInternal(t, path, file, f, *rewriteTestFiles)
+}
+
+// RunTestFromString is a version of RunTest which takes the contents of a test
+// directly.
+func RunTestFromString(t *testing.T, input string, f func(d *TestData) string) {
+	t.Helper()
+	runTestInternal(t, "<string>" /* optionalPath */, strings.NewReader(input), f, *rewriteTestFiles)
+}
+
+func runTestInternal(
+	t *testing.T, sourceName string, reader io.Reader, f func(d *TestData) string, rewrite bool,
+) {
+	t.Helper()
+
+	r := newTestDataReader(t, sourceName, reader, rewrite)
 	for r.Next(t) {
 		d := &r.data
 		actual := func() string {
@@ -95,7 +121,12 @@ func RunTest(t *testing.T, path string, f func(d *TestData) string) {
 		} else if d.Expected != actual {
 			t.Fatalf("\n%s: %s\nexpected:\n%s\nfound:\n%s", d.Pos, d.Input, d.Expected, actual)
 		} else if testing.Verbose() {
-			fmt.Printf("\n%s:\n%s\n----\n%s", d.Pos, d.Input, actual)
+			input := d.Input
+			if input == "" {
+				input = "<no input to command>"
+			}
+			// TODO(tbg): it's awkward to reproduce the args, but it would be helpful.
+			fmt.Printf("\n%s:\n%s [%d args]\n%s\n----\n%s", d.Pos, d.Cmd, len(d.CmdArgs), input, actual)
 		}
 	}
 
@@ -104,9 +135,18 @@ func RunTest(t *testing.T, path string, f func(d *TestData) string) {
 		if l := len(data); l > 2 && data[l-1] == '\n' && data[l-2] == '\n' {
 			data = data[:l-1]
 		}
-		err := ioutil.WriteFile(path, data, 0644)
-		if err != nil {
-			t.Fatal(err)
+		if dest, ok := reader.(*os.File); ok {
+			if _, err := dest.WriteAt(data, 0); err != nil {
+				t.Fatal(err)
+			}
+			if err := dest.Truncate(int64(len(data))); err != nil {
+				t.Fatal(err)
+			}
+			if err := dest.Sync(); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			t.Logf("input is not a file; rewritten output is:\n%s", data)
 		}
 	}
 }
@@ -160,7 +200,7 @@ func Walk(t *testing.T, path string, f func(t *testing.T, path string)) {
 // TestData contains information about one data-driven test case that was
 // parsed from the test file.
 type TestData struct {
-	Pos string // file and line number
+	Pos string // reader and line number
 
 	// Cmd is the first string on the directive line (up to the first whitespace).
 	Cmd string
@@ -169,6 +209,67 @@ type TestData struct {
 
 	Input    string
 	Expected string
+}
+
+// ScanArgs looks up the first CmdArg matching the given key and scans it into
+// the given destinations in order. If the arg does not exist, the number of
+// destinations does not match that of the arguments, or a destination can not
+// be populated from its matching value, a fatal error results.
+//
+// For example, for a TestData originating from
+//
+// cmd arg1=50 arg2=yoruba arg3=(50, 50, 50)
+//
+// the following would be valid:
+//
+// var i1, i2, i3, i4 int
+// var s string
+// td.ScanArgs(t, "arg1", &i1)
+// td.ScanArgs(t, "arg2", &s)
+// td.ScanArgs(t, "arg3", &i2, &i3, &i4)
+func (td *TestData) ScanArgs(t *testing.T, key string, dests ...interface{}) {
+	t.Helper()
+	var arg CmdArg
+	for i := range td.CmdArgs {
+		if td.CmdArgs[i].Key == key {
+			arg = td.CmdArgs[i]
+			break
+		}
+	}
+	if arg.Key == "" {
+		t.Fatalf("missing argument: %s", key)
+	}
+	if len(dests) != len(arg.Vals) {
+		t.Fatalf("%s: got %d destinations, but %d values", arg.Key, len(dests), len(arg.Vals))
+	}
+
+	for i := range dests {
+		val := arg.Vals[i]
+		switch dest := dests[i].(type) {
+		case *string:
+			*dest = val
+		case *int:
+			n, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			*dest = int(n) // assume 64bit ints
+		case *uint64:
+			n, err := strconv.ParseUint(val, 10, 64)
+			if err != nil {
+				t.Fatal(err)
+			}
+			*dest = n
+		case *bool:
+			b, err := strconv.ParseBool(val)
+			if err != nil {
+				t.Fatal(err)
+			}
+			*dest = b
+		default:
+			t.Fatalf("unsupported type %T for destination #%d (might be easy to add it)", dest, i+1)
+		}
+	}
 }
 
 // CmdArg contains information about an argument on the directive line. An
@@ -181,7 +282,7 @@ type CmdArg struct {
 	Vals []string
 }
 
-func (arg *CmdArg) String() string {
+func (arg CmdArg) String() string {
 	switch len(arg.Vals) {
 	case 0:
 		return arg.Key

--- a/internal/datadriven/datadriven_test.go
+++ b/internal/datadriven/datadriven_test.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package datadriven
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestDataDriven(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	input := `
+# NB: we allow duplicate args. It's unclear at this time whether this is useful,
+# either way, ScanArgs simply picks the first occurrence.
+make argTuple=(1, 🍌) argInt=12 argString=greedily argString=totally_ignored
+sentence
+----
+Did the following: make sentence
+1 hungry monkey eats a 🍌
+while 12 other monkeys watch greedily
+`
+
+	RunTestFromString(t, input, func(d *TestData) string {
+		var one int
+		var twelve int
+		var banana string
+		var greedily string
+		d.ScanArgs(t, "argTuple", &one, &banana)
+		d.ScanArgs(t, "argInt", &twelve)
+		d.ScanArgs(t, "argString", &greedily)
+		return fmt.Sprintf("Did the following: %s %s\n%d hungry monkey eats a %s\nwhile %d other monkeys watch %s\n",
+			d.Cmd, d.Input, one, banana, twelve, greedily,
+		)
+	})
+}

--- a/internal/datadriven/test_data_reader.go
+++ b/internal/datadriven/test_data_reader.go
@@ -17,41 +17,35 @@ package datadriven
 import (
 	"bytes"
 	"fmt"
-	"os"
+	"io"
 	"regexp"
 	"strings"
 	"testing"
 )
 
 type testDataReader struct {
-	path    string
-	file    *os.File
-	scanner *lineScanner
-	data    TestData
-	rewrite *bytes.Buffer
+	sourceName string
+	reader     io.Reader
+	scanner    *lineScanner
+	data       TestData
+	rewrite    *bytes.Buffer
 }
 
-func newTestDataReader(t *testing.T, path string) *testDataReader {
+func newTestDataReader(
+	t *testing.T, sourceName string, file io.Reader, record bool,
+) *testDataReader {
 	t.Helper()
 
-	file, err := os.Open(path)
-	if err != nil {
-		t.Fatal(err)
-	}
 	var rewrite *bytes.Buffer
-	if *rewriteTestFiles {
+	if record {
 		rewrite = &bytes.Buffer{}
 	}
 	return &testDataReader{
-		path:    path,
-		file:    file,
-		scanner: newLineScanner(file),
-		rewrite: rewrite,
+		sourceName: sourceName,
+		reader:     file,
+		scanner:    newLineScanner(file),
+		rewrite:    rewrite,
 	}
-}
-
-func (r *testDataReader) Close() error {
-	return r.file.Close()
 }
 
 func (r *testDataReader) Next(t *testing.T) bool {
@@ -81,7 +75,7 @@ func (r *testDataReader) Next(t *testing.T) bool {
 			continue
 		}
 		cmd := fields[0]
-		r.data.Pos = fmt.Sprintf("%s:%d", r.path, r.scanner.line)
+		r.data.Pos = fmt.Sprintf("%s:%d", r.sourceName, r.scanner.line)
 		r.data.Cmd = cmd
 
 		for _, arg := range fields[1:] {
@@ -185,7 +179,7 @@ func (r *testDataReader) emit(s string) {
 	}
 }
 
-var splitDirectivesRE = regexp.MustCompile(`^ *[a-zA-Z0-9_,-\.]+(|=[-a-zA-Z0-9_@:]+|=\([^)]*\))( |$)`)
+var splitDirectivesRE = regexp.MustCompile(`^ *[a-zA-Z0-9_,-\.]+(|=[-a-zA-Z0-9_@]+|=\([^)]*\))( |$)`)
 
 // splits a directive line into tokens, where each token is
 // either:

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -30,6 +30,8 @@ func TestRangeDel(t *testing.T) {
 			}
 
 			d.mu.Lock()
+			// Disable the "dynamic base level" code for this test.
+			d.mu.versions.picker.baseLevel = 1
 			s := fmt.Sprintf("mem: %d\n%s", len(d.mu.mem.queue), d.mu.versions.currentVersion())
 			d.mu.Unlock()
 			return s
@@ -39,6 +41,8 @@ func TestRangeDel(t *testing.T) {
 				return err.Error()
 			}
 			d.mu.Lock()
+			// Disable the "dynamic base level" code for this test.
+			d.mu.versions.picker.baseLevel = 1
 			s := d.mu.versions.currentVersion().String()
 			d.mu.Unlock()
 			return s
@@ -126,6 +130,10 @@ func TestRangeDelCompactionTruncation(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer d.Close()
+
+	d.mu.Lock()
+	d.mu.versions.dynamicBaseLevel = false
+	d.mu.Unlock()
 
 	lsm := func() string {
 		d.mu.Lock()

--- a/testdata/compaction_output_level
+++ b/testdata/compaction_output_level
@@ -1,0 +1,199 @@
+compact start=0 base=1
+----
+output=1
+max-output-file-size=4194304
+
+compact start=1 base=1
+----
+output=2
+max-output-file-size=8388608
+
+compact start=2 base=1
+----
+output=3
+max-output-file-size=16777216
+
+compact start=3 base=1
+----
+output=4
+max-output-file-size=33554432
+
+compact start=4 base=1
+----
+output=5
+max-output-file-size=67108864
+
+compact start=5 base=1
+----
+output=6
+max-output-file-size=134217728
+
+compact start=6 base=1
+----
+output=6
+max-output-file-size=134217728
+
+
+compact start=0 base=2
+----
+output=2
+max-output-file-size=4194304
+
+compact start=1 base=2
+----
+invalid compaction: start level 1 should be empty (base level 2)
+
+compact start=2 base=2
+----
+output=3
+max-output-file-size=8388608
+
+compact start=3 base=2
+----
+output=4
+max-output-file-size=16777216
+
+compact start=4 base=2
+----
+output=5
+max-output-file-size=33554432
+
+compact start=5 base=2
+----
+output=6
+max-output-file-size=67108864
+
+compact start=6 base=2
+----
+output=6
+max-output-file-size=67108864
+
+
+compact start=0 base=3
+----
+output=3
+max-output-file-size=4194304
+
+compact start=1 base=3
+----
+invalid compaction: start level 1 should be empty (base level 3)
+
+compact start=2 base=3
+----
+invalid compaction: start level 2 should be empty (base level 3)
+
+compact start=3 base=3
+----
+output=4
+max-output-file-size=8388608
+
+compact start=4 base=3
+----
+output=5
+max-output-file-size=16777216
+
+compact start=5 base=3
+----
+output=6
+max-output-file-size=33554432
+
+compact start=6 base=3
+----
+output=6
+max-output-file-size=33554432
+
+
+compact start=0 base=4
+----
+output=4
+max-output-file-size=4194304
+
+compact start=1 base=4
+----
+invalid compaction: start level 1 should be empty (base level 4)
+
+compact start=2 base=4
+----
+invalid compaction: start level 2 should be empty (base level 4)
+
+compact start=3 base=4
+----
+invalid compaction: start level 3 should be empty (base level 4)
+
+compact start=4 base=4
+----
+output=5
+max-output-file-size=8388608
+
+compact start=5 base=4
+----
+output=6
+max-output-file-size=16777216
+
+compact start=6 base=4
+----
+output=6
+max-output-file-size=16777216
+
+
+compact start=0 base=5
+----
+output=5
+max-output-file-size=4194304
+
+compact start=1 base=5
+----
+invalid compaction: start level 1 should be empty (base level 5)
+
+compact start=2 base=5
+----
+invalid compaction: start level 2 should be empty (base level 5)
+
+compact start=3 base=5
+----
+invalid compaction: start level 3 should be empty (base level 5)
+
+compact start=4 base=5
+----
+invalid compaction: start level 4 should be empty (base level 5)
+
+compact start=5 base=5
+----
+output=6
+max-output-file-size=8388608
+
+compact start=6 base=5
+----
+output=6
+max-output-file-size=8388608
+
+
+compact start=0 base=6
+----
+output=6
+max-output-file-size=4194304
+
+compact start=1 base=6
+----
+invalid compaction: start level 1 should be empty (base level 6)
+
+compact start=2 base=6
+----
+invalid compaction: start level 2 should be empty (base level 6)
+
+compact start=3 base=6
+----
+invalid compaction: start level 3 should be empty (base level 6)
+
+compact start=4 base=6
+----
+invalid compaction: start level 4 should be empty (base level 6)
+
+compact start=5 base=6
+----
+invalid compaction: start level 5 should be empty (base level 6)
+
+compact start=6 base=6
+----
+output=6
+max-output-file-size=4194304

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -5,7 +5,7 @@ set b 2
 
 compact a-b
 ----
-1: a-b
+6: a-b
 
 batch
 set c 3
@@ -14,7 +14,7 @@ set d 4
 
 compact c-d
 ----
-1: a-b c-d
+6: a-b c-d
 
 batch
 set b 5
@@ -23,7 +23,7 @@ set c 6
 
 compact a-d
 ----
-2: a-d
+6: a-d
 
 # This also tests flushing a memtable that only contains range
 # deletions.


### PR DESCRIPTION
The implementation of dynamic-level-bytes was incomplete: we were
dynamically determining the base level and the size for each level, but the
base level wasn't being utilized to compute the compaction output level
when compacting from L0. The end result is that we'd determine the LSM only
needed 2 levels, but then compact from L0 -> L1, thus invalidating the
dyanmic-level-bytes heuristic (which stops at the first non-empty level).

Also fixed the target file size calculation to account for the dynamic base
level.

Fixes #108