### PR TITLE
Rework the commitQueue and commitPipeline syncing

### DIFF
--- a/internal/record/log_writer_test.go
+++ b/internal/record/log_writer_test.go
@@ -1,0 +1,116 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package record
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestSyncQueue(t *testing.T) {
+	var q syncQueue
+	var closed int32
+
+	var flusherWG sync.WaitGroup
+	flusherWG.Add(1)
+	go func() {
+		defer flusherWG.Done()
+		for {
+			if atomic.LoadInt32(&closed) == 1 {
+				return
+			}
+			head, tail := q.load()
+			q.pop(head, tail)
+		}
+	}()
+
+	var commitMu sync.Mutex
+	var doneWG sync.WaitGroup
+	for i := 0; i < SyncConcurrency; i++ {
+		doneWG.Add(1)
+		go func(i int) {
+			defer doneWG.Done()
+			for j := 0; j < 1000; j++ {
+				wg := &sync.WaitGroup{}
+				wg.Add(1)
+				// syncQueue is a single-producer, single-consumer queue. We need to
+				// provide mutual exclusion on the producer side.
+				commitMu.Lock()
+				q.push(wg)
+				commitMu.Unlock()
+				wg.Wait()
+			}
+		}(i)
+	}
+	doneWG.Wait()
+
+	atomic.StoreInt32(&closed, 1)
+	flusherWG.Wait()
+}
+
+func TestFlusherCond(t *testing.T) {
+	var mu sync.Mutex
+	var q syncQueue
+	var c flusherCond
+	var closed bool
+
+	c.init(&mu, &q)
+
+	var flusherWG sync.WaitGroup
+	flusherWG.Add(1)
+	go func() {
+		defer flusherWG.Done()
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		for {
+			for {
+				if closed {
+					return
+				}
+				if !q.empty() {
+					break
+				}
+				c.Wait()
+			}
+
+			head, tail := q.load()
+			q.pop(head, tail)
+		}
+	}()
+
+	var commitMu sync.Mutex
+	var doneWG sync.WaitGroup
+	// NB: we're testing with low concurrency here, because what we want to
+	// stress is that signalling of the flusherCond works
+	// correctly. Specifically, we want to make sure that a signal is "lost",
+	// causing the test to wedge.
+	for i := 0; i < 2; i++ {
+		doneWG.Add(1)
+		go func(i int) {
+			defer doneWG.Done()
+			for j := 0; j < 10000; j++ {
+				wg := &sync.WaitGroup{}
+				wg.Add(1)
+				// syncQueue is a single-producer, single-consumer queue. We need to
+				// provide mutual exclusion on the producer side.
+				commitMu.Lock()
+				q.push(wg)
+				commitMu.Unlock()
+				c.Signal()
+				wg.Wait()
+			}
+		}(i)
+	}
+	doneWG.Wait()
+
+	mu.Lock()
+	closed = true
+	c.Signal()
+	mu.Unlock()
+	flusherWG.Wait()
+}

--- a/open.go
+++ b/open.go
@@ -79,7 +79,6 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 		logSeqNum:     &d.mu.versions.logSeqNum,
 		visibleSeqNum: &d.mu.versions.visibleSeqNum,
 		apply:         d.commitApply,
-		sync:          d.commitSync,
 		write:         d.commitWrite,
 	})
 	d.mu.nextJobID = 1


### PR DESCRIPTION
Replace the commitQueue implementation with one based on the
single-producer, multi-consumer queue used to implement `sync.Pool` in
go1.13. This implementation is similar to the previous one, but uses
fewer atomic operations per enqueue/dequeue and also takes care of
nil'ing out unused slots to avoid unnecessary retention of
batches. Removed the use of the cond var to signal when the queue had
space available. That approach was racy as it isn't safe to signal a
`sync.Cond` without holding a lock on the condition being examined
unless you jump through some hoops. Instead, we configure a maximum
commit concurrency which is enforced through a semaphore (implemented
via a `chan struct{}`).

Move most of the syncing logic into LogWriter. Added
`LogWriter.SyncRecord` which is similar to `WriteRecord` except that it
optionally queues a wait group and an asynchronous sync of the log. The
wait group is signalled via a call to `Done()` when the sync
completes. Pushing the handling of syncing into `LogWriter` allowed
removal of `commitQueue.syncLoop` which was somewhat redundant with
`LogWriter.flushLoop`. It also removed the need for `LogWriter.Sync()`
which allowed further simplification in `LogWriter.flushLoop`. Lastly,
this prepares for a future where there are different syncing styles in
`LogWriter`. For example, `O_DIRECT` or `O_DSYNC` will not require an
explicit sync call. As a final benefit, it removes a performance wart
where pipeline performance fell off a cliff at high parallelism (note
that the actual parallelism is `<N>*8` below). I'm not fully clear on
why that was happening. Profiles showed significant goroutine thrashing.

Added `syncQueue`, a lock-free single-producer, single-consumer
fixed-size queue. Added `flusherCond`, a specialized cond var that
allows signalling the addition to `syncQueue` without holding the
associated lock.

```
name                           old time/op    new time/op     delta
CommitPipeline/parallel=1-8       968ns ± 4%      859ns ± 1%   -11.28%  (p=0.000 n=10+10)
CommitPipeline/parallel=2-8       861ns ± 3%      824ns ± 2%    -4.36%  (p=0.000 n=10+10)
CommitPipeline/parallel=4-8       813ns ± 2%      812ns ± 3%      ~     (p=0.985 n=9+10)
CommitPipeline/parallel=8-8       797ns ± 3%      786ns ± 9%      ~     (p=0.984 n=10+10)
CommitPipeline/parallel=16-8      800ns ± 4%      824ns ± 2%      ~     (p=0.058 n=10+7)
CommitPipeline/parallel=32-8     1.12µs ±11%     0.83µs ± 9%   -25.90%  (p=0.000 n=8+10)
CommitPipeline/parallel=64-8     2.48µs ± 7%     0.85µs ±17%   -65.78%  (p=0.000 n=10+10)
CommitPipeline/parallel=128-8    2.42µs ± 6%     0.72µs ± 7%   -70.28%  (p=0.000 n=9+9)
```