### PR TITLE
Fix compaction output file boundaries

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -905,7 +905,8 @@ func (d *DB) compactDiskTables(c *compaction) (ve *versionEdit, pendingOutputs [
 			// This is not the first output. Bound the smallest range key by the
 			// previous tables largest key.
 			prevMeta := &ve.newFiles[n-2].meta
-			if d.cmp(writerMeta.SmallestRange.UserKey, prevMeta.largest.UserKey) <= 0 {
+			if writerMeta.SmallestRange.UserKey != nil &&
+				d.cmp(writerMeta.SmallestRange.UserKey, prevMeta.largest.UserKey) <= 0 {
 				// The range boundary user key is less than or equal to the previous
 				// table's largest key. We need the tables to be key-space partitioned,
 				// so force the boundary to a key that we know is larger than the
@@ -915,7 +916,7 @@ func (d *DB) compactDiskTables(c *compaction) (ve *versionEdit, pendingOutputs [
 			}
 		}
 
-		if key.UserKey != nil {
+		if key.UserKey != nil && writerMeta.LargestRange.UserKey != nil {
 			if d.cmp(writerMeta.LargestRange.UserKey, key.UserKey) >= 0 {
 				writerMeta.LargestRange = key
 				writerMeta.LargestRange.Trailer = db.InternalKeyRangeDeleteSentinel

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -710,6 +710,17 @@ func TestManualCompaction(t *testing.T) {
 			b.Commit(nil)
 			return ""
 
+		case "define":
+			var err error
+			if d, err = runDBDefineCmd(td); err != nil {
+				return err.Error()
+			}
+
+			d.mu.Lock()
+			s := d.mu.versions.currentVersion().String()
+			d.mu.Unlock()
+			return s
+
 		case "iter":
 			iter := d.NewIter(nil)
 			defer iter.Close()

--- a/testdata/manual_compaction
+++ b/testdata/manual_compaction
@@ -34,3 +34,17 @@ del-range a e
 
 compact a-d
 ----
+
+# Test that a multi-output-file compaction generates non-overlapping files.
+
+define target-file-sizes=(100, 1)
+L0
+  a.SET.2:v
+L0
+  b.SET.1:v
+----
+0: b-b a-a
+
+compact a-b
+----
+1: a-a b-b

--- a/testdata/range_del
+++ b/testdata/range_del
@@ -1282,7 +1282,7 @@ compact f-f L0
 
 compact a-f L1
 ----
-2: a-c c-f
+2: a-c f-f
 3: c-d d-e
 
 get seq=4


### PR DESCRIPTION
We need a nil check on the output file's ranges. Without it, we may
unnecessarily extend the output file's lower-bound to the previous
output file's upper bound (the nil `UserKey` compares less than the
previous file's upper bound, regardless of what it is).