### PR TITLE
Sync the DB dir whenever we manipulate directory entries

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -115,7 +115,7 @@ func TestBatchGet(t *testing.T) {
 	for _, method := range []string{"build", "apply"} {
 		t.Run(method, func(t *testing.T) {
 			d, err := Open("", &db.Options{
-				VFS: vfs.NewMem(),
+				FS: vfs.NewMem(),
 			})
 			if err != nil {
 				t.Fatalf("Open: %v", err)

--- a/compaction.go
+++ b/compaction.go
@@ -478,7 +478,7 @@ func (d *DB) flush1() error {
 		})
 	}
 
-	meta, err := d.writeLevel0Table(d.opts.VFS, iter,
+	meta, err := d.writeLevel0Table(d.opts.FS, iter,
 		true /* allowRangeTombstoneElision */)
 
 	if d.opts.EventListener != nil && d.opts.EventListener.FlushEnd != nil {
@@ -837,7 +837,7 @@ func (d *DB) compactDiskTables(c *compaction) (ve *versionEdit, pendingOutputs [
 		}
 		if retErr != nil {
 			for _, filename := range filenames {
-				d.opts.VFS.Remove(filename)
+				d.opts.FS.Remove(filename)
 			}
 		}
 	}()
@@ -854,7 +854,7 @@ func (d *DB) compactDiskTables(c *compaction) (ve *versionEdit, pendingOutputs [
 		d.mu.Unlock()
 
 		filename := dbFilename(d.dirname, fileTypeTable, fileNum)
-		file, err := d.opts.VFS.Create(filename)
+		file, err := d.opts.FS.Create(filename)
 		if err != nil {
 			return err
 		}
@@ -984,7 +984,7 @@ func (d *DB) scanObsoleteFiles() {
 	d.mu.Unlock()
 	defer d.mu.Lock()
 
-	fs := d.opts.VFS
+	fs := d.opts.FS
 	list, err := fs.List(d.dirname)
 	if err != nil {
 		// Ignore any filesystem errors.
@@ -1115,7 +1115,7 @@ func (d *DB) deleteObsoleteFiles(jobID int) {
 			}
 
 			path := dbFilename(d.dirname, f.fileType, fileNum)
-			err := d.opts.VFS.Remove(path)
+			err := d.opts.FS.Remove(path)
 
 			if err != os.ErrNotExist && d.opts.EventListener != nil {
 				switch f.fileType {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -581,7 +581,7 @@ func TestCompaction(t *testing.T) {
 
 	mem := vfs.NewMem()
 	d, err := Open("", &db.Options{
-		VFS:          mem,
+		FS:           mem,
 		MemTableSize: memTableSize,
 	})
 	if err != nil {
@@ -694,7 +694,7 @@ func TestManualCompaction(t *testing.T) {
 	}
 
 	d, err := Open("", &db.Options{
-		VFS: mem,
+		FS: mem,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/data_test.go
+++ b/data_test.go
@@ -192,7 +192,7 @@ func runDBDefineCmd(td *datadriven.TestData) (*DB, error) {
 	}
 
 	opts := db.Options{
-		VFS: vfs.NewMem(),
+		FS: vfs.NewMem(),
 	}
 	var snapshots []uint64
 	for _, arg := range td.CmdArgs {
@@ -247,7 +247,7 @@ func runDBDefineCmd(td *datadriven.TestData) (*DB, error) {
 		if rangeDelIter := mem.newRangeDelIter(nil); rangeDelIter != nil {
 			iter = newMergingIter(d.cmp, iter, rangeDelIter)
 		}
-		meta, err := d.writeLevel0Table(d.opts.VFS, iter,
+		meta, err := d.writeLevel0Table(d.opts.FS, iter,
 			false /* allowRangeTombstoneElision */)
 		if err != nil {
 			return nil

--- a/data_test.go
+++ b/data_test.go
@@ -247,8 +247,7 @@ func runDBDefineCmd(td *datadriven.TestData) (*DB, error) {
 		if rangeDelIter := mem.newRangeDelIter(nil); rangeDelIter != nil {
 			iter = newMergingIter(d.cmp, iter, rangeDelIter)
 		}
-		meta, err := d.writeLevel0Table(d.opts.FS, iter,
-			false /* allowRangeTombstoneElision */)
+		meta, err := d.writeLevel0Table(iter, false /* allowRangeTombstoneElision */)
 		if err != nil {
 			return nil
 		}
@@ -304,7 +303,7 @@ func runDBDefineCmd(td *datadriven.TestData) (*DB, error) {
 	}
 
 	if len(ve.newFiles) > 0 {
-		if err := d.mu.versions.logAndApply(ve); err != nil {
+		if err := d.mu.versions.logAndApply(ve, d.dir); err != nil {
 			return nil, err
 		}
 		d.updateReadStateLocked()

--- a/db.go
+++ b/db.go
@@ -791,11 +791,11 @@ func (d *DB) makeRoomForWrite(b *Batch) error {
 			recycleLogNumber := d.logRecycler.peek()
 			if recycleLogNumber > 0 {
 				recycleLogName := dbFilename(d.dirname, fileTypeLog, recycleLogNumber)
-				err = d.opts.VFS.Rename(recycleLogName, newLogName)
+				err = d.opts.FS.Rename(recycleLogName, newLogName)
 			}
 
 			if err == nil {
-				newLogFile, err = d.opts.VFS.Create(newLogName)
+				newLogFile, err = d.opts.FS.Create(newLogName)
 			}
 
 			if err == nil {

--- a/db/options.go
+++ b/db/options.go
@@ -218,6 +218,11 @@ type Options struct {
 	// flushes, compactions, and table deletion.
 	EventListener *EventListener
 
+	// FS provides the interface for persistent file storage.
+	//
+	// The default value uses the underlying operating system's file system.
+	FS vfs.FS
+
 	// The number of files necessary to trigger an L0 compaction.
 	L0CompactionThreshold int
 
@@ -276,12 +281,11 @@ type Options struct {
 	// TableFormatRocksDBv2 which creates RocksDB compatible sstables. Use
 	// TableFormatLevelDB to create LevelDB compatible sstable which can be used
 	// by a wider range of tools and libraries.
-	TableFormat TableFormat
-
-	// VFS provides the interface for persistent file storage.
 	//
-	// The default value uses the underlying operating system's file system.
-	VFS vfs.FS
+	// TODO(peter): TableFormatLevelDB does not support all of the functionality
+	// of TableFormatRocksDBv2. We should ensure it is only used when writing an
+	// sstable directly, and not used when opening a database.
+	TableFormat TableFormat
 }
 
 // EnsureDefaults ensures that the default values for all options are set if a
@@ -342,8 +346,8 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Merger == nil {
 		o.Merger = DefaultMerger
 	}
-	if o.VFS == nil {
-		o.VFS = vfs.Default
+	if o.FS == nil {
+		o.FS = vfs.Default
 	}
 	return o
 }

--- a/db_test.go
+++ b/db_test.go
@@ -197,7 +197,7 @@ func TestBasicReads(t *testing.T) {
 			continue
 		}
 		d, err := Open("", &db.Options{
-			VFS: fs,
+			FS: fs,
 		})
 		if err != nil {
 			t.Errorf("%s: Open failed: %v", tc.dirname, err)
@@ -224,7 +224,7 @@ func TestBasicReads(t *testing.T) {
 
 func TestBasicWrites(t *testing.T) {
 	d, err := Open("", &db.Options{
-		VFS: vfs.NewMem(),
+		FS: vfs.NewMem(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -363,7 +363,7 @@ func TestBasicWrites(t *testing.T) {
 
 func TestRandomWrites(t *testing.T) {
 	d, err := Open("", &db.Options{
-		VFS:          vfs.NewMem(),
+		FS:           vfs.NewMem(),
 		MemTableSize: 8 * 1024,
 	})
 	if err != nil {
@@ -419,7 +419,7 @@ func TestRandomWrites(t *testing.T) {
 
 func TestLargeBatch(t *testing.T) {
 	d, err := Open("", &db.Options{
-		VFS:                         vfs.NewMem(),
+		FS:                          vfs.NewMem(),
 		MemTableSize:                1400,
 		MemTableStopWritesThreshold: 100,
 	})
@@ -470,7 +470,7 @@ func TestLargeBatch(t *testing.T) {
 
 func TestGetMerge(t *testing.T) {
 	d, err := Open("", &db.Options{
-		VFS: vfs.NewMem(),
+		FS: vfs.NewMem(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -512,7 +512,7 @@ func TestIterLeak(t *testing.T) {
 			for _, flush := range []bool{true, false} {
 				t.Run(fmt.Sprintf("flush=%t", flush), func(t *testing.T) {
 					d, err := Open("", &db.Options{
-						VFS: vfs.NewMem(),
+						FS: vfs.NewMem(),
 					})
 					if err != nil {
 						t.Fatal(err)
@@ -554,7 +554,7 @@ func TestCacheEvict(t *testing.T) {
 	cache := cache.New(10 << 20)
 	d, err := Open("", &db.Options{
 		Cache: cache,
-		VFS:   vfs.NewMem(),
+		FS:    vfs.NewMem(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -602,7 +602,7 @@ func TestCacheEvict(t *testing.T) {
 
 func TestFlushEmpty(t *testing.T) {
 	d, err := Open("", &db.Options{
-		VFS: vfs.NewMem(),
+		FS: vfs.NewMem(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -619,7 +619,7 @@ func TestFlushEmpty(t *testing.T) {
 func TestRollManifest(t *testing.T) {
 	d, err := Open("", &db.Options{
 		MaxManifestFileSize: 1,
-		VFS:                 vfs.NewMem(),
+		FS:                  vfs.NewMem(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -632,7 +632,7 @@ func TestRollManifest(t *testing.T) {
 	}
 
 	current := func() string {
-		f, err := d.opts.VFS.Open(dbFilename(d.dirname, fileTypeCurrent, 0))
+		f, err := d.opts.FS.Open(dbFilename(d.dirname, fileTypeCurrent, 0))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -669,7 +669,7 @@ func TestRollManifest(t *testing.T) {
 		}
 	}
 
-	files, err := d.opts.VFS.List("")
+	files, err := d.opts.FS.List("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -7,16 +7,25 @@ package pebble
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 
 	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/datadriven"
+	"github.com/petermattis/pebble/sstable"
 	"github.com/petermattis/pebble/vfs"
 )
 
 type syncedBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
+}
+
+func (b *syncedBuffer) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf.Reset()
 }
 
 func (b *syncedBuffer) Write(p []byte) (n int, err error) {
@@ -31,78 +40,150 @@ func (b *syncedBuffer) String() string {
 	return b.buf.String()
 }
 
-func TestEventListener(t *testing.T) {
-	var buf syncedBuffer
+type loggingFS struct {
+	vfs.FS
+	w io.Writer
+}
 
-	d, err := Open("", &db.Options{
-		FS: vfs.NewMem(),
-		EventListener: &db.EventListener{
-			CompactionBegin: func(info db.CompactionInfo) {
-				fmt.Fprintf(&buf, "#%d: compaction begin: L%d -> L%d\n", info.JobID,
-					info.Input.Level, info.Input.Level+1)
-			},
-			CompactionEnd: func(info db.CompactionInfo) {
-				fmt.Fprintf(&buf, "#%d: compaction end: L%d -> L%d\n", info.JobID,
-					info.Input.Level, info.Input.Level+1)
-			},
-			FlushBegin: func(info db.FlushInfo) {
-				fmt.Fprintf(&buf, "#%d: flush begin\n", info.JobID)
-			},
-			FlushEnd: func(info db.FlushInfo) {
-				fmt.Fprintf(&buf, "#%d: flush end: %d\n", info.JobID, info.Output.FileNum)
-			},
-			TableDeleted: func(info db.TableDeleteInfo) {
-				fmt.Fprintf(&buf, "#%d: table deleted: %d\n", info.JobID, info.FileNum)
-			},
-			TableIngested: func(info db.TableIngestInfo) {
-				fmt.Fprintf(&buf, "#%d: table ingested\n", info.JobID)
-			},
-			WALCreated: func(info db.WALCreateInfo) {
-				fmt.Fprintf(&buf, "#%d: WAL created: %d recycled=%d\n",
-					info.JobID, info.FileNum, info.RecycledFileNum)
-			},
-			WALDeleted: func(info db.WALDeleteInfo) {
-				fmt.Fprintf(&buf, "#%d: WAL deleted: %d\n", info.JobID, info.FileNum)
-			},
+func (fs loggingFS) Create(name string) (vfs.File, error) {
+	fmt.Fprintf(fs.w, "create: %s\n", name)
+	f, err := fs.FS.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	return loggingFile{f, name, fs.w}, nil
+}
+
+func (fs loggingFS) Link(oldname, newname string) error {
+	fmt.Fprintf(fs.w, "link: %s -> %s\n", oldname, newname)
+	return fs.FS.Link(oldname, newname)
+}
+
+func (fs loggingFS) OpenDir(name string) (vfs.File, error) {
+	fmt.Fprintf(fs.w, "open-dir: %s\n", name)
+	f, err := fs.FS.OpenDir(name)
+	if err != nil {
+		return nil, err
+	}
+	return loggingFile{f, name, fs.w}, nil
+}
+
+func (fs loggingFS) Rename(oldname, newname string) error {
+	fmt.Fprintf(fs.w, "rename: %s -> %s\n", oldname, newname)
+	return fs.FS.Rename(oldname, newname)
+}
+
+type loggingFile struct {
+	vfs.File
+	name string
+	w    io.Writer
+}
+
+func (f loggingFile) Sync() error {
+	fmt.Fprintf(f.w, "sync: %s\n", f.name)
+	return f.File.Sync()
+}
+
+func newLoggingEventListener(w io.Writer) *db.EventListener {
+	return &db.EventListener{
+		CompactionBegin: func(info db.CompactionInfo) {
+			fmt.Fprintf(w, "#%d: compaction begin: L%d -> L%d\n", info.JobID,
+				info.Input.Level, info.Input.Level+1)
 		},
-	})
+		CompactionEnd: func(info db.CompactionInfo) {
+			fmt.Fprintf(w, "#%d: compaction end: L%d -> L%d\n", info.JobID,
+				info.Input.Level, info.Input.Level+1)
+		},
+		FlushBegin: func(info db.FlushInfo) {
+			fmt.Fprintf(w, "#%d: flush begin\n", info.JobID)
+		},
+		FlushEnd: func(info db.FlushInfo) {
+			fmt.Fprintf(w, "#%d: flush end: %d\n", info.JobID, info.Output.FileNum)
+		},
+		TableDeleted: func(info db.TableDeleteInfo) {
+			fmt.Fprintf(w, "#%d: table deleted: %d\n", info.JobID, info.FileNum)
+		},
+		TableIngested: func(info db.TableIngestInfo) {
+			fmt.Fprintf(w, "#%d: table ingested\n", info.JobID)
+		},
+		WALCreated: func(info db.WALCreateInfo) {
+			fmt.Fprintf(w, "#%d: WAL created: %d recycled=%d\n",
+				info.JobID, info.FileNum, info.RecycledFileNum)
+		},
+		WALDeleted: func(info db.WALDeleteInfo) {
+			fmt.Fprintf(w, "#%d: WAL deleted: %d\n", info.JobID, info.FileNum)
+		},
+	}
+}
+
+// Verify event listener actions, as well as expected filesystem operations.
+func TestEventListener(t *testing.T) {
+	var d *DB
+	var buf syncedBuffer
+	mem := vfs.NewMem()
+	err := mem.MkdirAll("ext", 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := d.Set([]byte("a"), nil, nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Flush(); err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Compact([]byte("a"), []byte("b")); err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Delete([]byte("a"), nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Compact([]byte("a"), []byte("b")); err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Close(); err != nil {
-		t.Fatal(err)
-	}
+	datadriven.RunTest(t, "testdata/event_listener", func(td *datadriven.TestData) string {
+		switch td.Cmd {
+		case "open":
+			buf.Reset()
+			var err error
+			d, err = Open("db", &db.Options{
+				FS:                  loggingFS{mem, &buf},
+				EventListener:       newLoggingEventListener(&buf),
+				MaxManifestFileSize: 1,
+			})
+			if err != nil {
+				return err.Error()
+			}
+			return buf.String()
 
-	expected := `#2: WAL created: 5 recycled=0
-#3: flush begin
-#3: flush end: 6
-#4: compaction begin: L0 -> L1
-#4: compaction end: L0 -> L1
-#5: WAL created: 7 recycled=2
-#6: flush begin
-#6: flush end: 8
-#7: compaction begin: L0 -> L1
-#7: compaction end: L0 -> L1
-#7: table deleted: 6
-#7: table deleted: 8
-`
-	if v := buf.String(); expected != v {
-		t.Fatalf("expected\n%s\nbut found\n%s", expected, v)
-	}
+		case "flush":
+			buf.Reset()
+			if err := d.Set([]byte("a"), nil, nil); err != nil {
+				return err.Error()
+			}
+			if err := d.Flush(); err != nil {
+				return err.Error()
+			}
+			return buf.String()
+
+		case "compact":
+			buf.Reset()
+			if err := d.Set([]byte("a"), nil, nil); err != nil {
+				return err.Error()
+			}
+			if err := d.Compact([]byte("a"), []byte("b")); err != nil {
+				return err.Error()
+			}
+			return buf.String()
+
+		case "ingest":
+			buf.Reset()
+			f, err := mem.Create("ext/0")
+			if err != nil {
+				return err.Error()
+			}
+			w := sstable.NewWriter(f, nil, db.LevelOptions{})
+			if err := w.Add(db.MakeInternalKey([]byte("a"), 0, db.InternalKeyKindSet), nil); err != nil {
+				return err.Error()
+			}
+			if err := w.Close(); err != nil {
+				return err.Error()
+			}
+			if err := d.Ingest([]string{"ext/0"}); err != nil {
+				return err.Error()
+			}
+			if err := mem.Remove("ext/0"); err != nil {
+				return err.Error()
+			}
+			return buf.String()
+
+		default:
+			return fmt.Sprintf("unknown command: %s", td.Cmd)
+		}
+	})
 }

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -35,7 +35,7 @@ func TestEventListener(t *testing.T) {
 	var buf syncedBuffer
 
 	d, err := Open("", &db.Options{
-		VFS: vfs.NewMem(),
+		FS: vfs.NewMem(),
 		EventListener: &db.EventListener{
 			CompactionBegin: func(info db.CompactionInfo) {
 				fmt.Fprintf(&buf, "#%d: compaction begin: L%d -> L%d\n", info.JobID,

--- a/flush_test.go
+++ b/flush_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestManualFlush(t *testing.T) {
 	d, err := Open("", &db.Options{
-		VFS: vfs.NewMem(),
+		FS: vfs.NewMem(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -70,7 +70,7 @@ func TestManualFlush(t *testing.T) {
 
 		case "reset":
 			d, err = Open("", &db.Options{
-				VFS: vfs.NewMem(),
+				FS: vfs.NewMem(),
 			})
 			if err != nil {
 				return err.Error()

--- a/ingest.go
+++ b/ingest.go
@@ -14,12 +14,12 @@ import (
 )
 
 func ingestLoad1(opts *db.Options, path string, fileNum uint64) (*fileMetadata, error) {
-	stat, err := opts.VFS.Stat(path)
+	stat, err := opts.FS.Stat(path)
 	if err != nil {
 		return nil, err
 	}
 
-	f, err := opts.VFS.Open(path)
+	f, err := opts.FS.Open(path)
 	if err != nil {
 		return nil, err
 	}
@@ -119,9 +119,9 @@ func ingestLink(
 ) error {
 	for i := range paths {
 		target := dbFilename(dirname, fileTypeTable, meta[i].fileNum)
-		err := opts.VFS.Link(paths[i], target)
+		err := opts.FS.Link(paths[i], target)
 		if err != nil {
-			if err2 := ingestCleanup(opts.VFS, dirname, meta[:i]); err2 != nil {
+			if err2 := ingestCleanup(opts.FS, dirname, meta[:i]); err2 != nil {
 				opts.Logger.Infof("ingest cleanup failed: %v", err2)
 			}
 			return err
@@ -339,7 +339,7 @@ func (d *DB) Ingest(paths []string) error {
 	d.commit.AllocateSeqNum(prepare, apply)
 
 	if err != nil {
-		if err2 := ingestCleanup(d.opts.VFS, d.dirname, meta); err2 != nil {
+		if err2 := ingestCleanup(d.opts.FS, d.dirname, meta); err2 != nil {
 			d.opts.Logger.Infof("ingest cleanup failed: %v", err2)
 		}
 	}

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -49,7 +49,7 @@ func TestIngestLoad(t *testing.T) {
 
 			opts := &db.Options{
 				Comparer: db.DefaultComparer,
-				VFS:      mem,
+				FS:       mem,
 			}
 			meta, err := ingestLoad(opts, []string{"ext"}, []uint64{1})
 			if err != nil {
@@ -129,7 +129,7 @@ func TestIngestLoadRand(t *testing.T) {
 
 	opts := &db.Options{
 		Comparer: db.DefaultComparer,
-		VFS:      mem,
+		FS:       mem,
 	}
 	meta, err := ingestLoad(opts, paths, pending)
 	if err != nil {
@@ -143,7 +143,7 @@ func TestIngestLoadRand(t *testing.T) {
 func TestIngestLoadNonExistent(t *testing.T) {
 	opts := &db.Options{
 		Comparer: db.DefaultComparer,
-		VFS:      vfs.NewMem(),
+		FS:       vfs.NewMem(),
 	}
 	if _, err := ingestLoad(opts, []string{"non-existent"}, []uint64{1}); err == nil {
 		t.Fatalf("expected error, but found success")
@@ -160,7 +160,7 @@ func TestIngestLoadEmpty(t *testing.T) {
 
 	opts := &db.Options{
 		Comparer: db.DefaultComparer,
-		VFS:      mem,
+		FS:       mem,
 	}
 	if _, err := ingestLoad(opts, []string{"empty"}, []uint64{1}); err == nil {
 		t.Fatalf("expected error, but found success")
@@ -245,7 +245,7 @@ func TestIngestLink(t *testing.T) {
 	for i := 0; i <= count; i++ {
 		t.Run("", func(t *testing.T) {
 			mem := vfs.NewMem()
-			opts := &db.Options{VFS: mem}
+			opts := &db.Options{FS: mem}
 			opts.EnsureDefaults()
 			if err := mem.MkdirAll(dir, 0755); err != nil {
 				t.Fatal(err)
@@ -473,7 +473,7 @@ func TestIngest(t *testing.T) {
 	}
 
 	d, err := Open("", &db.Options{
-		VFS:                   mem,
+		FS:                    mem,
 		L0CompactionThreshold: 100,
 	})
 	if err != nil {

--- a/log_recycler_test.go
+++ b/log_recycler_test.go
@@ -76,7 +76,7 @@ func TestLogRecycler(t *testing.T) {
 
 func TestRecycleLogs(t *testing.T) {
 	d, err := Open("", &db.Options{
-		VFS: vfs.NewMem(),
+		FS: vfs.NewMem(),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/open.go
+++ b/open.go
@@ -26,13 +26,13 @@ func createDB(dirname string, opts *db.Options) (retErr error) {
 		nextFileNumber: manifestFileNum + 1,
 	}
 	manifestFilename := dbFilename(dirname, fileTypeManifest, manifestFileNum)
-	f, err := opts.VFS.Create(manifestFilename)
+	f, err := opts.FS.Create(manifestFilename)
 	if err != nil {
 		return fmt.Errorf("pebble: could not create %q: %v", manifestFilename, err)
 	}
 	defer func() {
 		if retErr != nil {
-			opts.VFS.Remove(manifestFilename)
+			opts.FS.Remove(manifestFilename)
 		}
 	}()
 	defer f.Close()
@@ -50,7 +50,7 @@ func createDB(dirname string, opts *db.Options) (retErr error) {
 	if err != nil {
 		return err
 	}
-	return setCurrentFile(dirname, opts.VFS, manifestFileNum)
+	return setCurrentFile(dirname, opts.FS, manifestFileNum)
 }
 
 // Open opens a LevelDB whose files live in the given directory.
@@ -72,7 +72,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 	if tableCacheSize < minTableCacheSize {
 		tableCacheSize = minTableCacheSize
 	}
-	d.tableCache.init(dirname, opts.VFS, d.opts, tableCacheSize)
+	d.tableCache.init(dirname, opts.FS, d.opts, tableCacheSize)
 	d.newIters = d.tableCache.newIters
 	d.commit = newCommitPipeline(commitEnv{
 		logSeqNum:     &d.mu.versions.logSeqNum,
@@ -95,11 +95,11 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 	defer d.mu.Unlock()
 
 	// Lock the database directory.
-	err := opts.VFS.MkdirAll(dirname, 0755)
+	err := opts.FS.MkdirAll(dirname, 0755)
 	if err != nil {
 		return nil, err
 	}
-	fileLock, err := opts.VFS.Lock(dbFilename(dirname, fileTypeLock, 0))
+	fileLock, err := opts.FS.Lock(dbFilename(dirname, fileTypeLock, 0))
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 		}
 	}()
 
-	if _, err := opts.VFS.Stat(dbFilename(dirname, fileTypeCurrent, 0)); os.IsNotExist(err) {
+	if _, err := opts.FS.Stat(dbFilename(dirname, fileTypeCurrent, 0)); os.IsNotExist(err) {
 		// Create the DB if it did not already exist.
 		if err := createDB(dirname, opts); err != nil {
 			return nil, err
@@ -126,7 +126,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 		return nil, err
 	}
 
-	ls, err := opts.VFS.List(dirname)
+	ls, err := opts.FS.List(dirname)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +158,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 	})
 	var ve versionEdit
 	for _, lf := range logFiles {
-		maxSeqNum, err := d.replayWAL(&ve, opts.VFS, filepath.Join(dirname, lf.name), lf.num)
+		maxSeqNum, err := d.replayWAL(&ve, opts.FS, filepath.Join(dirname, lf.name), lf.num)
 		if err != nil {
 			return nil, err
 		}
@@ -172,7 +172,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 	// Create an empty .log file.
 	ve.logNumber = d.mu.versions.nextFileNum()
 	d.mu.log.queue = append(d.mu.log.queue, ve.logNumber)
-	logFile, err := opts.VFS.Create(dbFilename(dirname, fileTypeLog, ve.logNumber))
+	logFile, err := opts.FS.Create(dbFilename(dirname, fileTypeLog, ve.logNumber))
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +190,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 
 	// Write the current options to disk.
 	d.optionsFileNum = d.mu.versions.nextFileNum()
-	optionsFile, err := opts.VFS.Create(dbFilename(dirname, fileTypeOptions, d.optionsFileNum))
+	optionsFile, err := opts.FS.Create(dbFilename(dirname, fileTypeOptions, d.optionsFileNum))
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func (d *DB) replayWAL(
 }
 
 func checkOptions(opts *db.Options, path string) error {
-	f, err := opts.VFS.Open(path)
+	f, err := opts.FS.Open(path)
 	if err != nil {
 		return err
 	}

--- a/open_test.go
+++ b/open_test.go
@@ -23,7 +23,7 @@ func TestErrorIfDBExists(t *testing.T) {
 	for _, b := range [...]bool{false, true} {
 		mem := vfs.NewMem()
 		d0, err := Open("", &db.Options{
-			VFS: mem,
+			FS: mem,
 		})
 		if err != nil {
 			t.Errorf("b=%v: d0 Open: %v", b, err)
@@ -35,7 +35,7 @@ func TestErrorIfDBExists(t *testing.T) {
 		}
 
 		d1, err := Open("", &db.Options{
-			VFS:             mem,
+			FS:              mem,
 			ErrorIfDBExists: b,
 		})
 		if d1 != nil {
@@ -52,7 +52,7 @@ func TestNewDBFilenames(t *testing.T) {
 	fooBar := filepath.Join("foo", "bar")
 	mem := vfs.NewMem()
 	d, err := Open(fooBar, &db.Options{
-		VFS: mem,
+		FS: mem,
 	})
 	if err != nil {
 		t.Fatalf("Open: %v", err)
@@ -79,7 +79,7 @@ func TestNewDBFilenames(t *testing.T) {
 
 func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 	opts := &db.Options{
-		VFS: fs,
+		FS: fs,
 	}
 
 	for _, startFromEmpty := range []bool{false, true} {
@@ -144,7 +144,7 @@ func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 			}
 
 			{
-				got, err := opts.VFS.List(dirname)
+				got, err := opts.FS.List(dirname)
 				if err != nil {
 					t.Fatalf("List: %v", err)
 				}
@@ -189,7 +189,7 @@ func TestOpenCloseOpenClose(t *testing.T) {
 
 func TestOpenOptionsCheck(t *testing.T) {
 	mem := vfs.NewMem()
-	opts := &db.Options{VFS: mem}
+	opts := &db.Options{FS: mem}
 
 	d, err := Open("", opts)
 	if err != nil {
@@ -201,14 +201,14 @@ func TestOpenOptionsCheck(t *testing.T) {
 
 	opts = &db.Options{
 		Comparer: &db.Comparer{Name: "foo"},
-		VFS:      mem,
+		FS:       mem,
 	}
 	_, err = Open("", opts)
 	require.Regexp(t, `comparer name from file.*!=.*`, err)
 
 	opts = &db.Options{
 		Merger: &db.Merger{Name: "bar"},
-		VFS:    mem,
+		FS:     mem,
 	}
 	_, err = Open("", opts)
 	require.Regexp(t, `merger name from file.*!=.*`, err)

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -115,7 +115,7 @@ func TestRangeDel(t *testing.T) {
 func TestRangeDelCompactionTruncation(t *testing.T) {
 	// Use a small target file size so that there is a single key per sstable.
 	d, err := Open("", &db.Options{
-		VFS: vfs.NewMem(),
+		FS: vfs.NewMem(),
 		Levels: []db.LevelOptions{
 			{TargetFileSize: 100},
 			{TargetFileSize: 100},
@@ -249,7 +249,7 @@ func BenchmarkRangeDelIterate(b *testing.B) {
 					mem := vfs.NewMem()
 					d, err := Open("", &db.Options{
 						Cache: cache.New(128 << 20), // 128 MB
-						VFS:   mem,
+						FS:    mem,
 					})
 					if err != nil {
 						b.Fatal(err)

--- a/read_state_test.go
+++ b/read_state_test.go
@@ -16,7 +16,7 @@ import (
 
 func BenchmarkReadState(b *testing.B) {
 	d, err := Open("", &db.Options{
-		VFS: vfs.NewMem(),
+		FS: vfs.NewMem(),
 	})
 	if err != nil {
 		b.Fatal(err)

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -49,7 +49,7 @@ func TestSnapshot(t *testing.T) {
 		case "define":
 			var err error
 			d, err = Open("", &db.Options{
-				VFS: vfs.NewMem(),
+				FS: vfs.NewMem(),
 			})
 			if err != nil {
 				return err.Error()

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -1,0 +1,82 @@
+open
+----
+open-dir: db
+create: db/MANIFEST-000001
+create: db/CURRENT.000001.dbtmp
+sync: db/CURRENT.000001.dbtmp
+rename: db/CURRENT.000001.dbtmp -> db/CURRENT
+sync: db
+create: db/000002.log
+sync: db
+create: db/MANIFEST-000003
+sync: db/MANIFEST-000003
+create: db/CURRENT.000003.dbtmp
+sync: db/CURRENT.000003.dbtmp
+rename: db/CURRENT.000003.dbtmp -> db/CURRENT
+sync: db
+create: db/OPTIONS-000004
+sync: db
+
+flush
+----
+sync: db/000002.log
+create: db/000005.log
+sync: db
+sync: db/000002.log
+#2: WAL created: 5 recycled=0
+#3: flush begin
+create: db/000006.sst
+sync: db/000006.sst
+sync: db
+#3: flush end: 6
+create: db/MANIFEST-000007
+sync: db/MANIFEST-000007
+create: db/CURRENT.000007.dbtmp
+sync: db/CURRENT.000007.dbtmp
+rename: db/CURRENT.000007.dbtmp -> db/CURRENT
+sync: db
+
+compact
+----
+sync: db/000005.log
+rename: db/000002.log -> db/000008.log
+create: db/000008.log
+sync: db
+sync: db/000005.log
+#4: WAL created: 8 recycled=2
+#5: flush begin
+create: db/000009.sst
+sync: db/000009.sst
+sync: db
+#5: flush end: 9
+create: db/MANIFEST-000010
+sync: db/MANIFEST-000010
+create: db/CURRENT.000010.dbtmp
+sync: db/CURRENT.000010.dbtmp
+rename: db/CURRENT.000010.dbtmp -> db/CURRENT
+sync: db
+#6: compaction begin: L0 -> L1
+create: db/000011.sst
+sync: db/000011.sst
+sync: db
+#6: compaction end: L0 -> L1
+create: db/MANIFEST-000012
+sync: db/MANIFEST-000012
+create: db/CURRENT.000012.dbtmp
+sync: db/CURRENT.000012.dbtmp
+rename: db/CURRENT.000012.dbtmp -> db/CURRENT
+sync: db
+#6: table deleted: 6
+#6: table deleted: 9
+
+ingest
+----
+link: ext/0 -> db/000013.sst
+sync: db
+create: db/MANIFEST-000014
+sync: db/MANIFEST-000014
+create: db/CURRENT.000014.dbtmp
+sync: db/CURRENT.000014.dbtmp
+rename: db/CURRENT.000014.dbtmp -> db/CURRENT
+sync: db
+#7: table ingested

--- a/version_set.go
+++ b/version_set.go
@@ -59,7 +59,7 @@ func (vs *versionSet) load(dirname string, opts *db.Options, mu *sync.Mutex) err
 	vs.versions.mu = mu
 	vs.writerCond.L = mu
 	vs.opts = opts
-	vs.fs = opts.VFS
+	vs.fs = opts.FS
 	vs.cmp = opts.Comparer.Compare
 	vs.cmpName = opts.Comparer.Name
 	vs.versions.init()

--- a/version_set.go
+++ b/version_set.go
@@ -157,7 +157,7 @@ func (vs *versionSet) load(dirname string, opts *db.Options, mu *sync.Mutex) err
 // to the current version, and installs the new version. DB.mu must be held
 // when calling this method and will be released temporarily while performing
 // file I/O.
-func (vs *versionSet) logAndApply(ve *versionEdit) error {
+func (vs *versionSet) logAndApply(ve *versionEdit, dir vfs.File) error {
 	// Wait for any existing writing to the manifest to complete, then mark the
 	// manifest as busy.
 	for vs.writing {
@@ -221,6 +221,9 @@ func (vs *versionSet) logAndApply(ve *versionEdit) error {
 		}
 		if newManifestFileNumber != 0 {
 			if err := setCurrentFile(vs.dirname, vs.fs, newManifestFileNumber); err != nil {
+				return err
+			}
+			if err := dir.Sync(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Whenever an sstable is created (due to flush or compaction) or a WAL or
MANIFEST is created, we need to sync the parent directory in order to
ensure that the directory update is persisted to disk.

Set O_CLOEXEC and all of the files created and opened by Pebble, to
match RocksDB behavior.

Fixes #125