### PR TITLE
Remove TODO about the presence of a LOCK file

### DIFF
--- a/open_test.go
+++ b/open_test.go
@@ -65,7 +65,6 @@ func TestNewDBFilenames(t *testing.T) {
 		t.Fatalf("List: %v", err)
 	}
 	sort.Strings(got)
-	// TODO(peter): should there be a LOCK file here?
 	want := []string{
 		"000002.log",
 		"CURRENT",


### PR DESCRIPTION
The answer is no. We don't expect a LOCK file when using a `memFS` as
`memFS.Lock` is a no-op.