### PR TITLE
Support storing WALs in a separate directory

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -303,7 +303,7 @@ func runDBDefineCmd(td *datadriven.TestData) (*DB, error) {
 	}
 
 	if len(ve.newFiles) > 0 {
-		if err := d.mu.versions.logAndApply(ve, d.dir); err != nil {
+		if err := d.mu.versions.logAndApply(ve, d.dataDir); err != nil {
 			return nil, err
 		}
 		d.updateReadStateLocked()

--- a/db/options.go
+++ b/db/options.go
@@ -286,6 +286,11 @@ type Options struct {
 	// of TableFormatRocksDBv2. We should ensure it is only used when writing an
 	// sstable directly, and not used when opening a database.
 	TableFormat TableFormat
+
+	// WALDir specifies the directory to store write-ahead logs (WALs) in. If
+	// empty (the default), WALs will be stored in the same directory as sstables
+	// (i.e. the directory passed to pebble.Open).
+	WALDir string
 }
 
 // EnsureDefaults ensures that the default values for all options are set if a
@@ -385,6 +390,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  mem_table_size=%d\n", o.MemTableSize)
 	fmt.Fprintf(&buf, "  mem_table_stop_writes_threshold=%d\n", o.MemTableStopWritesThreshold)
 	fmt.Fprintf(&buf, "  merger=%s\n", o.Merger.Name)
+	fmt.Fprintf(&buf, "  wal_dir=%s\n", o.WALDir)
 
 	for i := range o.Levels {
 		l := &o.Levels[i]

--- a/db/options_test.go
+++ b/db/options_test.go
@@ -53,6 +53,7 @@ func TestOptionsString(t *testing.T) {
   mem_table_size=4194304
   mem_table_stop_writes_threshold=2
   merger=pebble.concatenate
+  wal_dir=
 
 [Level "0"]
   block_restart_interval=16

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -135,6 +135,7 @@ func TestEventListener(t *testing.T) {
 				FS:                  loggingFS{mem, &buf},
 				EventListener:       newLoggingEventListener(&buf),
 				MaxManifestFileSize: 1,
+				WALDir:              "wal",
 			})
 			if err != nil {
 				return err.Error()

--- a/ingest.go
+++ b/ingest.go
@@ -289,7 +289,7 @@ func (d *DB) Ingest(paths []string) error {
 	// point before we update the MANIFEST (via logAndApply), otherwise a crash
 	// can have the tables referenced in the MANIFEST, but not present in the
 	// directory.
-	if err := d.dir.Sync(); err != nil {
+	if err := d.dataDir.Sync(); err != nil {
 		return err
 	}
 
@@ -389,7 +389,7 @@ func (d *DB) ingestApply(meta []*fileMetadata) (*versionEdit, error) {
 		ve.newFiles[i].level = ingestTargetLevel(d.cmp, current, m)
 		ve.newFiles[i].meta = *m
 	}
-	if err := d.mu.versions.logAndApply(ve, d.dir); err != nil {
+	if err := d.mu.versions.logAndApply(ve, d.dataDir); err != nil {
 		return nil, err
 	}
 	d.updateReadStateLocked()

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -1,13 +1,14 @@
 open
 ----
 open-dir: db
+open-dir: wal
 create: db/MANIFEST-000001
 create: db/CURRENT.000001.dbtmp
 sync: db/CURRENT.000001.dbtmp
 rename: db/CURRENT.000001.dbtmp -> db/CURRENT
 sync: db
-create: db/000002.log
-sync: db
+create: wal/000002.log
+sync: wal
 create: db/MANIFEST-000003
 sync: db/MANIFEST-000003
 create: db/CURRENT.000003.dbtmp
@@ -19,10 +20,10 @@ sync: db
 
 flush
 ----
-sync: db/000002.log
-create: db/000005.log
-sync: db
-sync: db/000002.log
+sync: wal/000002.log
+create: wal/000005.log
+sync: wal
+sync: wal/000002.log
 #2: WAL created: 5 recycled=0
 #3: flush begin
 create: db/000006.sst
@@ -38,11 +39,11 @@ sync: db
 
 compact
 ----
-sync: db/000005.log
-rename: db/000002.log -> db/000008.log
-create: db/000008.log
-sync: db
-sync: db/000005.log
+sync: wal/000005.log
+rename: wal/000002.log -> wal/000008.log
+create: wal/000008.log
+sync: wal
+sync: wal/000005.log
 #4: WAL created: 8 recycled=2
 #5: flush begin
 create: db/000009.sst


### PR DESCRIPTION
Add `Options.WALDir` which specifies the directory to store write-ahead
logs in. This allows write-ahead logs to be stored on faster disk than
sstables. For example, write-ahead logs could be stored on
battery-backed SSD, while sstables are stored on spinning disk. Or
write-ahead logs could be stored on an Optane drive, while sstables are
stored on SSDs. If `Options.WALDir` is empty, write-ahead logs are
stored in the primary data directory.

Fixes #65