### PR TITLE
Fix behavior of `ycsb --num-ops=0`

### DIFF
--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -140,7 +140,8 @@ func runYcsb(cmd *cobra.Command, args []string) error {
 							elapsed := time.Since(start)
 							writeLatency.Record(elapsed)
 						}
-						if atomic.AddUint64(&numSuccess, 1) >= ycsbConfig.numOps {
+						if ycsbConfig.numOps > 0 &&
+							atomic.AddUint64(&numSuccess, 1) >= ycsbConfig.numOps {
 							break
 						}
 					}


### PR DESCRIPTION
Make `--num-ops=0` really mean unlimited. Previously it was causing
`ycsb` to exit as soon as the first set of ops completed.