### PR TITLE
Add basic level / compaction metrics

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -974,8 +974,8 @@ func (b *flushableBatch) readyForFlush() bool {
 	return true
 }
 
-func (b *flushableBatch) logNumber() uint64 {
-	return b.logNum
+func (b *flushableBatch) logInfo() (uint64, uint64) {
+	return b.logNum, 0 /* logSize */
 }
 
 // Note: flushableBatchIter mirrors the implementation of batchIter. Keep the

--- a/cmd/pebble/test.go
+++ b/cmd/pebble/test.go
@@ -240,6 +240,7 @@ func runTest(dir string, t test) {
 
 		case <-done:
 			t.done(time.Since(start))
+			fmt.Printf("%s", db.Metrics())
 			return
 		}
 	}

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -183,6 +183,9 @@ func TestEventListener(t *testing.T) {
 			}
 			return buf.String()
 
+		case "metrics":
+			return d.Metrics().String()
+
 		default:
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
 		}

--- a/internal/datadriven/datadriven_test.go
+++ b/internal/datadriven/datadriven_test.go
@@ -17,13 +17,9 @@ package datadriven
 import (
 	"fmt"
 	"testing"
-
-	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestDataDriven(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
 	input := `
 # NB: we allow duplicate args. It's unclear at this time whether this is useful,
 # either way, ScanArgs simply picks the first occurrence.

--- a/internal/humanize/humanize.go
+++ b/internal/humanize/humanize.go
@@ -1,0 +1,34 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package humanize
+
+import (
+	"fmt"
+	"math"
+)
+
+var sizes = []string{"B", "K", "M", "G", "T", "P", "E"}
+
+func logn(n, b float64) float64 {
+	return math.Log(n) / math.Log(b)
+}
+
+// Uint64 produces a human readable representation of the value.
+func Uint64(s uint64) string {
+	const base = 1024
+
+	if s < 10 {
+		return fmt.Sprintf("%d B", s)
+	}
+	e := math.Floor(logn(float64(s), base))
+	suffix := sizes[int(e)]
+	val := math.Floor(float64(s)/math.Pow(base, e)*10+0.5) / 10
+	f := "%.0f %s"
+	if val < 10 {
+		f = "%.1f %s"
+	}
+
+	return fmt.Sprintf(f, val, suffix)
+}

--- a/internal/record/log_writer.go
+++ b/internal/record/log_writer.go
@@ -291,6 +291,11 @@ func (w *LogWriter) WriteRecord(p []byte) (int64, error) {
 	return offset, w.err
 }
 
+// Size returns the current size of the file.
+func (w *LogWriter) Size() int64 {
+	return w.blockNum*blockSize + int64(w.block.written)
+}
+
 func (w *LogWriter) emitFragment(n int, p []byte) []byte {
 	b := w.block
 	i := b.written

--- a/mem_table.go
+++ b/mem_table.go
@@ -54,6 +54,7 @@ type memTable struct {
 	flushedCh   chan struct{}
 	tombstones  rangeTombstoneCache
 	logNum      uint64
+	logSize     uint64
 }
 
 // newMemTable returns a new MemTable.
@@ -95,8 +96,8 @@ func (m *memTable) readyForFlush() bool {
 	return atomic.LoadInt32(&m.refs) == 0
 }
 
-func (m *memTable) logNumber() uint64 {
-	return m.logNum
+func (m *memTable) logInfo() (uint64, uint64) {
+	return m.logNum, m.logSize
 }
 
 // Get gets the value for the given key. It returns ErrNotFound if the DB does

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,140 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/petermattis/pebble/internal/humanize"
+)
+
+// LevelMetrics holds per-level metrics such as the number of files and total
+// size of the files, and compaction related metrics.
+type LevelMetrics struct {
+	// The total number of files in the level.
+	NumFiles uint64
+	// The total size in bytes of the files in the level.
+	Size uint64
+	// The level's compaction score.
+	Score float64
+	// The number of incoming bytes from other levels read during
+	// compactions. This excludes bytes moved and bytes ingested. For L0 this is
+	// the bytes written to the WAL.
+	BytesIn uint64
+	// The number of bytes ingested.
+	BytesIngested uint64
+	// The number of bytes moved into the level by a "move" compaction.
+	BytesMoved uint64
+	// The number of bytes read for compactions at the level. This includes bytes
+	// read from other levels (BytesIn), as well as bytes read for the level.
+	BytesRead uint64
+	// The number of bytes written during compactions.
+	BytesWritten uint64
+}
+
+// Add updates the counter metrics for the level.
+func (m *LevelMetrics) Add(u *LevelMetrics) {
+	m.BytesIn += u.BytesIn
+	m.BytesIngested += u.BytesIngested
+	m.BytesMoved += u.BytesMoved
+	m.BytesRead += u.BytesRead
+	m.BytesWritten += u.BytesWritten
+}
+
+// WriteAmp computes the write amplification for compactions at this
+// level. Computed as BytesWritten / BytesIn.
+func (m *LevelMetrics) WriteAmp() float64 {
+	if m.BytesIn == 0 {
+		return 0
+	}
+	return float64(m.BytesWritten) / float64(m.BytesIn)
+}
+
+func (m *LevelMetrics) format(buf *bytes.Buffer) {
+	fmt.Fprintf(buf, "%6d %7s %7.2f %7s %7s %7s %7s %7s %7.1f\n",
+		m.NumFiles,
+		humanize.Uint64(m.Size),
+		m.Score,
+		humanize.Uint64(m.BytesIn),
+		humanize.Uint64(m.BytesIngested),
+		humanize.Uint64(m.BytesMoved),
+		humanize.Uint64(m.BytesRead),
+		humanize.Uint64(m.BytesWritten),
+		m.WriteAmp(),
+	)
+}
+
+// VersionMetrics holds metrics for each level.
+type VersionMetrics struct {
+	WAL struct {
+		// Number of live WAL files.
+		Files uint64
+		// Size of the live data in the WAL files. Note that with WAL file
+		// recycling this is less than the actual on-disk size of the WAL files.
+		Size uint64
+		// Number of logical bytes written to the WAL.
+		BytesIn uint64
+		// Number of bytes written to the WAL.
+		BytesWritten uint64
+	}
+	Levels [numLevels]LevelMetrics
+}
+
+func (m *VersionMetrics) formatWAL(buf *bytes.Buffer) {
+	var writeAmp float64
+	if m.WAL.BytesIn > 0 {
+		writeAmp = float64(m.WAL.BytesWritten) / float64(m.WAL.BytesIn)
+	}
+	fmt.Fprintf(buf, "  WAL %6d %7s       - %7s       -       -       - %7s %7.1f\n",
+		m.WAL.Files,
+		humanize.Uint64(m.WAL.Size),
+		humanize.Uint64(m.WAL.BytesIn),
+		humanize.Uint64(m.WAL.BytesWritten),
+		writeAmp)
+}
+
+// Pretty-print the metrics, showing a line for the WAL, a line per-level, and
+// a total:
+//
+//   level__files____size___score______in__ingest____move____read___write___w-amp
+//     WAL      1    53 M       -   744 M       -       -       -   765 M     1.0
+//       0      6   285 M    3.00   712 M     0 B     0 B     0 B   707 M     1.0
+//       1      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
+//       2      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
+//       3      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
+//       4      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
+//       5     80   312 M    1.09   328 M     0 B     0 B   580 M   580 M     1.8
+//       6     23   110 M    0.35   110 M     0 B     0 B   146 M   146 M     1.3
+//   total    109   706 M    0.00   765 M     0 B     0 B   726 M   2.1 G     2.9
+//
+// The WAL "in" metric is the size of the batches written to the WAL. The WAL
+// "write" metric is the size of the physical data written to the WAL which
+// includes record fragment overhead. Write amplification is computed as
+// bytes-written / bytes-in, except for the total row where bytes-in is
+// replaced with WAL-bytes-written + bytes-ingested.
+func (m *VersionMetrics) String() string {
+	var buf bytes.Buffer
+	var total LevelMetrics
+	fmt.Fprintf(&buf, "level__files____size___score______in__ingest____move____read___write___w-amp\n")
+	m.formatWAL(&buf)
+	for level := 0; level < numLevels; level++ {
+		l := &m.Levels[level]
+		fmt.Fprintf(&buf, "%5d ", level)
+		l.format(&buf)
+		total.Add(l)
+		total.NumFiles += l.NumFiles
+		total.Size += l.Size
+	}
+	// Compute total bytes-in as the bytes written to the WAL + bytes ingested
+	total.BytesIn = m.WAL.BytesWritten + total.BytesIngested
+	// Add the total bytes-in to the total bytes-written. This is to account for
+	// the bytes written to the log and bytes written externally and then
+	// ingested.
+	total.BytesWritten += total.BytesIn
+	fmt.Fprintf(&buf, "total ")
+	total.format(&buf)
+	return buf.String()
+}

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -81,3 +81,16 @@ sync: db/CURRENT.000014.dbtmp
 rename: db/CURRENT.000014.dbtmp -> db/CURRENT
 sync: db
 #7: table ingested
+
+metrics
+----
+level__files____size___score______in__ingest____move____read___write___w-amp
+  WAL      0    27 B       -    32 B       -       -       -    81 B     2.5
+    0      0     0 B    0.00    54 B     0 B     0 B     0 B   1.9 K    35.5
+    1      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
+    2      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
+    3      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
+    4      0     0 B    0.00     0 B     0 B     0 B     0 B     0 B     0.0
+    5      1   959 B    0.00     0 B   959 B     0 B     0 B     0 B     0.0
+    6      1   959 B    0.00   1.9 K     0 B     0 B   1.9 K   959 B     0.5
+total      2   1.9 K    0.00   1.0 K   959 B     0 B   1.9 K   3.8 K     3.8

--- a/version_edit.go
+++ b/version_edit.go
@@ -74,6 +74,7 @@ type versionEdit struct {
 	lastSequence   uint64
 	deletedFiles   map[deletedFileEntry]bool // A set of deletedFileEntry values.
 	newFiles       []newFileEntry
+	metrics        map[int]*LevelMetrics // level -> metrics update
 }
 
 func (v *versionEdit) decode(r io.Reader) error {


### PR DESCRIPTION
Track level metrics during flushes, compactions, and ingestion. Provide a
pretty-printer for thes metrics which shows per-level num-files, size,
bytes-in, bytes-ingested, bytes-moved, bytes-read, bytes-written, and
write-amplification. Also show a total across all levels, as well as WAL
bytes in, and written.