### PR TITLE
Add support for prefix iterators

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -473,8 +473,8 @@ func (b *Batch) Repr() []byte {
 }
 
 // NewIter returns an iterator that is unpositioned (Iterator.Valid() will
-// return false). The iterator can be positioned via a call to SeekGE, SeekLT,
-// First or Last. Only indexed batches support iterators.
+// return false). The iterator can be positioned via a call to SeekGE,
+// SeekPrefixGE, SeekLT, First or Last. Only indexed batches support iterators.
 func (b *Batch) NewIter(o *db.IterOptions) *Iterator {
 	if b.index == nil {
 		return &Iterator{err: ErrNotIndexed}
@@ -752,6 +752,10 @@ func (i *batchIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
 	return ikey, i.Value()
 }
 
+func (i *batchIter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+	return i.SeekGE(key)
+}
+
 func (i *batchIter) SeekLT(key []byte) (*db.InternalKey, []byte) {
 	ikey := i.iter.SeekLT(key)
 	if ikey == nil {
@@ -1004,6 +1008,10 @@ func (i *flushableBatchIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
 	}
 	i.key = i.getKey(i.index)
 	return &i.key, i.Value()
+}
+
+func (i *flushableBatchIter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+	return i.SeekGE(key)
 }
 
 func (i *flushableBatchIter) SeekLT(key []byte) (*db.InternalKey, []byte) {

--- a/db.go
+++ b/db.go
@@ -135,6 +135,7 @@ type DB struct {
 	cmp            db.Compare
 	equal          db.Equal
 	merge          db.Merge
+	split          db.Split
 	abbreviatedKey db.AbbreviatedKey
 
 	dataDir vfs.File
@@ -254,6 +255,7 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, error) {
 	i.cmp = d.cmp
 	i.equal = d.equal
 	i.merge = d.merge
+	i.split = d.split
 	i.iter = get
 	i.readState = readState
 
@@ -452,6 +454,7 @@ func (d *DB) newIterInternal(
 	dbi.cmp = d.cmp
 	dbi.equal = d.equal
 	dbi.merge = d.merge
+	dbi.split = d.split
 	dbi.readState = readState
 
 	iters := buf.iters[:0]

--- a/db/comparer.go
+++ b/db/comparer.go
@@ -80,9 +80,10 @@ type Successor func(dst, a []byte) []byte
 // The returned prefix must have the following properties (where a and b are
 // feasible):
 //
-// 1) Compare(prefix(a), a) <= 0,
-// 2) If Compare(a, b) <= 0, then Compare(prefix(a), prefix(b)) <= 0
-// 3) if b begins with a, then prefix(b) = prefix(a).
+// 1) bytes.HasPrefix(a, prefix(a))
+// 2) Compare(prefix(a), a) <= 0,
+// 3) If Compare(a, b) <= 0, then Compare(prefix(a), prefix(b)) <= 0
+// 4) if b begins with a, then prefix(b) = prefix(a).
 type Split func(a []byte) int
 
 // Comparer defines a total ordering over the space of []byte keys: a 'less

--- a/db/options.go
+++ b/db/options.go
@@ -483,20 +483,6 @@ type IterOptions struct {
 	//
 	// TODO(peter): unimplemented.
 	// TableFilter func(userProps map[string]string) bool
-
-	// If Prefix is true, the iterator will only be used to iterate over keys
-	// matching that of the key it is first positioned at. If the Comparer was
-	// supplied with a user-defined Split function and bloom filters are
-	// enabled, this allows for improved performance by skipping SSTables known
-	// not to contain the given prefix. The iterator will not properly observe
-	// keys not matching the prefix.
-	//
-	// TODO(tbg): should an assertion trip if the first key's prefix is unstable?
-	// TODO(tbg): should Prefix override (or sharpen) {Lower,Upper}Bound? When
-	// we see the first key, we get the prefix and a separator which should be
-	// a good {Lower,Upper}Bound.
-	// TODO(tbg): unimplemented.
-	// Prefix bool
 }
 
 // GetLowerBound returns the LowerBound or nil if the receiver is nil.

--- a/error_iter.go
+++ b/error_iter.go
@@ -20,6 +20,10 @@ func (c *errorIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
 	return nil, nil
 }
 
+func (c *errorIter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+	return nil, nil
+}
+
 func (c *errorIter) SeekLT(key []byte) (*db.InternalKey, []byte) {
 	return nil, nil
 }

--- a/get_iter.go
+++ b/get_iter.go
@@ -40,6 +40,10 @@ func (g *getIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
 
+func (g *getIter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+	panic("pebble: SeekPrefixGE unimplemented")
+}
+
 func (g *getIter) SeekLT(key []byte) (*db.InternalKey, []byte) {
 	panic("pebble: SeekLT unimplemented")
 }

--- a/internal.go
+++ b/internal.go
@@ -32,6 +32,14 @@ type internalIterator interface {
 	// is pointing at a valid entry, and (nil, nil) otherwise.
 	SeekGE(key []byte) (*db.InternalKey, []byte)
 
+	// SeekPrefixGE moves the iterator to the first key/value pair whose key
+	// starts with the given prefix and is greater than or equal to the given
+	// key. Returns the key and value if the iterator is pointing at a valid
+	// entry, and (nil, nil) otherwise. Note that the iterator will still observe
+	// keys not matching the prefix. It is up to the user to check if the prefix
+	// matches, and iteration beyond the prefix is undefined.
+	SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte)
+
 	// SeekLT moves the iterator to the last key/value pair whose key is less
 	// than the given key. Returns the key and value if the iterator is pointing
 	// at a valid entry, and (nil, nil) otherwise.

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -84,6 +84,10 @@ func (it *Iterator) SeekGE(key []byte) (*db.InternalKey, []byte) {
 	return &it.key, it.Value()
 }
 
+func (it *Iterator) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+	return it.SeekGE(key)
+}
+
 // SeekLT moves the iterator to the last entry whose key is less than the given
 // key. Returns the key and value if the iterator is pointing at a valid entry,
 // and (nil, nil) otherwise. Note that SeekLT only checks the lower bound. It

--- a/internal/arenaskl/skl_test.go
+++ b/internal/arenaskl/skl_test.go
@@ -61,6 +61,10 @@ func (i *iterAdapter) SeekGE(key []byte) bool {
 	return i.verify(i.Iterator.SeekGE(key))
 }
 
+func (i *iterAdapter) SeekPrefixGE(prefix, key []byte) bool {
+	return i.verify(i.Iterator.SeekPrefixGE(prefix, key))
+}
+
 func (i *iterAdapter) SeekLT(key []byte) bool {
 	return i.verify(i.Iterator.SeekLT(key))
 }

--- a/internal/rangedel/iter.go
+++ b/internal/rangedel/iter.go
@@ -52,6 +52,11 @@ func (i *Iter) SeekGE(key []byte) (*db.InternalKey, []byte) {
 	return &t.Start, t.End
 }
 
+func (i *Iter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+	// This should never be called as prefix iteration is only done for point records.
+	panic("pebble: SeekPrefixGE unimplemented")
+}
+
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
 // package.
 func (i *Iter) SeekLT(key []byte) (*db.InternalKey, []byte) {

--- a/internal_test.go
+++ b/internal_test.go
@@ -39,6 +39,10 @@ func (i *internalIterAdapter) SeekGE(key []byte) bool {
 	return i.verify(i.internalIterator.SeekGE(key))
 }
 
+func (i *internalIterAdapter) SeekPrefixGE(prefix, key []byte) bool {
+	return i.verify(i.internalIterator.SeekPrefixGE(prefix, key))
+}
+
 func (i *internalIterAdapter) SeekLT(key []byte) bool {
 	return i.verify(i.internalIterator.SeekLT(key))
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -77,6 +77,10 @@ func (f *fakeIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
 	return nil, nil
 }
 
+func (f *fakeIter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+	return f.SeekGE(key)
+}
+
 func (f *fakeIter) SeekLT(key []byte) (*db.InternalKey, []byte) {
 	f.valid = false
 	for f.index = len(f.keys) - 1; f.index >= 0; f.index-- {
@@ -295,6 +299,7 @@ func TestIterator(t *testing.T) {
 	newIter := func(seqNum uint64, opts *db.IterOptions) *Iterator {
 		cmp := db.DefaultComparer.Compare
 		equal := db.DefaultComparer.Equal
+		split := func(a []byte) int { return len(a) }
 		// NB: Use a mergingIter to filter entries newer than seqNum.
 		iter := newMergingIter(cmp, &fakeIter{
 			lower: opts.GetLowerBound(),
@@ -307,6 +312,7 @@ func TestIterator(t *testing.T) {
 			opts:  opts,
 			cmp:   cmp,
 			equal: equal,
+			split: split,
 			merge: db.DefaultMerger.Merge,
 			iter:  iter,
 		}

--- a/level_iter.go
+++ b/level_iter.go
@@ -206,6 +206,18 @@ func (l *levelIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
 	return l.skipEmptyFileForward()
 }
 
+func (l *levelIter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+	// NB: the top-level Iterator has already adjusted key based on
+	// IterOptions.LowerBound.
+	if !l.loadFile(l.findFileGE(key), 1) {
+		return nil, nil
+	}
+	if key, val := l.iter.SeekPrefixGE(prefix, key); key != nil {
+		return key, val
+	}
+	return l.skipEmptyFileForward()
+}
+
 func (l *levelIter) SeekLT(key []byte) (*db.InternalKey, []byte) {
 	// NB: the top-level Iterator has already adjusted key based on
 	// IterOptions.UpperBound.

--- a/open.go
+++ b/open.go
@@ -63,6 +63,7 @@ func Open(dirname string, opts *db.Options) (*DB, error) {
 		cmp:            opts.Comparer.Compare,
 		equal:          opts.Comparer.Equal,
 		merge:          opts.Merger.Merge,
+		split:          opts.Comparer.Split,
 		abbreviatedKey: opts.Comparer.AbbreviatedKey,
 		logRecycler:    logRecycler{limit: opts.MemTableStopWritesThreshold + 1},
 	}

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -354,6 +354,13 @@ func (i *blockIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
 	return nil, nil
 }
 
+// SeekPrefixGE implements internalIterator.SeekPrefixGE, as documented in the
+// pebble package.
+func (i *blockIter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+	// This should never be called as prefix iteration is handled by sstable.Iterator.
+	panic("pebble: SeekPrefixGE unimplemented")
+}
+
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
 // package.
 func (i *blockIter) SeekLT(key []byte) (*db.InternalKey, []byte) {

--- a/sstable/raw_block.go
+++ b/sstable/raw_block.go
@@ -142,6 +142,13 @@ func (i *rawBlockIter) SeekGE(key []byte) bool {
 	return i.Valid()
 }
 
+// SeekPrefixGE implements internalIterator.SeekPrefixGE, as documented in the
+// pebble package.
+func (i *rawBlockIter) SeekPrefixGE(key []byte) bool {
+	// This should never be called as prefix iteration is never used with raw blocks.
+	panic("pebble: SeekPrefixGE unimplemented")
+}
+
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
 // package.
 func (i *rawBlockIter) SeekLT(key []byte) bool {

--- a/sstable/testdata/prefixreader/bloom
+++ b/sstable/testdata/prefixreader/bloom
@@ -1,0 +1,18 @@
+build
+a:1=A,aa:2=AA,aaa:3=AAA,aaaa:4=AAAA,b:5=B
+----
+
+get
+b
+ab
+a
+aaa
+aa
+aaaa
+----
+B
+<err: pebble: not found>
+A
+AAA
+AA
+AAAA

--- a/sstable/testdata/prefixreader/iter
+++ b/sstable/testdata/prefixreader/iter
@@ -1,0 +1,196 @@
+build
+a:1=A,aa:2=AA,c:3=C,d:4=D
+----
+
+iter
+seek-prefix-ge a
+next
+next
+----
+<a:1><aa:2>.
+
+iter
+seek-prefix-ge aa
+next
+----
+<aa:2>.
+
+iter
+seek-prefix-ge aa
+prev
+----
+<aa:2>.
+
+iter
+seek-prefix-ge c
+prev
+----
+<c:3>.
+
+iter
+seek-prefix-ge b
+----
+.
+
+iter
+seek-prefix-ge c
+next
+----
+<c:3>.
+
+iter
+seek-prefix-ge d
+next
+----
+<d:4>.
+
+iter
+seek-prefix-ge e
+----
+.
+
+iter
+seek-prefix-ge c
+seek-prefix-ge d
+seek-prefix-ge e
+----
+<c:3><d:4>.
+
+iter
+seek-prefix-ge c
+next
+seek-prefix-ge a
+next
+next
+----
+<c:3>.<a:1><aa:2>.
+
+iter
+seek-prefix-ge aa
+next
+seek-prefix-ge a
+next
+next
+seek-prefix-ge c
+next
+----
+<aa:2>.<a:1><aa:2>.<c:3>.
+
+iter
+seek-prefix-ge c
+next
+seek-prefix-ge aa
+next
+seek-prefix-ge a
+next
+next
+----
+<c:3>.<aa:2>.<a:1><aa:2>.
+
+iter
+seek-prefix-ge a
+next
+next
+----
+<a:1><aa:2>.
+
+iter
+seek-prefix-ge a
+next
+prev
+prev
+----
+<a:1><aa:2><a:1>.
+
+iter
+seek-prefix-ge a
+prev
+----
+<a:1>.
+
+iter
+seek-prefix-ge a
+seek-ge a
+next
+next
+next
+next
+----
+<a:1><a:1><aa:2><c:3><d:4>.
+
+iter
+seek-prefix-ge a
+seek-ge aa
+next
+next
+next
+----
+<a:1><aa:2><c:3><d:4>.
+
+iter
+seek-prefix-ge aa
+seek-ge c
+next
+next
+----
+<aa:2><c:3><d:4>.
+
+iter
+seek-prefix-ge aa
+seek-lt c
+next
+next
+next
+----
+<aa:2><aa:2><c:3><d:4>.
+
+iter
+seek-prefix-ge aa
+seek-lt c
+prev
+prev
+----
+<aa:2><aa:2><a:1>.
+
+iter
+seek-lt c
+seek-prefix-ge aa
+prev
+----
+<aa:2><aa:2>.
+
+iter
+seek-lt c
+seek-prefix-ge a
+next
+next
+
+----
+<aa:2><a:1><aa:2>.
+
+iter
+seek-ge aa
+seek-prefix-ge a
+next
+next
+
+----
+<aa:2><a:1><aa:2>.
+
+iter
+seek-prefix-ge 1
+----
+.
+
+get
+a
+aa
+f
+d
+c
+----
+A
+AA
+<err: pebble: not found>
+D
+C

--- a/testdata/internal_iter_next
+++ b/testdata/internal_iter_next
@@ -16,6 +16,10 @@ seek-lt a
 seek-lt b
 seek-lt c
 seek-lt d
+seek-prefix-ge a
+seek-prefix-ge b
+seek-prefix-ge c
+seek-prefix-ge d
 ----
 a:2
 b:2
@@ -25,6 +29,10 @@ c:2
 a:1
 b:1
 c:1
+a:2
+b:2
+c:2
+.
 
 iter
 first

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -45,6 +45,24 @@ a:c
 .
 a:c
 
+iter seq=2
+seek-prefix-ge a
+next
+prev
+----
+a:b
+.
+a:b
+
+iter seq=3
+seek-prefix-ge a
+next
+prev
+----
+a:c
+.
+a:c
+
 
 define
 a.DEL.2:
@@ -77,6 +95,15 @@ a:b
 .
 a:b
 
+iter seq=3
+seek-prefix-ge a
+----
+.
+
+iter seq=2
+seek-prefix-ge 1
+----
+.
 
 define
 a.DEL.2:
@@ -98,6 +125,21 @@ seek-ge a
 
 iter seq=2
 seek-ge a
+----
+a:b
+
+iter seq=4
+seek-prefix-ge a
+----
+.
+
+iter seq=3
+seek-prefix-ge a
+----
+.
+
+iter seq=2
+seek-prefix-ge a
 ----
 a:b
 
@@ -170,6 +212,35 @@ a:a
 .
 a:a
 
+iter seq=4
+seek-prefix-ge a
+next
+----
+a:a
+.
+
+iter seq=4
+seek-prefix-ge b
+next
+----
+b:b
+.
+
+
+iter seq=4
+seek-prefix-ge c
+next
+----
+c:c
+.
+
+
+iter seq=4
+seek-prefix-ge d
+----
+.
+
+
 define
 a.SET.b2:b
 b.SET.2:c
@@ -211,6 +282,187 @@ next
 a:b
 .
 a:b
+
+iter seq=2
+seek-prefix-ge a
+next
+prev
+----
+a:b
+.
+a:b
+
+iter seq=2
+seek-prefix-ge b
+----
+.
+
+
+define
+a.SET.1:a
+aa.SET.2:aa
+aaa.SET.3:aaa
+b.SET.4:b
+----
+
+iter seq=5
+seek-prefix-ge a
+next
+next
+next
+----
+a:a
+aa:aa
+aaa:aaa
+.
+
+iter seq=5
+seek-prefix-ge a
+next
+next
+prev
+next
+next
+----
+a:a
+aa:aa
+aaa:aaa
+aa:aa
+aaa:aaa
+.
+
+iter seq=5
+seek-prefix-ge aa
+prev
+----
+aa:aa
+.
+
+iter seq=5
+seek-prefix-ge aa
+next
+prev
+next
+next
+----
+aa:aa
+aaa:aaa
+aa:aa
+aaa:aaa
+.
+
+iter seq=5
+seek-prefix-ge aa
+next
+prev
+prev
+----
+aa:aa
+aaa:aaa
+aa:aa
+.
+
+iter seq=5
+seek-prefix-ge aaa
+next
+----
+aaa:aaa
+.
+
+iter seq=5
+seek-prefix-ge aaa
+prev
+----
+aaa:aaa
+.
+
+iter seq=5
+seek-prefix-ge b
+next
+----
+b:b
+.
+
+iter seq=5
+seek-prefix-ge aa
+last
+prev
+prev
+prev
+prev
+----
+aa:aa
+b:b
+aaa:aaa
+aa:aa
+a:a
+.
+
+iter seq=5
+seek-prefix-ge aa
+first
+next
+next
+next
+next
+----
+aa:aa
+a:a
+aa:aa
+aaa:aaa
+b:b
+.
+
+iter seq=5
+seek-prefix-ge aaa
+seek-ge aa
+next
+next
+next
+----
+aaa:aaa
+aa:aa
+aaa:aaa
+b:b
+.
+
+iter seq=5
+seek-prefix-ge aaa
+seek-ge aaa
+next
+next
+----
+aaa:aaa
+aaa:aaa
+b:b
+.
+
+iter seq=5
+seek-prefix-ge aaa
+seek-lt aa
+next
+next
+next
+next
+----
+aaa:aaa
+a:a
+aa:aa
+aaa:aaa
+b:b
+.
+
+
+iter seq=5
+seek-prefix-ge aaa
+seek-lt b
+next
+next
+----
+aaa:aaa
+aaa:aaa
+b:b
+.
 
 
 # NB: RANGEDEL entries are ignored.
@@ -343,6 +595,147 @@ a:d
 b:b
 a:d
 
+iter seq=3
+seek-prefix-ge a
+next
+----
+a:cd
+.
+
+iter seq=2
+seek-prefix-ge a
+next
+----
+a:d
+.
+
+iter seq=4
+seek-prefix-ge a
+next
+prev
+next
+----
+a:bcd
+.
+a:bcd
+.
+
+iter seq=2
+seek-prefix-ge a
+next
+prev
+next
+----
+a:d
+.
+a:d
+.
+
+iter seq=3
+seek-prefix-ge a
+next
+prev
+next
+----
+a:cd
+.
+a:cd
+.
+
+iter seq=3
+seek-prefix-ge c
+----
+.
+
+iter seq=3
+seek-prefix-ge 1
+----
+.
+
+iter seq=3
+seek-prefix-ge a
+prev
+----
+a:cd
+.
+
+
+# NB: RANGEDEL entries are ignored.
+define
+a.RANGEDEL.4:c
+a.MERGE.3:b
+a.RANGEDEL.2:c
+a.MERGE.2:c
+a.RANGEDEL.1:c
+a.MERGE.1:d
+aa.RANGEDEL.3:c
+aa.MERGE.2:a
+aa.RANGEDEL.1:c
+aa.MERGE.1:b
+b.RANGEDEL.3:c
+b.MERGE.2:a
+b.RANGEDEL.1:c
+b.MERGE.1:b
+----
+
+iter seq=3
+seek-prefix-ge a
+next
+next
+----
+a:cd
+aa:ab
+.
+
+iter seq=2
+seek-prefix-ge a
+next
+next
+----
+a:d
+aa:b
+.
+
+iter seq=4
+seek-prefix-ge a
+next
+prev
+next
+----
+a:bcd
+aa:ab
+a:bcd
+aa:ab
+
+iter seq=2
+seek-prefix-ge a
+next
+prev
+next
+----
+a:d
+aa:b
+a:d
+aa:b
+
+iter seq=3
+seek-prefix-ge aa
+next
+prev
+next
+----
+aa:ab
+.
+aa:ab
+.
+
+iter seq=4
+seek-prefix-ge aa
+prev
+----
+aa:ab
+.
+
 define
 a.SET.1:a
 b.SET.1:b
@@ -432,6 +825,145 @@ seek-ge a
 next
 ----
 b:b
+.
+
+
+define
+a.SET.1:a
+aa.SET.1:aa
+aaa.SET.1:aaa
+b.SET.1:b
+----
+
+iter seq=2 lower=a
+seek-prefix-ge a
+first
+prev
+----
+a:a
+a:a
+.
+
+
+iter seq=2 lower=aa
+seek-prefix-ge a
+next
+prev
+prev
+----
+aa:aa
+aaa:aaa
+aa:aa
+.
+
+iter seq=2 lower=b
+seek-prefix-ge a
+----
+err=pebble: SeekPrefixGE supplied with key outside of lower bound
+
+iter seq=2 lower=aaa
+seek-prefix-ge a
+----
+aaa:aaa
+
+iter seq=2 lower=aa
+seek-prefix-ge a
+next
+next
+----
+aa:aa
+aaa:aaa
+.
+
+iter seq=2 lower=aa
+seek-prefix-ge a
+first
+next
+next
+next
+----
+aa:aa
+aa:aa
+aaa:aaa
+b:b
+.
+
+iter seq=2 lower=a upper=aa
+seek-prefix-ge a
+next
+----
+a:a
+.
+
+iter seq=2 lower=a upper=aaa
+seek-prefix-ge a
+next
+next
+----
+a:a
+aa:aa
+.
+
+iter seq=2 lower=a upper=b
+seek-prefix-ge a
+next
+next
+next
+----
+a:a
+aa:aa
+aaa:aaa
+.
+
+iter seq=2 lower=a upper=c
+seek-prefix-ge a
+next
+next
+next
+----
+a:a
+aa:aa
+aaa:aaa
+.
+
+iter seq=2 lower=aa upper=aaa
+seek-prefix-ge a
+next
+----
+aa:aa
+.
+
+iter seq=2 lower=aa upper=b
+seek-prefix-ge a
+next
+next
+----
+aa:aa
+aaa:aaa
+.
+
+iter seq=2 lower=aa upper=aa
+seek-prefix-ge a
+----
+.
+
+iter seq=2 lower=aa upper=aa
+seek-prefix-ge a
+----
+.
+
+iter seq=2 lower=a upper=aaa
+seek-prefix-ge aa
+prev
+----
+aa:aa
+.
+
+iter seq=2 lower=a upper=aaa
+seek-prefix-ge aa
+next
+----
+aa:aa
 .
 
 # NB: RANGEDEL entries are ignored.

--- a/testdata/level_iter
+++ b/testdata/level_iter
@@ -1,10 +1,12 @@
 define
 a.SET.1:1 b.SET.2:2
 c.SET.3:3 d.SET.4:4
+dd.SET.5:5
 ----
 
 iter
 seek-ge a
+next
 next
 next
 next
@@ -14,6 +16,7 @@ a:1
 b:2
 c:3
 d:4
+dd:5
 .
 
 iter
@@ -21,26 +24,39 @@ seek-ge b
 next
 next
 next
+next
 ----
 b:2
 c:3
 d:4
+dd:5
 .
 
 iter
 seek-ge c
 next
 next
+next
 ----
 c:3
 d:4
+dd:5
 .
 
 iter
 seek-ge d
 next
+next
 ----
 d:4
+dd:5
+.
+
+iter
+seek-ge dd
+next
+----
+dd:5
 .
 
 iter
@@ -86,11 +102,61 @@ prev
 prev
 prev
 prev
+prev
 ----
+dd:5
 d:4
 c:3
 b:2
 a:1
+.
+
+iter
+seek-prefix-ge a
+next
+----
+a:1
+.
+
+iter
+seek-prefix-ge d
+next
+next
+----
+d:4
+dd:5
+.
+
+iter
+seek-prefix-ge dd
+next
+----
+dd:5
+.
+
+iter
+seek-prefix-ge d
+next
+prev
+prev
+----
+d:4
+dd:5
+d:4
+.
+
+iter
+seek-prefix-ge d
+prev
+----
+d:4
+.
+
+iter
+seek-prefix-ge dd
+prev
+----
+dd:5
 .
 
 iter lower=a
@@ -155,8 +221,8 @@ iter upper=e
 seek-lt e
 last
 ----
-d:4
-d:4
+dd:5
+dd:5
 
 # levelIter only checks upper bound when loading sstables.
 iter upper=d
@@ -186,4 +252,41 @@ seek-lt e
 last
 ----
 .
+.
+
+iter upper=dd
+seek-prefix-ge d
+next
+----
+d:4
+.
+
+iter upper=e
+seek-prefix-ge d
+next
+next
+----
+d:4
+dd:5
+.
+
+iter lower=dd
+seek-prefix-ge d
+next
+----
+dd:5
+.
+
+iter lower=d
+seek-prefix-ge dd
+prev
+----
+dd:5
+.
+
+iter lower=c
+seek-prefix-ge dd
+prev
+----
+dd:5
 .

--- a/testdata/level_iter_boundaries
+++ b/testdata/level_iter_boundaries
@@ -27,7 +27,25 @@ a#1,15:
 .
 
 iter
+seek-prefix-ge c
+seek-prefix-ge d
+seek-lt b
+prev
+----
+.
+.
+a#1,15:
+.
+
+iter
 seek-ge e
+seek-lt a
+----
+.
+.
+
+iter
+seek-prefix-ge e
 seek-lt a
 ----
 .

--- a/testdata/merging_iter_seek
+++ b/testdata/merging_iter_seek
@@ -68,6 +68,88 @@ a1:1
 a0:0
 .
 
+iter
+seek-prefix-ge a0
+next
+----
+a0:0
+.
+
+iter
+seek-prefix-ge a0
+prev
+----
+a0:0
+.
+
+iter
+seek-prefix-ge a0
+first
+next
+next
+next
+----
+a0:0
+a0:0
+a1:1
+a2:2
+.
+
+iter
+seek-prefix-ge a0
+last
+next
+----
+a0:0
+a2:2
+.
+
+iter
+seek-prefix-ge a0
+seek-ge a0
+next
+next
+next
+----
+a0:0
+a0:0
+a1:1
+a2:2
+.
+
+iter
+seek-prefix-ge a0
+seek-lt a2
+next
+next
+----
+a0:0
+a1:1
+a2:2
+.
+
+iter
+seek-prefix-ge a1
+last
+prev
+prev
+prev
+----
+a1:1
+a2:2
+a1:1
+a0:0
+.
+
+iter
+seek-prefix-ge a1
+first
+prev
+----
+a1:1
+a0:0
+.
+
 define
 a0.SET.0:0 b3.SET.3:3
 a1.SET.1:1
@@ -90,4 +172,138 @@ prev
 ----
 a1:1
 a0:0
+.
+
+define
+a.SET.0:0 b.SET.3:3
+aa.SET.1:1
+aaa.SET.2:2
+----
+
+iter
+seek-prefix-ge a
+next
+next
+next
+----
+a:0
+aa:1
+aaa:2
+.
+
+iter
+seek-prefix-ge aa
+prev
+----
+aa:1
+.
+
+iter
+seek-prefix-ge aa
+next
+prev
+prev
+----
+aa:1
+aaa:2
+aa:1
+.
+
+iter
+seek-prefix-ge aa
+next
+prev
+next
+next
+----
+aa:1
+aaa:2
+aa:1
+aaa:2
+.
+
+iter
+seek-prefix-ge aaa
+next
+----
+aaa:2
+.
+
+iter
+seek-prefix-ge aaa
+prev
+----
+aaa:2
+.
+
+iter
+seek-prefix-ge b
+prev
+----
+b:3
+.
+
+iter
+seek-prefix-ge b
+next
+----
+b:3
+.
+
+iter
+seek-prefix-ge aa
+last
+prev
+prev
+prev
+prev
+----
+aa:1
+b:3
+aaa:2
+aa:1
+a:0
+.
+
+iter
+seek-prefix-ge aa
+first
+next
+next
+next
+next
+----
+aa:1
+a:0
+aa:1
+aaa:2
+b:3
+.
+
+iter
+seek-prefix-ge aa
+seek-ge a
+next
+next
+next
+next
+----
+aa:1
+a:0
+aa:1
+aaa:2
+b:3
+.
+
+iter
+seek-prefix-ge aa
+seek-lt aaa
+next
+next
+next
+----
+aa:1
+aa:1
+aaa:2
+b:3
 .


### PR DESCRIPTION
This is a continuation of https://github.com/petermattis/pebble/pull/35, which added support for writing prefix bloom filters.

Some things to keep note of are:
- `First()`, `Last()`, and `SeekLT()` are not supported in prefix iteration mode
- Prefix iteration mode **requires** a `Split()` function (aka `PrefixExtractor()` in RocksDB) to be passed into the reader options
- `{Lower,Upper}Bound` are ignored in prefix iteration mode
- There can be multiple calls to `SeekGE()`, each of which reset the prefix being iterated on
- The prefix is extracted on calls to `SeekGE()` from the key which is passed in, not the first key encountered

Since prefix iterators behave differently from regular iterators, the `./sstable/testdata/reader/` tests were separated into `./sstable/testdata/prefixreader/` to test just prefix iterators. 

