### PR TITLE
Replace db package with internal/base

### DIFF
--- a/bloom/bloom_test.go
+++ b/bloom/bloom_test.go
@@ -7,7 +7,7 @@ package bloom
 import (
 	"testing"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 )
 
 func (f tableFilter) String() string {
@@ -25,7 +25,7 @@ func (f tableFilter) String() string {
 }
 
 func newTableFilter(buf []byte, keys [][]byte, bitsPerKey int) tableFilter {
-	w := FilterPolicy(bitsPerKey).NewWriter(db.TableFilter)
+	w := FilterPolicy(bitsPerKey).NewWriter(base.TableFilter)
 	for _, key := range keys {
 		w.AddKey(key)
 	}

--- a/cmd/pebble/mvcc.go
+++ b/cmd/pebble/mvcc.go
@@ -8,14 +8,13 @@ import (
 	"bytes"
 
 	"github.com/petermattis/pebble"
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/internal/bytealloc"
 )
 
 // MVCC encoding and decoding routines adapted from CockroachDB sources. Used
 // to perform apples-to-apples benchmarking for CockroachDB's usage of RocksDB.
 
-var mvccComparer = &db.Comparer{
+var mvccComparer = &pebble.Comparer{
 	Compare: mvccCompare,
 
 	AbbreviatedKey: func(k []byte) uint64 {
@@ -23,7 +22,7 @@ var mvccComparer = &db.Comparer{
 		if !ok {
 			return 0
 		}
-		return db.DefaultComparer.AbbreviatedKey(key)
+		return pebble.DefaultComparer.AbbreviatedKey(key)
 	},
 
 	Separator: func(dst, a, b []byte) []byte {
@@ -92,7 +91,7 @@ func mvccEncode(dst, key []byte, walltime uint64, logical uint32) []byte {
 }
 
 func mvccForwardScan(d *pebble.DB, start, end, ts []byte) int {
-	it := d.NewIter(&db.IterOptions{
+	it := d.NewIter(&pebble.IterOptions{
 		LowerBound: mvccEncode(nil, start, 0, 0),
 		UpperBound: mvccEncode(nil, end, 0, 0),
 	})
@@ -113,7 +112,7 @@ func mvccForwardScan(d *pebble.DB, start, end, ts []byte) int {
 }
 
 func mvccReverseScan(d *pebble.DB, start, end, ts []byte) int {
-	it := d.NewIter(&db.IterOptions{
+	it := d.NewIter(&pebble.IterOptions{
 		LowerBound: mvccEncode(nil, start, 0, 0),
 		UpperBound: mvccEncode(nil, end, 0, 0),
 	})

--- a/cmd/pebble/scan.go
+++ b/cmd/pebble/scan.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/petermattis/pebble"
-	"github.com/petermattis/pebble/db"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/rand"
 )
@@ -39,9 +38,9 @@ func runScan(cmd *cobra.Command, args []string) {
 		lastElapsed time.Duration
 	)
 
-	opts := db.Sync
+	opts := pebble.Sync
 	if disableWAL {
-		opts = db.NoSync
+		opts = pebble.NoSync
 	}
 
 	runTest(args[0], test{

--- a/cmd/pebble/sync.go
+++ b/cmd/pebble/sync.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/petermattis/pebble"
-	"github.com/petermattis/pebble/db"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/rand"
 )
@@ -29,9 +28,9 @@ func runSync(cmd *cobra.Command, args []string) {
 	reg := newHistogramRegistry()
 	var bytes, lastBytes uint64
 
-	opts := db.Sync
+	opts := pebble.Sync
 	if disableWAL {
-		opts = db.NoSync
+		opts = pebble.NoSync
 	}
 
 	runTest(args[0], test{

--- a/cmd/pebble/test.go
+++ b/cmd/pebble/test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/codahale/hdrhistogram"
 	"github.com/petermattis/pebble"
 	"github.com/petermattis/pebble/cache"
-	"github.com/petermattis/pebble/db"
 )
 
 const (
@@ -190,7 +189,7 @@ func runTest(dir string, t test) {
 
 	fmt.Printf("dir %s\nconcurrency %d\n", dir, concurrency)
 
-	opts := &db.Options{
+	opts := &pebble.Options{
 		Cache:                       cache.New(1 << 30),
 		Comparer:                    mvccComparer,
 		DisableWAL:                  disableWAL,
@@ -200,14 +199,14 @@ func runTest(dir string, t test) {
 		L0SlowdownWritesThreshold:   20,
 		L0StopWritesThreshold:       32,
 		LBaseMaxBytes:               64 << 20, // 64 MB
-		Levels: []db.LevelOptions{{
+		Levels: []pebble.LevelOptions{{
 			BlockSize: 32 << 10,
 		}},
 	}
 	opts.EnsureDefaults()
 
 	if verbose {
-		opts.EventListener = db.MakeLoggingEventListener(nil)
+		opts.EventListener = pebble.MakeLoggingEventListener(nil)
 		opts.EventListener.TableDeleted = nil
 		opts.EventListener.TableIngested = nil
 		opts.EventListener.WALCreated = nil

--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/petermattis/pebble"
-	pebble_db "github.com/petermattis/pebble/db"
 	"github.com/spf13/cobra"
 )
 
@@ -133,7 +132,7 @@ func runYcsb(cmd *cobra.Command, args []string) error {
 								key := mvccEncode(buf[:0], raw, 0, 0)
 								b.Set(key, val, nil)
 							}
-							err := b.Commit(pebble_db.Sync)
+							err := b.Commit(pebble.Sync)
 							if err != nil {
 								log.Fatal(err)
 							}

--- a/compaction_iter_test.go
+++ b/compaction_iter_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 )
 
@@ -23,14 +23,14 @@ func TestSnapshotIndex(t *testing.T) {
 		expectedIndex  int
 		expectedSeqNum uint64
 	}{
-		{[]uint64{}, 1, 0, db.InternalKeySeqNumMax},
+		{[]uint64{}, 1, 0, InternalKeySeqNumMax},
 		{[]uint64{1}, 0, 0, 1},
-		{[]uint64{1}, 1, 1, db.InternalKeySeqNumMax},
-		{[]uint64{1}, 2, 1, db.InternalKeySeqNumMax},
+		{[]uint64{1}, 1, 1, InternalKeySeqNumMax},
+		{[]uint64{1}, 2, 1, InternalKeySeqNumMax},
 		{[]uint64{1, 3}, 1, 1, 3},
 		{[]uint64{1, 3}, 2, 1, 3},
-		{[]uint64{1, 3}, 3, 2, db.InternalKeySeqNumMax},
-		{[]uint64{1, 3}, 4, 2, db.InternalKeySeqNumMax},
+		{[]uint64{1, 3}, 3, 2, InternalKeySeqNumMax},
+		{[]uint64{1, 3}, 4, 2, InternalKeySeqNumMax},
 		{[]uint64{1, 3, 3}, 2, 1, 3},
 	}
 	for _, c := range testCases {
@@ -47,15 +47,15 @@ func TestSnapshotIndex(t *testing.T) {
 }
 
 func TestCompactionIter(t *testing.T) {
-	var keys []db.InternalKey
+	var keys []InternalKey
 	var vals [][]byte
 	var snapshots []uint64
 	var elideTombstones bool
 
 	newIter := func() *compactionIter {
 		return newCompactionIter(
-			db.DefaultComparer.Compare,
-			db.DefaultMerger.Merge,
+			DefaultComparer.Compare,
+			DefaultMerger.Merge,
 			&fakeIter{keys: keys, vals: vals},
 			snapshots,
 			false, /* allowZeroSeqNum */
@@ -75,7 +75,7 @@ func TestCompactionIter(t *testing.T) {
 			vals = vals[:0]
 			for _, key := range strings.Split(d.Input, "\n") {
 				j := strings.Index(key, ":")
-				keys = append(keys, db.ParseInternalKey(key[:j]))
+				keys = append(keys, base.ParseInternalKey(key[:j]))
 				vals = append(vals, []byte(key[j+1:]))
 			}
 			return ""

--- a/compaction_picker.go
+++ b/compaction_picker.go
@@ -6,8 +6,6 @@ package pebble
 
 import (
 	"math"
-
-	"github.com/petermattis/pebble/db"
 )
 
 // compactionPicker holds the state and logic for picking a compaction. A
@@ -32,7 +30,7 @@ type compactionPicker struct {
 	file  int
 }
 
-func newCompactionPicker(v *version, opts *db.Options) *compactionPicker {
+func newCompactionPicker(v *version, opts *Options) *compactionPicker {
 	p := &compactionPicker{
 		vers: v,
 	}
@@ -48,7 +46,7 @@ func (p *compactionPicker) compactionNeeded() bool {
 	return p.score >= 1
 }
 
-func (p *compactionPicker) initLevelMaxBytes(v *version, opts *db.Options) {
+func (p *compactionPicker) initLevelMaxBytes(v *version, opts *Options) {
 	// Determine the first non-empty level and the maximum size of any level.
 	firstNonEmptyLevel := -1
 	var maxLevelSize int64
@@ -124,7 +122,7 @@ func (p *compactionPicker) initLevelMaxBytes(v *version, opts *db.Options) {
 // initTarget initializes the compaction score and level. If the compaction
 // score indicates compaction is needed, a target table within the target level
 // is selected for compaction.
-func (p *compactionPicker) initTarget(v *version, opts *db.Options) {
+func (p *compactionPicker) initTarget(v *version, opts *Options) {
 	// We treat level-0 specially by bounding the number of files instead of
 	// number of bytes for two reasons:
 	//
@@ -201,7 +199,7 @@ func (p *compactionPicker) initTarget(v *version, opts *db.Options) {
 }
 
 // pickAuto picks the best compaction, if any.
-func (p *compactionPicker) pickAuto(opts *db.Options) (c *compaction) {
+func (p *compactionPicker) pickAuto(opts *Options) (c *compaction) {
 	if !p.compactionNeeded() {
 		return nil
 	}
@@ -224,7 +222,7 @@ func (p *compactionPicker) pickAuto(opts *db.Options) (c *compaction) {
 	return c
 }
 
-func (p *compactionPicker) pickManual(opts *db.Options, manual *manualCompaction) (c *compaction) {
+func (p *compactionPicker) pickManual(opts *Options, manual *manualCompaction) (c *compaction) {
 	if p == nil {
 		return nil
 	}

--- a/compaction_picker_test.go
+++ b/compaction_picker_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/internal/datadriven"
 )
 
@@ -20,7 +19,7 @@ func TestCompactionPickerLevelMaxBytes(t *testing.T) {
 		func(d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "init":
-				opts := &db.Options{}
+				opts := &Options{}
 				opts.EnsureDefaults()
 
 				if len(d.CmdArgs) != 1 {
@@ -82,7 +81,7 @@ func TestCompactionPickerTargetLevel(t *testing.T) {
 		func(d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "pick":
-				opts := &db.Options{}
+				opts := &Options{}
 				opts.EnsureDefaults()
 
 				if len(d.CmdArgs) != 1 {

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 	"github.com/petermattis/pebble/sstable"
 	"github.com/petermattis/pebble/vfs"
@@ -30,7 +30,7 @@ func TestPickCompaction(t *testing.T) {
 		return strings.Join(ss, ",")
 	}
 
-	opts := (*db.Options)(nil).EnsureDefaults()
+	opts := (*Options)(nil).EnsureDefaults()
 	testCases := []struct {
 		desc    string
 		version version
@@ -45,8 +45,8 @@ func TestPickCompaction(t *testing.T) {
 						{
 							fileNum:  100,
 							size:     1,
-							smallest: db.ParseInternalKey("i.SET.101"),
-							largest:  db.ParseInternalKey("j.SET.102"),
+							smallest: base.ParseInternalKey("i.SET.101"),
+							largest:  base.ParseInternalKey("j.SET.102"),
 						},
 					},
 				},
@@ -62,8 +62,8 @@ func TestPickCompaction(t *testing.T) {
 						{
 							fileNum:  100,
 							size:     1,
-							smallest: db.ParseInternalKey("i.SET.101"),
-							largest:  db.ParseInternalKey("j.SET.102"),
+							smallest: base.ParseInternalKey("i.SET.101"),
+							largest:  base.ParseInternalKey("j.SET.102"),
 						},
 					},
 				},
@@ -84,14 +84,14 @@ func TestPickCompaction(t *testing.T) {
 						{
 							fileNum:  100,
 							size:     1,
-							smallest: db.ParseInternalKey("i.SET.101"),
-							largest:  db.ParseInternalKey("j.SET.102"),
+							smallest: base.ParseInternalKey("i.SET.101"),
+							largest:  base.ParseInternalKey("j.SET.102"),
 						},
 						{
 							fileNum:  110,
 							size:     1,
-							smallest: db.ParseInternalKey("k.SET.111"),
-							largest:  db.ParseInternalKey("l.SET.112"),
+							smallest: base.ParseInternalKey("k.SET.111"),
+							largest:  base.ParseInternalKey("l.SET.112"),
 						},
 					},
 				},
@@ -112,14 +112,14 @@ func TestPickCompaction(t *testing.T) {
 						{
 							fileNum:  100,
 							size:     1,
-							smallest: db.ParseInternalKey("i.SET.101"),
-							largest:  db.ParseInternalKey("p.SET.102"),
+							smallest: base.ParseInternalKey("i.SET.101"),
+							largest:  base.ParseInternalKey("p.SET.102"),
 						},
 						{
 							fileNum:  110,
 							size:     1,
-							smallest: db.ParseInternalKey("j.SET.111"),
-							largest:  db.ParseInternalKey("q.SET.112"),
+							smallest: base.ParseInternalKey("j.SET.111"),
+							largest:  base.ParseInternalKey("q.SET.112"),
 						},
 					},
 				},
@@ -140,14 +140,14 @@ func TestPickCompaction(t *testing.T) {
 						{
 							fileNum:  100,
 							size:     1,
-							smallest: db.ParseInternalKey("i.SET.101"),
-							largest:  db.ParseInternalKey("i.SET.102"),
+							smallest: base.ParseInternalKey("i.SET.101"),
+							largest:  base.ParseInternalKey("i.SET.102"),
 						},
 						{
 							fileNum:  110,
 							size:     1,
-							smallest: db.ParseInternalKey("i.SET.111"),
-							largest:  db.ParseInternalKey("i.SET.112"),
+							smallest: base.ParseInternalKey("i.SET.111"),
+							largest:  base.ParseInternalKey("i.SET.112"),
 						},
 					},
 				},
@@ -168,22 +168,22 @@ func TestPickCompaction(t *testing.T) {
 						{
 							fileNum:  100,
 							size:     1,
-							smallest: db.ParseInternalKey("i.SET.101"),
-							largest:  db.ParseInternalKey("i.SET.102"),
+							smallest: base.ParseInternalKey("i.SET.101"),
+							largest:  base.ParseInternalKey("i.SET.102"),
 						},
 					},
 					1: []fileMetadata{
 						{
 							fileNum:  200,
 							size:     1,
-							smallest: db.ParseInternalKey("a.SET.201"),
-							largest:  db.ParseInternalKey("b.SET.202"),
+							smallest: base.ParseInternalKey("a.SET.201"),
+							largest:  base.ParseInternalKey("b.SET.202"),
 						},
 						{
 							fileNum:  210,
 							size:     1,
-							smallest: db.ParseInternalKey("y.SET.211"),
-							largest:  db.ParseInternalKey("z.SET.212"),
+							smallest: base.ParseInternalKey("y.SET.211"),
+							largest:  base.ParseInternalKey("z.SET.212"),
 						},
 					},
 				},
@@ -204,48 +204,48 @@ func TestPickCompaction(t *testing.T) {
 						{
 							fileNum:  100,
 							size:     1,
-							smallest: db.ParseInternalKey("i.SET.101"),
-							largest:  db.ParseInternalKey("t.SET.102"),
+							smallest: base.ParseInternalKey("i.SET.101"),
+							largest:  base.ParseInternalKey("t.SET.102"),
 						},
 					},
 					1: []fileMetadata{
 						{
 							fileNum:  200,
 							size:     1,
-							smallest: db.ParseInternalKey("a.SET.201"),
-							largest:  db.ParseInternalKey("e.SET.202"),
+							smallest: base.ParseInternalKey("a.SET.201"),
+							largest:  base.ParseInternalKey("e.SET.202"),
 						},
 						{
 							fileNum:  210,
 							size:     1,
-							smallest: db.ParseInternalKey("f.SET.211"),
-							largest:  db.ParseInternalKey("j.SET.212"),
+							smallest: base.ParseInternalKey("f.SET.211"),
+							largest:  base.ParseInternalKey("j.SET.212"),
 						},
 					},
 					2: []fileMetadata{
 						{
 							fileNum:  300,
 							size:     1,
-							smallest: db.ParseInternalKey("a.SET.301"),
-							largest:  db.ParseInternalKey("b.SET.302"),
+							smallest: base.ParseInternalKey("a.SET.301"),
+							largest:  base.ParseInternalKey("b.SET.302"),
 						},
 						{
 							fileNum:  310,
 							size:     1,
-							smallest: db.ParseInternalKey("c.SET.311"),
-							largest:  db.ParseInternalKey("g.SET.312"),
+							smallest: base.ParseInternalKey("c.SET.311"),
+							largest:  base.ParseInternalKey("g.SET.312"),
 						},
 						{
 							fileNum:  320,
 							size:     1,
-							smallest: db.ParseInternalKey("h.SET.321"),
-							largest:  db.ParseInternalKey("m.SET.322"),
+							smallest: base.ParseInternalKey("h.SET.321"),
+							largest:  base.ParseInternalKey("m.SET.322"),
 						},
 						{
 							fileNum:  330,
 							size:     1,
-							smallest: db.ParseInternalKey("n.SET.331"),
-							largest:  db.ParseInternalKey("z.SET.332"),
+							smallest: base.ParseInternalKey("n.SET.331"),
+							largest:  base.ParseInternalKey("z.SET.332"),
 						},
 					},
 				},
@@ -266,40 +266,40 @@ func TestPickCompaction(t *testing.T) {
 						{
 							fileNum:  200,
 							size:     1,
-							smallest: db.ParseInternalKey("i1.SET.201"),
-							largest:  db.ParseInternalKey("i2.SET.202"),
+							smallest: base.ParseInternalKey("i1.SET.201"),
+							largest:  base.ParseInternalKey("i2.SET.202"),
 						},
 						{
 							fileNum:  210,
 							size:     1,
-							smallest: db.ParseInternalKey("j1.SET.211"),
-							largest:  db.ParseInternalKey("j2.SET.212"),
+							smallest: base.ParseInternalKey("j1.SET.211"),
+							largest:  base.ParseInternalKey("j2.SET.212"),
 						},
 						{
 							fileNum:  220,
 							size:     1,
-							smallest: db.ParseInternalKey("k1.SET.221"),
-							largest:  db.ParseInternalKey("k2.SET.222"),
+							smallest: base.ParseInternalKey("k1.SET.221"),
+							largest:  base.ParseInternalKey("k2.SET.222"),
 						},
 						{
 							fileNum:  230,
 							size:     1,
-							smallest: db.ParseInternalKey("l1.SET.231"),
-							largest:  db.ParseInternalKey("l2.SET.232"),
+							smallest: base.ParseInternalKey("l1.SET.231"),
+							largest:  base.ParseInternalKey("l2.SET.232"),
 						},
 					},
 					2: []fileMetadata{
 						{
 							fileNum:  300,
 							size:     1,
-							smallest: db.ParseInternalKey("a0.SET.301"),
-							largest:  db.ParseInternalKey("l0.SET.302"),
+							smallest: base.ParseInternalKey("a0.SET.301"),
+							largest:  base.ParseInternalKey("l0.SET.302"),
 						},
 						{
 							fileNum:  310,
 							size:     1,
-							smallest: db.ParseInternalKey("l2.SET.311"),
-							largest:  db.ParseInternalKey("z2.SET.312"),
+							smallest: base.ParseInternalKey("l2.SET.311"),
+							largest:  base.ParseInternalKey("z2.SET.312"),
 						},
 					},
 				},
@@ -320,40 +320,40 @@ func TestPickCompaction(t *testing.T) {
 						{
 							fileNum:  200,
 							size:     1,
-							smallest: db.ParseInternalKey("i1.SET.201"),
-							largest:  db.ParseInternalKey("i2.SET.202"),
+							smallest: base.ParseInternalKey("i1.SET.201"),
+							largest:  base.ParseInternalKey("i2.SET.202"),
 						},
 						{
 							fileNum:  210,
 							size:     1,
-							smallest: db.ParseInternalKey("j1.SET.211"),
-							largest:  db.ParseInternalKey("j2.SET.212"),
+							smallest: base.ParseInternalKey("j1.SET.211"),
+							largest:  base.ParseInternalKey("j2.SET.212"),
 						},
 						{
 							fileNum:  220,
 							size:     1,
-							smallest: db.ParseInternalKey("k1.SET.221"),
-							largest:  db.ParseInternalKey("k2.SET.222"),
+							smallest: base.ParseInternalKey("k1.SET.221"),
+							largest:  base.ParseInternalKey("k2.SET.222"),
 						},
 						{
 							fileNum:  230,
 							size:     1,
-							smallest: db.ParseInternalKey("l1.SET.231"),
-							largest:  db.ParseInternalKey("l2.SET.232"),
+							smallest: base.ParseInternalKey("l1.SET.231"),
+							largest:  base.ParseInternalKey("l2.SET.232"),
 						},
 					},
 					2: []fileMetadata{
 						{
 							fileNum:  300,
 							size:     1,
-							smallest: db.ParseInternalKey("a0.SET.301"),
-							largest:  db.ParseInternalKey("j0.SET.302"),
+							smallest: base.ParseInternalKey("a0.SET.301"),
+							largest:  base.ParseInternalKey("j0.SET.302"),
 						},
 						{
 							fileNum:  310,
 							size:     1,
-							smallest: db.ParseInternalKey("j2.SET.311"),
-							largest:  db.ParseInternalKey("z2.SET.312"),
+							smallest: base.ParseInternalKey("j2.SET.311"),
+							largest:  base.ParseInternalKey("z2.SET.312"),
 						},
 					},
 				},
@@ -374,40 +374,40 @@ func TestPickCompaction(t *testing.T) {
 						{
 							fileNum:  200,
 							size:     expandedCompactionByteSizeLimit(opts, 1) - 1,
-							smallest: db.ParseInternalKey("i1.SET.201"),
-							largest:  db.ParseInternalKey("i2.SET.202"),
+							smallest: base.ParseInternalKey("i1.SET.201"),
+							largest:  base.ParseInternalKey("i2.SET.202"),
 						},
 						{
 							fileNum:  210,
 							size:     expandedCompactionByteSizeLimit(opts, 1) - 1,
-							smallest: db.ParseInternalKey("j1.SET.211"),
-							largest:  db.ParseInternalKey("j2.SET.212"),
+							smallest: base.ParseInternalKey("j1.SET.211"),
+							largest:  base.ParseInternalKey("j2.SET.212"),
 						},
 						{
 							fileNum:  220,
 							size:     expandedCompactionByteSizeLimit(opts, 1) - 1,
-							smallest: db.ParseInternalKey("k1.SET.221"),
-							largest:  db.ParseInternalKey("k2.SET.222"),
+							smallest: base.ParseInternalKey("k1.SET.221"),
+							largest:  base.ParseInternalKey("k2.SET.222"),
 						},
 						{
 							fileNum:  230,
 							size:     expandedCompactionByteSizeLimit(opts, 1) - 1,
-							smallest: db.ParseInternalKey("l1.SET.231"),
-							largest:  db.ParseInternalKey("l2.SET.232"),
+							smallest: base.ParseInternalKey("l1.SET.231"),
+							largest:  base.ParseInternalKey("l2.SET.232"),
 						},
 					},
 					2: []fileMetadata{
 						{
 							fileNum:  300,
 							size:     expandedCompactionByteSizeLimit(opts, 2) - 1,
-							smallest: db.ParseInternalKey("a0.SET.301"),
-							largest:  db.ParseInternalKey("l0.SET.302"),
+							smallest: base.ParseInternalKey("a0.SET.301"),
+							largest:  base.ParseInternalKey("l0.SET.302"),
 						},
 						{
 							fileNum:  310,
 							size:     expandedCompactionByteSizeLimit(opts, 2) - 1,
-							smallest: db.ParseInternalKey("l2.SET.311"),
-							largest:  db.ParseInternalKey("z2.SET.312"),
+							smallest: base.ParseInternalKey("l2.SET.311"),
+							largest:  base.ParseInternalKey("z2.SET.312"),
 						},
 					},
 				},
@@ -424,8 +424,8 @@ func TestPickCompaction(t *testing.T) {
 	for _, tc := range testCases {
 		vs := &versionSet{
 			opts:    opts,
-			cmp:     db.DefaultComparer.Compare,
-			cmpName: db.DefaultComparer.Name,
+			cmp:     DefaultComparer.Compare,
+			cmpName: DefaultComparer.Name,
 		}
 		vs.versions.init()
 		vs.append(&tc.version)
@@ -467,42 +467,42 @@ func TestElideTombstone(t *testing.T) {
 				files: [numLevels][]fileMetadata{
 					1: []fileMetadata{
 						{
-							smallest: db.ParseInternalKey("c.SET.801"),
-							largest:  db.ParseInternalKey("g.SET.800"),
+							smallest: base.ParseInternalKey("c.SET.801"),
+							largest:  base.ParseInternalKey("g.SET.800"),
 						},
 						{
-							smallest: db.ParseInternalKey("x.SET.701"),
-							largest:  db.ParseInternalKey("y.SET.700"),
+							smallest: base.ParseInternalKey("x.SET.701"),
+							largest:  base.ParseInternalKey("y.SET.700"),
 						},
 					},
 					2: []fileMetadata{
 						{
-							smallest: db.ParseInternalKey("d.SET.601"),
-							largest:  db.ParseInternalKey("h.SET.600"),
+							smallest: base.ParseInternalKey("d.SET.601"),
+							largest:  base.ParseInternalKey("h.SET.600"),
 						},
 						{
-							smallest: db.ParseInternalKey("r.SET.501"),
-							largest:  db.ParseInternalKey("t.SET.500"),
+							smallest: base.ParseInternalKey("r.SET.501"),
+							largest:  base.ParseInternalKey("t.SET.500"),
 						},
 					},
 					3: []fileMetadata{
 						{
-							smallest: db.ParseInternalKey("f.SET.401"),
-							largest:  db.ParseInternalKey("g.SET.400"),
+							smallest: base.ParseInternalKey("f.SET.401"),
+							largest:  base.ParseInternalKey("g.SET.400"),
 						},
 						{
-							smallest: db.ParseInternalKey("w.SET.301"),
-							largest:  db.ParseInternalKey("x.SET.300"),
+							smallest: base.ParseInternalKey("w.SET.301"),
+							largest:  base.ParseInternalKey("x.SET.300"),
 						},
 					},
 					4: []fileMetadata{
 						{
-							smallest: db.ParseInternalKey("f.SET.201"),
-							largest:  db.ParseInternalKey("m.SET.200"),
+							smallest: base.ParseInternalKey("f.SET.201"),
+							largest:  base.ParseInternalKey("m.SET.200"),
 						},
 						{
-							smallest: db.ParseInternalKey("t.SET.101"),
-							largest:  db.ParseInternalKey("t.SET.100"),
+							smallest: base.ParseInternalKey("t.SET.101"),
+							largest:  base.ParseInternalKey("t.SET.100"),
 						},
 					},
 				},
@@ -537,20 +537,20 @@ func TestElideTombstone(t *testing.T) {
 				files: [numLevels][]fileMetadata{
 					6: []fileMetadata{
 						{
-							smallest: db.ParseInternalKey("i.SET.401"),
-							largest:  db.ParseInternalKey("i.SET.400"),
+							smallest: base.ParseInternalKey("i.SET.401"),
+							largest:  base.ParseInternalKey("i.SET.400"),
 						},
 						{
-							smallest: db.ParseInternalKey("i.SET.301"),
-							largest:  db.ParseInternalKey("k.SET.300"),
+							smallest: base.ParseInternalKey("i.SET.301"),
+							largest:  base.ParseInternalKey("k.SET.300"),
 						},
 						{
-							smallest: db.ParseInternalKey("k.SET.201"),
-							largest:  db.ParseInternalKey("m.SET.200"),
+							smallest: base.ParseInternalKey("k.SET.201"),
+							largest:  base.ParseInternalKey("m.SET.200"),
 						},
 						{
-							smallest: db.ParseInternalKey("m.SET.101"),
-							largest:  db.ParseInternalKey("m.SET.100"),
+							smallest: base.ParseInternalKey("m.SET.101"),
+							largest:  base.ParseInternalKey("m.SET.100"),
 						},
 					},
 				},
@@ -569,7 +569,7 @@ func TestElideTombstone(t *testing.T) {
 
 	for _, tc := range testCases {
 		c := compaction{
-			cmp:         db.DefaultComparer.Compare,
+			cmp:         DefaultComparer.Compare,
 			version:     &tc.version,
 			startLevel:  tc.level,
 			outputLevel: tc.level + 1,
@@ -590,7 +590,7 @@ func TestCompaction(t *testing.T) {
 	const valueSize = 3500
 
 	mem := vfs.NewMem()
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS:           mem,
 		MemTableSize: memTableSize,
 	})
@@ -703,7 +703,7 @@ func TestManualCompaction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS: mem,
 	})
 	if err != nil {
@@ -785,7 +785,7 @@ func TestManualCompaction(t *testing.T) {
 }
 
 func TestCompactionShouldStopBefore(t *testing.T) {
-	cmp := db.DefaultComparer.Compare
+	cmp := DefaultComparer.Compare
 	var grandparents []fileMetadata
 
 	parseMeta := func(s string) fileMetadata {
@@ -794,8 +794,8 @@ func TestCompactionShouldStopBefore(t *testing.T) {
 			t.Fatalf("malformed table spec: %s", s)
 		}
 		return fileMetadata{
-			smallest: db.InternalKey{UserKey: []byte(parts[0])},
-			largest:  db.InternalKey{UserKey: []byte(parts[1])},
+			smallest: InternalKey{UserKey: []byte(parts[0])},
+			largest:  InternalKey{UserKey: []byte(parts[1])},
 		}
 	}
 
@@ -847,7 +847,7 @@ func TestCompactionShouldStopBefore(t *testing.T) {
 					if i == 0 {
 						smallest = key
 					}
-					if c.shouldStopBefore(db.MakeInternalKey([]byte(key), 0, 0)) {
+					if c.shouldStopBefore(base.MakeInternalKey([]byte(key), 0, 0)) {
 						fmt.Fprintf(&buf, "%s-%s\n", smallest, largest)
 						smallest = key
 					}
@@ -863,7 +863,7 @@ func TestCompactionShouldStopBefore(t *testing.T) {
 }
 
 func TestCompactionOutputLevel(t *testing.T) {
-	opts := (*db.Options)(nil).EnsureDefaults()
+	opts := (*Options)(nil).EnsureDefaults()
 	version := &version{}
 
 	datadriven.RunTest(t, "testdata/compaction_output_level",
@@ -890,7 +890,7 @@ func TestCompactionOutputLevel(t *testing.T) {
 }
 
 func TestCompactionExpandInputs(t *testing.T) {
-	cmp := db.DefaultComparer.Compare
+	cmp := DefaultComparer.Compare
 	var files []fileMetadata
 
 	parseMeta := func(s string) fileMetadata {
@@ -899,8 +899,8 @@ func TestCompactionExpandInputs(t *testing.T) {
 			t.Fatalf("malformed table spec: %s", s)
 		}
 		return fileMetadata{
-			smallest: db.ParseInternalKey(parts[0]),
-			largest:  db.ParseInternalKey(parts[1]),
+			smallest: base.ParseInternalKey(parts[0]),
+			largest:  base.ParseInternalKey(parts[1]),
 		}
 	}
 
@@ -951,7 +951,7 @@ func TestCompactionExpandInputs(t *testing.T) {
 }
 
 func TestCompactionAtomicUnitBounds(t *testing.T) {
-	cmp := db.DefaultComparer.Compare
+	cmp := DefaultComparer.Compare
 	var files []fileMetadata
 
 	parseMeta := func(s string) fileMetadata {
@@ -960,8 +960,8 @@ func TestCompactionAtomicUnitBounds(t *testing.T) {
 			t.Fatalf("malformed table spec: %s", s)
 		}
 		return fileMetadata{
-			smallest: db.ParseInternalKey(parts[0]),
-			largest:  db.ParseInternalKey(parts[1]),
+			smallest: base.ParseInternalKey(parts[0]),
+			largest:  base.ParseInternalKey(parts[1]),
 		}
 	}
 
@@ -1017,8 +1017,8 @@ func TestCompactionAllowZeroSeqNum(t *testing.T) {
 			t.Fatalf("malformed table spec: %s: %s", s, err)
 		}
 		meta = fileMetadata{
-			smallest: db.InternalKey{UserKey: []byte(match[2])},
-			largest:  db.InternalKey{UserKey: []byte(match[3])},
+			smallest: InternalKey{UserKey: []byte(match[2])},
+			largest:  InternalKey{UserKey: []byte(match[3])},
 		}
 		return level, meta
 	}

--- a/comparer.go
+++ b/comparer.go
@@ -1,0 +1,31 @@
+// Copyright 2011 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import "github.com/petermattis/pebble/internal/base"
+
+// Compare exports the base.Compare type.
+type Compare = base.Compare
+
+// Equal exports the base.Equal type.
+type Equal = base.Equal
+
+// AbbreviatedKey exports the base.AbbreviatedKey type.
+type AbbreviatedKey = base.AbbreviatedKey
+
+// Separator exports the base.Separator type.
+type Separator = base.Separator
+
+// Successor exports the base.Successor type.
+type Successor = base.Successor
+
+// Split exports the base.Split type.
+type Split = base.Split
+
+// Comparer exports the base.Comparer type.
+type Comparer = base.Comparer
+
+// DefaultComparer exports the base.DefaultComparer variable.
+var DefaultComparer = base.DefaultComparer

--- a/data_test.go
+++ b/data_test.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 	"github.com/petermattis/pebble/vfs"
 )
@@ -186,8 +186,8 @@ func runCompactCommand(td *datadriven.TestData, d *DB) error {
 	}
 	if len(td.CmdArgs) == 2 {
 		levelString := td.CmdArgs[1].String()
-		iStart := db.MakeInternalKey([]byte(parts[0]), db.InternalKeySeqNumMax, db.InternalKeyKindMax)
-		iEnd := db.MakeInternalKey([]byte(parts[1]), 0, 0)
+		iStart := base.MakeInternalKey([]byte(parts[0]), InternalKeySeqNumMax, InternalKeyKindMax)
+		iEnd := base.MakeInternalKey([]byte(parts[1]), 0, 0)
 		if levelString[0] != 'L' {
 			return fmt.Errorf("expected L<n>: %s", levelString)
 		}
@@ -205,7 +205,7 @@ func runCompactCommand(td *datadriven.TestData, d *DB) error {
 	return d.Compact([]byte(parts[0]), []byte(parts[1]))
 }
 
-func runDBDefineCmd(td *datadriven.TestData, opts *db.Options) (*DB, error) {
+func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 	if td.Input == "" {
 		return nil, fmt.Errorf("empty test input")
 	}
@@ -217,7 +217,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *db.Options) (*DB, error) {
 	for _, arg := range td.CmdArgs {
 		switch arg.Key {
 		case "target-file-sizes":
-			opts.Levels = make([]db.LevelOptions, len(arg.Vals))
+			opts.Levels = make([]LevelOptions, len(arg.Vals))
 			for i := range arg.Vals {
 				size, err := strconv.ParseInt(arg.Vals[i], 10, 64)
 				if err != nil {
@@ -311,7 +311,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *db.Options) (*DB, error) {
 
 		for _, data := range fields {
 			i := strings.Index(data, ":")
-			key := db.ParseInternalKey(data[:i])
+			key := base.ParseInternalKey(data[:i])
 			value := []byte(data[i+1:])
 			if err := mem.set(key, value); err != nil {
 				return nil, err

--- a/db_test.go
+++ b/db_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/petermattis/pebble/cache"
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/vfs"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
@@ -196,7 +195,7 @@ func TestBasicReads(t *testing.T) {
 			t.Errorf("%s: cloneFileSystem failed: %v", tc.dirname, err)
 			continue
 		}
-		d, err := Open("", &db.Options{
+		d, err := Open("", &Options{
 			FS: fs,
 		})
 		if err != nil {
@@ -205,7 +204,7 @@ func TestBasicReads(t *testing.T) {
 		}
 		for key, want := range tc.wantMap {
 			got, err := d.Get([]byte(key))
-			if err != nil && err != db.ErrNotFound {
+			if err != nil && err != ErrNotFound {
 				t.Errorf("%s: Get(%q) failed: %v", tc.dirname, key, err)
 				continue
 			}
@@ -223,7 +222,7 @@ func TestBasicReads(t *testing.T) {
 }
 
 func TestBasicWrites(t *testing.T) {
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
 	})
 	if err != nil {
@@ -339,7 +338,7 @@ func TestBasicWrites(t *testing.T) {
 		fail := false
 		for _, name := range names {
 			g, err := d.Get([]byte(name))
-			if err != nil && err != db.ErrNotFound {
+			if err != nil && err != ErrNotFound {
 				t.Errorf("#%d %s: Get(%q): %v", i, tc, name, err)
 				fail = true
 			}
@@ -362,7 +361,7 @@ func TestBasicWrites(t *testing.T) {
 }
 
 func TestRandomWrites(t *testing.T) {
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS:           vfs.NewMem(),
 		MemTableSize: 8 * 1024,
 	})
@@ -400,7 +399,7 @@ func TestRandomWrites(t *testing.T) {
 		for k := range keys {
 			got := -1
 			if v, err := d.Get(keys[k]); err != nil {
-				if err != db.ErrNotFound {
+				if err != ErrNotFound {
 					t.Fatalf("Get: %v", err)
 				}
 			} else {
@@ -418,7 +417,7 @@ func TestRandomWrites(t *testing.T) {
 }
 
 func TestLargeBatch(t *testing.T) {
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS:                          vfs.NewMem(),
 		MemTableSize:                1400,
 		MemTableStopWritesThreshold: 100,
@@ -469,7 +468,7 @@ func TestLargeBatch(t *testing.T) {
 }
 
 func TestGetMerge(t *testing.T) {
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
 	})
 	if err != nil {
@@ -511,7 +510,7 @@ func TestIterLeak(t *testing.T) {
 		t.Run(fmt.Sprintf("leak=%t", leak), func(t *testing.T) {
 			for _, flush := range []bool{true, false} {
 				t.Run(fmt.Sprintf("flush=%t", flush), func(t *testing.T) {
-					d, err := Open("", &db.Options{
+					d, err := Open("", &Options{
 						FS: vfs.NewMem(),
 					})
 					if err != nil {
@@ -552,7 +551,7 @@ func TestIterLeak(t *testing.T) {
 
 func TestCacheEvict(t *testing.T) {
 	cache := cache.New(10 << 20)
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		Cache: cache,
 		FS:    vfs.NewMem(),
 	})
@@ -601,7 +600,7 @@ func TestCacheEvict(t *testing.T) {
 }
 
 func TestFlushEmpty(t *testing.T) {
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
 	})
 	if err != nil {
@@ -617,7 +616,7 @@ func TestFlushEmpty(t *testing.T) {
 }
 
 func TestRollManifest(t *testing.T) {
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		MaxManifestFileSize:   1,
 		L0CompactionThreshold: 10,
 		FS:                    vfs.NewMem(),

--- a/error_iter.go
+++ b/error_iter.go
@@ -4,8 +4,6 @@
 
 package pebble
 
-import "github.com/petermattis/pebble/db"
-
 type errorIter struct {
 	err error
 }
@@ -16,35 +14,35 @@ func newErrorIter(err error) *errorIter {
 	return &errorIter{err: err}
 }
 
-func (c *errorIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
+func (c *errorIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	return nil, nil
 }
 
-func (c *errorIter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+func (c *errorIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
 	return nil, nil
 }
 
-func (c *errorIter) SeekLT(key []byte) (*db.InternalKey, []byte) {
+func (c *errorIter) SeekLT(key []byte) (*InternalKey, []byte) {
 	return nil, nil
 }
 
-func (c *errorIter) First() (*db.InternalKey, []byte) {
+func (c *errorIter) First() (*InternalKey, []byte) {
 	return nil, nil
 }
 
-func (c *errorIter) Last() (*db.InternalKey, []byte) {
+func (c *errorIter) Last() (*InternalKey, []byte) {
 	return nil, nil
 }
 
-func (c *errorIter) Next() (*db.InternalKey, []byte) {
+func (c *errorIter) Next() (*InternalKey, []byte) {
 	return nil, nil
 }
 
-func (c *errorIter) Prev() (*db.InternalKey, []byte) {
+func (c *errorIter) Prev() (*InternalKey, []byte) {
 	return nil, nil
 }
 
-func (c *errorIter) Key() *db.InternalKey {
+func (c *errorIter) Key() *InternalKey {
 	return nil
 }
 

--- a/event.go
+++ b/event.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import "github.com/petermattis/pebble/internal/base"
+
+// TableInfo exports the base.TableInfo type.
+type TableInfo = base.TableInfo
+
+// CompactionInfo exports the base.CompactionInfo type.
+type CompactionInfo = base.CompactionInfo
+
+// FlushInfo exports the base.FlushInfo type.
+type FlushInfo = base.FlushInfo
+
+// ManifestCreateInfo exports the base.ManifestCreateInfo type.
+type ManifestCreateInfo = base.ManifestCreateInfo
+
+// ManifestDeleteInfo exports the base.ManifestDeleteInfo type.
+type ManifestDeleteInfo = base.ManifestDeleteInfo
+
+// TableDeleteInfo exports the base.TableDeleteInfo type.
+type TableDeleteInfo = base.TableDeleteInfo
+
+// TableIngestInfo exports the base.TableIngestInfo type.
+type TableIngestInfo = base.TableIngestInfo
+
+// WALCreateInfo exports the base.WALCreateInfo type.
+type WALCreateInfo = base.WALCreateInfo
+
+// WALDeleteInfo exports the base.WALDeleteInfo type.
+type WALDeleteInfo = base.WALDeleteInfo
+
+// EventListener exports the base.EventListener type.
+type EventListener = base.EventListener
+
+// MakeLoggingEventListener exports the base.MakeLoggingEventListener function.
+func MakeLoggingEventListener(logger Logger) EventListener {
+	return base.MakeLoggingEventListener(logger)
+}

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 	"github.com/petermattis/pebble/sstable"
 	"github.com/petermattis/pebble/vfs"
@@ -113,9 +113,9 @@ func TestEventListener(t *testing.T) {
 		case "open":
 			buf.Reset()
 			var err error
-			d, err = Open("db", &db.Options{
+			d, err = Open("db", &Options{
 				FS:                  loggingFS{mem, &buf},
-				EventListener:       db.MakeLoggingEventListener(&buf),
+				EventListener:       MakeLoggingEventListener(&buf),
 				MaxManifestFileSize: 1,
 				WALDir:              "wal",
 			})
@@ -150,8 +150,8 @@ func TestEventListener(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			w := sstable.NewWriter(f, nil, db.LevelOptions{})
-			if err := w.Add(db.MakeInternalKey([]byte("a"), 0, db.InternalKeyKindSet), nil); err != nil {
+			w := sstable.NewWriter(f, nil, LevelOptions{})
+			if err := w.Add(base.MakeInternalKey([]byte("a"), 0, InternalKeyKindSet), nil); err != nil {
 				return err.Error()
 			}
 			if err := w.Close(); err != nil {

--- a/flush_test.go
+++ b/flush_test.go
@@ -9,13 +9,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/internal/datadriven"
 	"github.com/petermattis/pebble/vfs"
 )
 
 func TestManualFlush(t *testing.T) {
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
 	})
 	if err != nil {
@@ -69,7 +68,7 @@ func TestManualFlush(t *testing.T) {
 			return s
 
 		case "reset":
-			d, err = Open("", &db.Options{
+			d, err = Open("", &Options{
 				FS: vfs.NewMem(),
 			})
 			if err != nil {

--- a/get_iter.go
+++ b/get_iter.go
@@ -5,7 +5,6 @@
 package pebble
 
 import (
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/internal/rangedel"
 )
 
@@ -14,8 +13,8 @@ import (
 // internalIterator, but specialized for Get operations so that it loads data
 // lazily.
 type getIter struct {
-	cmp          db.Compare
-	equal        db.Equal
+	cmp          Compare
+	equal        Equal
 	newIters     tableNewIters
 	snapshot     uint64
 	key          []byte
@@ -28,7 +27,7 @@ type getIter struct {
 	mem          []flushable
 	l0           []fileMetadata
 	version      *version
-	iterKey      *db.InternalKey
+	iterKey      *InternalKey
 	iterValue    []byte
 	err          error
 }
@@ -36,27 +35,27 @@ type getIter struct {
 // getIter implements the internalIterator interface.
 var _ internalIterator = (*getIter)(nil)
 
-func (g *getIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
+func (g *getIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	panic("pebble: SeekGE unimplemented")
 }
 
-func (g *getIter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+func (g *getIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 
-func (g *getIter) SeekLT(key []byte) (*db.InternalKey, []byte) {
+func (g *getIter) SeekLT(key []byte) (*InternalKey, []byte) {
 	panic("pebble: SeekLT unimplemented")
 }
 
-func (g *getIter) First() (*db.InternalKey, []byte) {
+func (g *getIter) First() (*InternalKey, []byte) {
 	return g.Next()
 }
 
-func (g *getIter) Last() (*db.InternalKey, []byte) {
+func (g *getIter) Last() (*InternalKey, []byte) {
 	panic("pebble: Last unimplemented")
 }
 
-func (g *getIter) Next() (*db.InternalKey, []byte) {
+func (g *getIter) Next() (*InternalKey, []byte) {
 	if g.iter != nil {
 		g.iterKey, g.iterValue = g.iter.Next()
 	}
@@ -160,11 +159,11 @@ func (g *getIter) Next() (*db.InternalKey, []byte) {
 	}
 }
 
-func (g *getIter) Prev() (*db.InternalKey, []byte) {
+func (g *getIter) Prev() (*InternalKey, []byte) {
 	panic("pebble: Prev unimplemented")
 }
 
-func (g *getIter) Key() *db.InternalKey {
+func (g *getIter) Key() *InternalKey {
 	return g.iterKey
 }
 

--- a/internal.go
+++ b/internal.go
@@ -5,9 +5,29 @@
 package pebble
 
 import (
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/sstable"
 )
+
+// InternalKeyKind exports the base.InternalKeyKind type.
+type InternalKeyKind = base.InternalKeyKind
+
+// These constants are part of the file format, and should not be changed.
+const (
+	InternalKeyKindDelete          = base.InternalKeyKindDelete
+	InternalKeyKindSet             = base.InternalKeyKindSet
+	InternalKeyKindMerge           = base.InternalKeyKindMerge
+	InternalKeyKindLogData         = base.InternalKeyKindLogData
+	InternalKeyKindRangeDelete     = base.InternalKeyKindRangeDelete
+	InternalKeyKindMax             = base.InternalKeyKindMax
+	InternalKeyKindInvalid         = base.InternalKeyKindInvalid
+	InternalKeySeqNumBatch         = base.InternalKeySeqNumBatch
+	InternalKeySeqNumMax           = base.InternalKeySeqNumMax
+	InternalKeyRangeDeleteSentinel = base.InternalKeyRangeDeleteSentinel
+)
+
+// InternalKey exports the base.InternalKey type.
+type InternalKey = base.InternalKey
 
 // internalIterator iterates over a DB's key/value pairs in key order. Unlike
 // the Iterator interface, the returned keys are InternalKeys composed of the
@@ -30,7 +50,7 @@ type internalIterator interface {
 	// SeekGE moves the iterator to the first key/value pair whose key is greater
 	// than or equal to the given key. Returns the key and value if the iterator
 	// is pointing at a valid entry, and (nil, nil) otherwise.
-	SeekGE(key []byte) (*db.InternalKey, []byte)
+	SeekGE(key []byte) (*InternalKey, []byte)
 
 	// SeekPrefixGE moves the iterator to the first key/value pair whose key
 	// starts with the given prefix and is greater than or equal to the given
@@ -38,37 +58,37 @@ type internalIterator interface {
 	// entry, and (nil, nil) otherwise. Note that the iterator will still observe
 	// keys not matching the prefix. It is up to the user to check if the prefix
 	// matches, and iteration beyond the prefix is undefined.
-	SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte)
+	SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte)
 
 	// SeekLT moves the iterator to the last key/value pair whose key is less
 	// than the given key. Returns the key and value if the iterator is pointing
 	// at a valid entry, and (nil, nil) otherwise.
-	SeekLT(key []byte) (*db.InternalKey, []byte)
+	SeekLT(key []byte) (*InternalKey, []byte)
 
 	// First moves the iterator the the first key/value pair. Returns the key and
 	// value if the iterator is pointing at a valid entry, and (nil, nil)
 	// otherwise.
-	First() (*db.InternalKey, []byte)
+	First() (*InternalKey, []byte)
 
 	// Last moves the iterator the the last key/value pair. Returns the key and
 	// value if the iterator is pointing at a valid entry, and (nil, nil)
 	// otherwise.
-	Last() (*db.InternalKey, []byte)
+	Last() (*InternalKey, []byte)
 
 	// Next moves the iterator to the next key/value pair. Returns the key and
 	// value if the iterator is pointing at a valid entry, and (nil, nil)
 	// otherwise.
-	Next() (*db.InternalKey, []byte)
+	Next() (*InternalKey, []byte)
 
 	// Prev moves the iterator to the previous key/value pair. Returns the key
 	// and value if the iterator is pointing at a valid entry, and (nil, nil)
 	// otherwise.
-	Prev() (*db.InternalKey, []byte)
+	Prev() (*InternalKey, []byte)
 
 	// Key returns the encoded internal key of the current key/value pair, or nil
 	// if done. The caller should not modify the contents of the returned key,
 	// and its contents may change on the next call to Next.
-	Key() *db.InternalKey
+	Key() *InternalKey
 
 	// Value returns the value of the current key/value pair, or nil if done.
 	// The caller should not modify the contents of the returned slice, and

--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -21,7 +21,7 @@ import (
 	"math"
 	"sync/atomic"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 )
 
 // MaxNodeSize returns the maximum space needed for a node with the specified
@@ -59,7 +59,7 @@ type node struct {
 }
 
 func newNode(
-	arena *Arena, height uint32, key db.InternalKey, value []byte,
+	arena *Arena, height uint32, key base.InternalKey, value []byte,
 ) (nd *node, err error) {
 	if height < 1 || height > maxHeight {
 		panic("height cannot be less than one or greater than the max height")

--- a/internal/base/comparer.go
+++ b/internal/base/comparer.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package db
+package base
 
 import (
 	"bytes"

--- a/internal/base/comparer_test.go
+++ b/internal/base/comparer_test.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package db
+package base
 
 import (
 	"fmt"

--- a/internal/base/error.go
+++ b/internal/base/error.go
@@ -1,0 +1,12 @@
+// Copyright 2011 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package base
+
+import (
+	"errors"
+)
+
+// ErrNotFound means that a get or delete call did not find the requested key.
+var ErrNotFound = errors.New("pebble: not found")

--- a/internal/base/event.go
+++ b/internal/base/event.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package db
+package base
 
 import (
 	"bytes"

--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package db // import "github.com/petermattis/pebble/db"
+package base // import "github.com/petermattis/pebble/internal/base"
 
 import (
 	"bytes"

--- a/internal/base/internal_test.go
+++ b/internal/base/internal_test.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package db
+package base
 
 import (
 	"testing"

--- a/internal/base/logger.go
+++ b/internal/base/logger.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package db
+package base
 
 import (
 	"fmt"

--- a/internal/base/merger.go
+++ b/internal/base/merger.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package db
+package base
 
 // Merge merges oldValue and newValue, and returns the merged value. The buf
 // parameter can be used to store the newly merged value in order to avoid

--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package db
+package base
 
 import (
 	"bytes"
@@ -202,7 +202,7 @@ func (o *LevelOptions) EnsureDefaults() *LevelOptions {
 }
 
 // Options holds the optional parameters for configuring pebble. These options
-// apply to the DB at large; per-query options are defined by the ReadOptions
+// apply to the DB at large; per-query options are defined by the IterOptions
 // and WriteOptions types.
 type Options struct {
 	// Sync sstables and the WAL periodically in order to smooth out writes to
@@ -496,75 +496,4 @@ func (o *Options) Check(s string) error {
 		}
 	}
 	return nil
-}
-
-// IterOptions hold the optional per-query parameters for NewIter.
-//
-// Like Options, a nil *IterOptions is valid and means to use the default
-// values.
-type IterOptions struct {
-	// LowerBound specifies the smallest key (inclusive) that the iterator will
-	// return during iteration. If the iterator is seeked or iterated past this
-	// boundary the iterator will return Valid()==false. Setting LowerBound
-	// effectively truncates the key space visible to the iterator.
-	LowerBound []byte
-	// UpperBound specifies the largest key (exclusive) that the iterator will
-	// return during iteration. If the iterator is seeked or iterated past this
-	// boundary the iterator will return Valid()==false. Setting UpperBound
-	// effectively truncates the key space visible to the iterator.
-	UpperBound []byte
-	// TableFilter can be used to filter the tables that are scanned during
-	// iteration based on the user properties. Return true to scan the table and
-	// false to skip scanning.
-	TableFilter func(userProps map[string]string) bool
-}
-
-// GetLowerBound returns the LowerBound or nil if the receiver is nil.
-func (o *IterOptions) GetLowerBound() []byte {
-	if o == nil {
-		return nil
-	}
-	return o.LowerBound
-}
-
-// GetUpperBound returns the UpperBound or nil if the receiver is nil.
-func (o *IterOptions) GetUpperBound() []byte {
-	if o == nil {
-		return nil
-	}
-	return o.UpperBound
-}
-
-// WriteOptions hold the optional per-query parameters for Set and Delete
-// operations.
-//
-// Like Options, a nil *WriteOptions is valid and means to use the default
-// values.
-type WriteOptions struct {
-	// Sync is whether to sync underlying writes from the OS buffer cache
-	// through to actual disk, if applicable. Setting Sync can result in
-	// slower writes.
-	//
-	// If false, and the machine crashes, then some recent writes may be lost.
-	// Note that if it is just the process that crashes (and the machine does
-	// not) then no writes will be lost.
-	//
-	// In other words, Sync being false has the same semantics as a write
-	// system call. Sync being true means write followed by fsync.
-	//
-	// The default value is true.
-	Sync bool
-}
-
-// Sync specifies the default write options for writes which synchronize to
-// disk.
-var Sync = &WriteOptions{Sync: true}
-
-// NoSync specifies the default write options for writes which do not
-// synchronize to disk.
-var NoSync = &WriteOptions{Sync: false}
-
-// GetSync returns the Sync value or true if the receiver is nil.
-func (o *WriteOptions) GetSync() bool {
-	return o == nil || o.Sync
 }

--- a/internal/base/options_test.go
+++ b/internal/base/options_test.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package db
+package base
 
 import (
 	"testing"

--- a/internal/batchskl/iterator.go
+++ b/internal/batchskl/iterator.go
@@ -17,9 +17,7 @@
 
 package batchskl
 
-import (
-	"github.com/petermattis/pebble/db"
-)
+import "github.com/petermattis/pebble/internal/base"
 
 type splice struct {
 	prev uint32
@@ -37,7 +35,7 @@ func (s *splice) init(prev, next uint32) {
 type Iterator struct {
 	list  *Skiplist
 	nd    uint32
-	key   db.InternalKey
+	key   base.InternalKey
 	lower []byte
 	upper []byte
 }
@@ -54,7 +52,7 @@ func (it *Iterator) Close() error {
 // entry and false otherwise. Note that SeekGE only checks the upper bound. It
 // is up to the caller to ensure that key is greater than or equal to the lower
 // bound.
-func (it *Iterator) SeekGE(key []byte) *db.InternalKey {
+func (it *Iterator) SeekGE(key []byte) *base.InternalKey {
 	_, it.nd, _ = it.seekForBaseSplice(key, it.list.storage.AbbreviatedKey(key))
 	if it.nd == it.list.tail {
 		return nil
@@ -72,7 +70,7 @@ func (it *Iterator) SeekGE(key []byte) *db.InternalKey {
 // key. Returns true if the iterator is pointing at a valid entry and false
 // otherwise. Note that SeekLT only checks the lower bound. It is up to the
 // caller to ensure that key is less than the upper bound.
-func (it *Iterator) SeekLT(key []byte) *db.InternalKey {
+func (it *Iterator) SeekLT(key []byte) *base.InternalKey {
 	it.nd, _, _ = it.seekForBaseSplice(key, it.list.storage.AbbreviatedKey(key))
 	if it.nd == it.list.head {
 		return nil
@@ -90,7 +88,7 @@ func (it *Iterator) SeekLT(key []byte) *db.InternalKey {
 // Valid() iff list is not empty. Note that First only checks the upper
 // bound. It is up to the caller to ensure that key is greater than or equal to
 // the lower bound (e.g. via a call to SeekGE(lower)).
-func (it *Iterator) First() *db.InternalKey {
+func (it *Iterator) First() *base.InternalKey {
 	it.nd = it.list.getNext(it.list.head, 0)
 	if it.nd == it.list.tail {
 		return nil
@@ -108,7 +106,7 @@ func (it *Iterator) First() *db.InternalKey {
 // Valid() iff list is not empty. Note that Last only checks the lower
 // bound. It is up to the caller to ensure that key is less than the upper
 // bound (e.g. via a call to SeekLT(upper)).
-func (it *Iterator) Last() *db.InternalKey {
+func (it *Iterator) Last() *base.InternalKey {
 	it.nd = it.list.getPrev(it.list.tail, 0)
 	if it.nd == it.list.head {
 		return nil
@@ -124,7 +122,7 @@ func (it *Iterator) Last() *db.InternalKey {
 
 // Next advances to the next position. If there are no following nodes, then
 // Valid() will be false after this call.
-func (it *Iterator) Next() *db.InternalKey {
+func (it *Iterator) Next() *base.InternalKey {
 	it.nd = it.list.getNext(it.nd, 0)
 	if it.nd == it.list.tail {
 		return nil
@@ -140,7 +138,7 @@ func (it *Iterator) Next() *db.InternalKey {
 
 // Prev moves to the previous position. If there are no previous nodes, then
 // Valid() will be false after this call.
-func (it *Iterator) Prev() *db.InternalKey {
+func (it *Iterator) Prev() *base.InternalKey {
 	it.nd = it.list.getPrev(it.nd, 0)
 	if it.nd == it.list.head {
 		return nil
@@ -155,7 +153,7 @@ func (it *Iterator) Prev() *db.InternalKey {
 }
 
 // Key returns the key at the current position.
-func (it *Iterator) Key() *db.InternalKey {
+func (it *Iterator) Key() *base.InternalKey {
 	return &it.key
 }
 

--- a/internal/batchskl/skl.go
+++ b/internal/batchskl/skl.go
@@ -61,7 +61,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"golang.org/x/exp/rand"
 )
 
@@ -98,7 +98,7 @@ type node struct {
 // Storage defines the storage interface for retrieval and comparison of keys.
 type Storage interface {
 	// Get returns the key stored at the specified offset.
-	Get(offset uint32) db.InternalKey
+	Get(offset uint32) base.InternalKey
 
 	// AbbreviatedKey returns a fixed length prefix of the specified key such
 	// that AbbreviatedKey(a) < AbbreviatedKey(b) iff a < b and AbbreviatedKey(a)

--- a/internal/batchskl/skl_test.go
+++ b/internal/batchskl/skl_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/rand"
 )
@@ -36,13 +36,13 @@ type iterAdapter struct {
 	Iterator
 }
 
-func (i *iterAdapter) verify(key *db.InternalKey) bool {
+func (i *iterAdapter) verify(key *base.InternalKey) bool {
 	valid := key != nil
 	if valid != i.Valid() {
 		panic(fmt.Sprintf("inconsistent valid: %t != %t", valid, i.Valid()))
 	}
 	if valid {
-		if db.InternalCompare(bytes.Compare, *key, i.Key()) != 0 {
+		if base.InternalCompare(bytes.Compare, *key, i.Key()) != 0 {
 			panic(fmt.Sprintf("inconsistent key: %s != %s", *key, i.Key()))
 		}
 	}
@@ -73,7 +73,7 @@ func (i *iterAdapter) Prev() bool {
 	return i.verify(i.Iterator.Prev())
 }
 
-func (i *iterAdapter) Key() db.InternalKey {
+func (i *iterAdapter) Key() base.InternalKey {
 	return *i.Iterator.Key()
 }
 
@@ -115,12 +115,12 @@ func (d *testStorage) add(key string) uint32 {
 	return offset
 }
 
-func (d *testStorage) Get(offset uint32) db.InternalKey {
-	return db.InternalKey{UserKey: d.keys[offset]}
+func (d *testStorage) Get(offset uint32) base.InternalKey {
+	return base.InternalKey{UserKey: d.keys[offset]}
 }
 
 func (d *testStorage) AbbreviatedKey(key []byte) uint64 {
-	return db.DefaultComparer.AbbreviatedKey(key)
+	return base.DefaultComparer.AbbreviatedKey(key)
 }
 
 func (d *testStorage) Compare(a []byte, b uint32) int {

--- a/internal/rangedel/fragmenter.go
+++ b/internal/rangedel/fragmenter.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 )
 
 type tombstonesByEndKey struct {
-	cmp db.Compare
+	cmp base.Compare
 	buf []Tombstone
 }
 
@@ -38,7 +38,7 @@ func (v *tombstonesBySeqNum) Swap(i, j int) {
 // tombstones are split at their overlap points. The fragmented tombstones are
 // output to the supplied Output function.
 type Fragmenter struct {
-	Cmp db.Compare
+	Cmp base.Compare
 	// Emit is called to emit a chunk of tombstone fragments. Every tombstone
 	// within the chunk has the same start and end key, and differ only by
 	// sequence number.
@@ -141,7 +141,7 @@ func (f *Fragmenter) checkInvariants() {
 // method returns and should not be modified. This is safe for tombstones that
 // are added from a memtable or batch. It is not safe for a tombstone added
 // from an sstable where the range-del block has been prefix compressed.
-func (f *Fragmenter) Add(start db.InternalKey, end []byte) {
+func (f *Fragmenter) Add(start base.InternalKey, end []byte) {
 	if f.finished {
 		panic("pebble: tombstone fragmenter already finished")
 	}
@@ -182,7 +182,7 @@ func (f *Fragmenter) Add(start db.InternalKey, end []byte) {
 // tombstones. The key must be consistent with the ordering of the
 // tombstones. That is, it is invalid to specify a key here that is out of
 // order with the tombstone start keys passed to Add.
-func (f *Fragmenter) Deleted(key db.InternalKey, snapshot uint64) bool {
+func (f *Fragmenter) Deleted(key base.InternalKey, snapshot uint64) bool {
 	if f.finished {
 		panic("pebble: tombstone fragmenter already finished")
 	}
@@ -259,7 +259,7 @@ func (f *Fragmenter) truncateAndFlush(key []byte) {
 			// new:    c------
 			done = append(done, Tombstone{Start: t.Start, End: key})
 			f.pending = append(f.pending, Tombstone{
-				Start: db.MakeInternalKey(key, t.Start.SeqNum(), t.Start.Kind()),
+				Start: base.MakeInternalKey(key, t.Start.SeqNum(), t.Start.Kind()),
 				End:   t.End,
 			})
 		} else {

--- a/internal/rangedel/fragmenter_test.go
+++ b/internal/rangedel/fragmenter_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 )
 
@@ -28,12 +28,12 @@ func parseTombstone(t *testing.T, s string) Tombstone {
 		t.Fatal(err)
 	}
 	return Tombstone{
-		Start: db.MakeInternalKey([]byte(m[2]), uint64(seqNum), db.InternalKeyKindRangeDelete),
+		Start: base.MakeInternalKey([]byte(m[2]), uint64(seqNum), base.InternalKeyKindRangeDelete),
 		End:   []byte(m[3]),
 	}
 }
 
-func buildTombstones(t *testing.T, cmp db.Compare, s string) []Tombstone {
+func buildTombstones(t *testing.T, cmp base.Compare, s string) []Tombstone {
 	var tombstones []Tombstone
 	f := &Fragmenter{
 		Cmp: cmp,
@@ -78,7 +78,7 @@ func formatTombstones(tombstones []Tombstone) string {
 }
 
 func TestFragmenter(t *testing.T) {
-	cmp := db.DefaultComparer.Compare
+	cmp := base.DefaultComparer.Compare
 
 	var getRe = regexp.MustCompile(`(\w+)#(\d+)`)
 
@@ -146,7 +146,7 @@ func TestFragmenterDeleted(t *testing.T) {
 		switch d.Cmd {
 		case "build":
 			f := &Fragmenter{
-				Cmp: db.DefaultComparer.Compare,
+				Cmp: base.DefaultComparer.Compare,
 				Emit: func(fragmented []Tombstone) {
 				},
 			}
@@ -157,14 +157,14 @@ func TestFragmenterDeleted(t *testing.T) {
 					t := parseTombstone(t, strings.TrimPrefix(line, "add "))
 					f.Add(t.Start, t.End)
 				case strings.HasPrefix(line, "deleted "):
-					key := db.ParseInternalKey(strings.TrimPrefix(line, "deleted "))
+					key := base.ParseInternalKey(strings.TrimPrefix(line, "deleted "))
 					func() {
 						defer func() {
 							if r := recover(); r != nil {
 								fmt.Fprintf(&buf, "%s: %s\n", key, r)
 							}
 						}()
-						fmt.Fprintf(&buf, "%s: %t\n", key, f.Deleted(key, db.InternalKeySeqNumMax))
+						fmt.Fprintf(&buf, "%s: %t\n", key, f.Deleted(key, base.InternalKeySeqNumMax))
 					}()
 				}
 			}

--- a/internal/rangedel/get.go
+++ b/internal/rangedel/get.go
@@ -4,30 +4,28 @@
 
 package rangedel
 
-import (
-	"github.com/petermattis/pebble/db"
-)
+import "github.com/petermattis/pebble/internal/base"
 
 // iterator is a subset of the pebble.internalIterator interface needed for
 // range deletion iteration.
 type iterator interface {
 	// SeekLT moves the iterator to the last key/value pair whose key is less
 	// than the given key.
-	SeekLT(key []byte) (*db.InternalKey, []byte)
+	SeekLT(key []byte) (*base.InternalKey, []byte)
 
 	// First moves the iterator the the first key/value pair.
-	First() (*db.InternalKey, []byte)
+	First() (*base.InternalKey, []byte)
 
 	// Last moves the iterator the the last key/value pair.
-	Last() (*db.InternalKey, []byte)
+	Last() (*base.InternalKey, []byte)
 
 	// Next moves the iterator to the next key/value pair.
 	// It returns whether the iterator is exhausted.
-	Next() (*db.InternalKey, []byte)
+	Next() (*base.InternalKey, []byte)
 
 	// Prev moves the iterator to the previous key/value pair.
 	// It returns whether the iterator is exhausted.
-	Prev() (*db.InternalKey, []byte)
+	Prev() (*base.InternalKey, []byte)
 }
 
 // Get returns the newest tombstone that contains the target key. If no
@@ -36,7 +34,7 @@ type iterator interface {
 // older than the snapshot sequence number are visible). The iterator must
 // contain fragmented tombstones: any overlapping tombstones must have the same
 // start and end key.
-func Get(cmp db.Compare, iter iterator, key []byte, snapshot uint64) Tombstone {
+func Get(cmp base.Compare, iter iterator, key []byte, snapshot uint64) Tombstone {
 	// NB: We use SeekLT in order to land on the proper tombstone for a search
 	// key that resides in the middle of a tombstone. Consider the scenario:
 	//

--- a/internal/rangedel/iter.go
+++ b/internal/rangedel/iter.go
@@ -4,19 +4,17 @@
 
 package rangedel
 
-import (
-	"github.com/petermattis/pebble/db"
-)
+import "github.com/petermattis/pebble/internal/base"
 
 // Iter is an iterator over a set of fragmented tombstones.
 type Iter struct {
-	cmp        db.Compare
+	cmp        base.Compare
 	tombstones []Tombstone
 	index      int
 }
 
 // NewIter returns a new iterator over a set of fragmented tombstones.
-func NewIter(cmp db.Compare, tombstones []Tombstone) *Iter {
+func NewIter(cmp base.Compare, tombstones []Tombstone) *Iter {
 	return &Iter{
 		cmp:        cmp,
 		tombstones: tombstones,
@@ -26,18 +24,18 @@ func NewIter(cmp db.Compare, tombstones []Tombstone) *Iter {
 
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble
 // package.
-func (i *Iter) SeekGE(key []byte) (*db.InternalKey, []byte) {
+func (i *Iter) SeekGE(key []byte) (*base.InternalKey, []byte) {
 	// NB: manually inlined sort.Seach is ~5% faster.
 	//
 	// Define f(-1) == false and f(n) == true.
 	// Invariant: f(index-1) == false, f(upper) == true.
-	ikey := db.MakeSearchKey(key)
+	ikey := base.MakeSearchKey(key)
 	i.index = 0
 	upper := len(i.tombstones)
 	for i.index < upper {
 		h := int(uint(i.index+upper) >> 1) // avoid overflow when computing h
 		// i.index ≤ h < upper
-		if db.InternalCompare(i.cmp, ikey, i.tombstones[h].Start) >= 0 {
+		if base.InternalCompare(i.cmp, ikey, i.tombstones[h].Start) >= 0 {
 			i.index = h + 1 // preserves f(i-1) == false
 		} else {
 			upper = h // preserves f(j) == true
@@ -52,25 +50,25 @@ func (i *Iter) SeekGE(key []byte) (*db.InternalKey, []byte) {
 	return &t.Start, t.End
 }
 
-func (i *Iter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+func (i *Iter) SeekPrefixGE(prefix, key []byte) (*base.InternalKey, []byte) {
 	// This should never be called as prefix iteration is only done for point records.
 	panic("pebble: SeekPrefixGE unimplemented")
 }
 
 // SeekLT implements internalIterator.SeekLT, as documented in the pebble
 // package.
-func (i *Iter) SeekLT(key []byte) (*db.InternalKey, []byte) {
+func (i *Iter) SeekLT(key []byte) (*base.InternalKey, []byte) {
 	// NB: manually inlined sort.Search is ~5% faster.
 	//
 	// Define f(-1) == false and f(n) == true.
 	// Invariant: f(index-1) == false, f(upper) == true.
-	ikey := db.MakeSearchKey(key)
+	ikey := base.MakeSearchKey(key)
 	i.index = 0
 	upper := len(i.tombstones)
 	for i.index < upper {
 		h := int(uint(i.index+upper) >> 1) // avoid overflow when computing h
 		// i.index ≤ h < upper
-		if db.InternalCompare(i.cmp, ikey, i.tombstones[h].Start) > 0 {
+		if base.InternalCompare(i.cmp, ikey, i.tombstones[h].Start) > 0 {
 			i.index = h + 1 // preserves f(i-1) == false
 		} else {
 			upper = h // preserves f(j) == true
@@ -91,7 +89,7 @@ func (i *Iter) SeekLT(key []byte) (*db.InternalKey, []byte) {
 
 // First implements internalIterator.First, as documented in the pebble
 // package.
-func (i *Iter) First() (*db.InternalKey, []byte) {
+func (i *Iter) First() (*base.InternalKey, []byte) {
 	if len(i.tombstones) == 0 {
 		return nil, nil
 	}
@@ -102,7 +100,7 @@ func (i *Iter) First() (*db.InternalKey, []byte) {
 
 // Last implements internalIterator.Last, as documented in the pebble
 // package.
-func (i *Iter) Last() (*db.InternalKey, []byte) {
+func (i *Iter) Last() (*base.InternalKey, []byte) {
 	if len(i.tombstones) == 0 {
 		return nil, nil
 	}
@@ -113,7 +111,7 @@ func (i *Iter) Last() (*db.InternalKey, []byte) {
 
 // Next implements internalIterator.Next, as documented in the pebble
 // package.
-func (i *Iter) Next() (*db.InternalKey, []byte) {
+func (i *Iter) Next() (*base.InternalKey, []byte) {
 	if i.index == len(i.tombstones) {
 		return nil, nil
 	}
@@ -127,7 +125,7 @@ func (i *Iter) Next() (*db.InternalKey, []byte) {
 
 // Prev implements internalIterator.Prev, as documented in the pebble
 // package.
-func (i *Iter) Prev() (*db.InternalKey, []byte) {
+func (i *Iter) Prev() (*base.InternalKey, []byte) {
 	if i.index < 0 {
 		return nil, nil
 	}
@@ -141,7 +139,7 @@ func (i *Iter) Prev() (*db.InternalKey, []byte) {
 
 // Key implements internalIterator.Key, as documented in the pebble
 // package.
-func (i *Iter) Key() *db.InternalKey {
+func (i *Iter) Key() *base.InternalKey {
 	return &i.tombstones[i.index].Start
 }
 

--- a/internal/rangedel/iter_test.go
+++ b/internal/rangedel/iter_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 )
 
@@ -23,14 +23,14 @@ func TestIter(t *testing.T) {
 			for _, key := range strings.Split(d.Input, "\n") {
 				j := strings.Index(key, ":")
 				tombstones = append(tombstones, Tombstone{
-					Start: db.ParseInternalKey(key[:j]),
+					Start: base.ParseInternalKey(key[:j]),
 					End:   []byte(key[j+1:]),
 				})
 			}
 			return ""
 
 		case "iter":
-			iter := NewIter(db.DefaultComparer.Compare, tombstones)
+			iter := NewIter(base.DefaultComparer.Compare, tombstones)
 			defer iter.Close()
 
 			var b bytes.Buffer

--- a/internal/rangedel/seek.go
+++ b/internal/rangedel/seek.go
@@ -4,9 +4,7 @@
 
 package rangedel
 
-import (
-	"github.com/petermattis/pebble/db"
-)
+import "github.com/petermattis/pebble/internal/base"
 
 // invalidate the specified iterator by moving it past the last entry.
 func invalidate(iter iterator) {
@@ -19,7 +17,7 @@ func invalidate(iter iterator) {
 // tombstones older than the snapshot sequence number are visible). The
 // iterator must contain fragmented tombstones: any overlapping tombstones must
 // have the same start and end key.
-func SeekGE(cmp db.Compare, iter iterator, key []byte, snapshot uint64) Tombstone {
+func SeekGE(cmp base.Compare, iter iterator, key []byte, snapshot uint64) Tombstone {
 	// NB: We use SeekLT in order to land on the proper tombstone for a search
 	// key that resides in the middle of a tombstone. Consider the scenario:
 	//
@@ -86,7 +84,7 @@ func SeekGE(cmp db.Compare, iter iterator, key []byte, snapshot uint64) Tombston
 // tombstones older than the snapshot sequence number are visible). The
 // iterator must contain fragmented tombstones: any overlapping tombstones must
 // have the same start and end key.
-func SeekLE(cmp db.Compare, iter iterator, key []byte, snapshot uint64) Tombstone {
+func SeekLE(cmp base.Compare, iter iterator, key []byte, snapshot uint64) Tombstone {
 	// NB: We use SeekLT in order to land on the proper tombstone for a search
 	// key that resides in the middle of a tombstone. Consider the scenario:
 	//

--- a/internal/rangedel/seek_test.go
+++ b/internal/rangedel/seek_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 )
 
@@ -20,13 +20,13 @@ type iterAdapter struct {
 	*Iter
 }
 
-func (i *iterAdapter) verify(key *db.InternalKey, val []byte) (*db.InternalKey, []byte) {
+func (i *iterAdapter) verify(key *base.InternalKey, val []byte) (*base.InternalKey, []byte) {
 	valid := key != nil
 	if valid != i.Valid() {
 		panic(fmt.Sprintf("inconsistent valid: %t != %t", valid, i.Valid()))
 	}
 	if valid {
-		if db.InternalCompare(bytes.Compare, *key, *i.Key()) != 0 {
+		if base.InternalCompare(bytes.Compare, *key, *i.Key()) != 0 {
 			panic(fmt.Sprintf("inconsistent key: %s != %s", *key, i.Key()))
 		}
 		if !bytes.Equal(val, i.Value()) {
@@ -36,32 +36,32 @@ func (i *iterAdapter) verify(key *db.InternalKey, val []byte) (*db.InternalKey, 
 	return key, val
 }
 
-func (i *iterAdapter) SeekGE(key []byte) (*db.InternalKey, []byte) {
+func (i *iterAdapter) SeekGE(key []byte) (*base.InternalKey, []byte) {
 	return i.verify(i.Iter.SeekGE(key))
 }
 
-func (i *iterAdapter) SeekLT(key []byte) (*db.InternalKey, []byte) {
+func (i *iterAdapter) SeekLT(key []byte) (*base.InternalKey, []byte) {
 	return i.verify(i.Iter.SeekLT(key))
 }
 
-func (i *iterAdapter) First() (*db.InternalKey, []byte) {
+func (i *iterAdapter) First() (*base.InternalKey, []byte) {
 	return i.verify(i.Iter.First())
 }
 
-func (i *iterAdapter) Last() (*db.InternalKey, []byte) {
+func (i *iterAdapter) Last() (*base.InternalKey, []byte) {
 	return i.verify(i.Iter.Last())
 }
 
-func (i *iterAdapter) Next() (*db.InternalKey, []byte) {
+func (i *iterAdapter) Next() (*base.InternalKey, []byte) {
 	return i.verify(i.Iter.Next())
 }
 
-func (i *iterAdapter) Prev() (*db.InternalKey, []byte) {
+func (i *iterAdapter) Prev() (*base.InternalKey, []byte) {
 	return i.verify(i.Iter.Prev())
 }
 
 func TestSeek(t *testing.T) {
-	cmp := db.DefaultComparer.Compare
+	cmp := base.DefaultComparer.Compare
 	iter := &iterAdapter{}
 
 	datadriven.RunTest(t, "testdata/seek", func(d *datadriven.TestData) string {

--- a/internal/rangedel/tombstone.go
+++ b/internal/rangedel/tombstone.go
@@ -7,25 +7,25 @@ package rangedel // import "github.com/petermattis/pebble/internal/rangedel"
 import (
 	"fmt"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 )
 
 // Tombstone is a range deletion tombstone. A range deletion tombstone deletes
 // all of the keys in the range [start,end). Note that the start key is
 // inclusive and the end key is exclusive.
 type Tombstone struct {
-	Start db.InternalKey
+	Start base.InternalKey
 	End   []byte
 }
 
 // Empty returns true if the tombstone does not cover any keys.
 func (t Tombstone) Empty() bool {
-	return t.Start.Kind() != db.InternalKeyKindRangeDelete
+	return t.Start.Kind() != base.InternalKeyKindRangeDelete
 }
 
 // Contains returns true if the specified key resides within the range
 // tombstone bounds.
-func (t Tombstone) Contains(cmp db.Compare, key []byte) bool {
+func (t Tombstone) Contains(cmp base.Compare, key []byte) bool {
 	return cmp(t.Start.UserKey, key) <= 0 && cmp(key, t.End) < 0
 }
 

--- a/internal/rangedel/truncate.go
+++ b/internal/rangedel/truncate.go
@@ -4,13 +4,11 @@
 
 package rangedel
 
-import (
-	"github.com/petermattis/pebble/db"
-)
+import "github.com/petermattis/pebble/internal/base"
 
 // Truncate creates a new iterator where every tombstone in the supplied
 // iterator is truncated to be contained within the range [lower, upper).
-func Truncate(cmp db.Compare, iter iterator, lower, upper []byte) *Iter {
+func Truncate(cmp base.Compare, iter iterator, lower, upper []byte) *Iter {
 	var tombstones []Tombstone
 	for key, value := iter.First(); key != nil; key, value = iter.Next() {
 		t := Tombstone{

--- a/internal/rangedel/truncate_test.go
+++ b/internal/rangedel/truncate_test.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 )
 
 func TestTruncate(t *testing.T) {
-	cmp := db.DefaultComparer.Compare
+	cmp := base.DefaultComparer.Compare
 	var iter iterator
 
 	datadriven.RunTest(t, "testdata/truncate", func(d *datadriven.TestData) string {

--- a/internal_test.go
+++ b/internal_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 )
 
 // internalIterAdapter adapts the new internalIterator interface which returns
@@ -19,13 +19,13 @@ type internalIterAdapter struct {
 	internalIterator
 }
 
-func (i *internalIterAdapter) verify(key *db.InternalKey, val []byte) bool {
+func (i *internalIterAdapter) verify(key *InternalKey, val []byte) bool {
 	valid := key != nil
 	if valid != i.Valid() {
 		panic(fmt.Sprintf("inconsistent valid: %t != %t", valid, i.Valid()))
 	}
 	if valid {
-		if db.InternalCompare(bytes.Compare, *key, i.Key()) != 0 {
+		if base.InternalCompare(bytes.Compare, *key, i.Key()) != 0 {
 			panic(fmt.Sprintf("inconsistent key: %s != %s", *key, i.Key()))
 		}
 		if !bytes.Equal(val, i.Value()) {
@@ -63,6 +63,6 @@ func (i *internalIterAdapter) Prev() bool {
 	return i.verify(i.internalIterator.Prev())
 }
 
-func (i *internalIterAdapter) Key() db.InternalKey {
+func (i *internalIterAdapter) Key() InternalKey {
 	return *i.internalIterator.Key()
 }

--- a/log_recycler_test.go
+++ b/log_recycler_test.go
@@ -7,7 +7,6 @@ package pebble
 import (
 	"testing"
 
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -75,7 +74,7 @@ func TestLogRecycler(t *testing.T) {
 }
 
 func TestRecycleLogs(t *testing.T) {
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
 	})
 	if err != nil {

--- a/logger.go
+++ b/logger.go
@@ -2,11 +2,11 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-package db
+package pebble
 
 import (
-	"errors"
+	"github.com/petermattis/pebble/internal/base"
 )
 
-// ErrNotFound means that a get or delete call did not find the requested key.
-var ErrNotFound = errors.New("pebble: not found")
+// Logger exports the base.Logger type.
+type Logger = base.Logger

--- a/merger.go
+++ b/merger.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import "github.com/petermattis/pebble/internal/base"
+
+// Merge exports the base.Merge type.
+type Merge = base.Merge
+
+// Merger exports the base.Merger type.
+type Merger = base.Merger
+
+// DefaultMerger exports the base.DefaultMerger variable.
+var DefaultMerger = base.DefaultMerger

--- a/merging_iter.go
+++ b/merging_iter.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/rangedel"
 )
 
@@ -197,14 +197,14 @@ var _ internalIterator = (*mergingIter)(nil)
 // keys: if iters[i] contains a key k then iters[j] will not contain that key k.
 //
 // None of the iters may be nil.
-func newMergingIter(cmp db.Compare, iters ...internalIterator) *mergingIter {
+func newMergingIter(cmp Compare, iters ...internalIterator) *mergingIter {
 	m := &mergingIter{}
 	m.init(cmp, iters...)
 	return m
 }
 
-func (m *mergingIter) init(cmp db.Compare, iters ...internalIterator) {
-	m.snapshot = db.InternalKeySeqNumMax
+func (m *mergingIter) init(cmp Compare, iters ...internalIterator) {
+	m.snapshot = InternalKeySeqNumMax
 	m.iters = iters
 	m.heap.cmp = cmp
 	m.heap.items = make([]mergingIterItem, 0, len(iters))
@@ -298,7 +298,7 @@ func (m *mergingIter) switchToMinHeap() {
 			iterKey, _ = i.Next()
 		}
 		for ; iterKey != nil; iterKey, _ = i.Next() {
-			if db.InternalCompare(m.heap.cmp, key, *iterKey) < 0 {
+			if base.InternalCompare(m.heap.cmp, key, *iterKey) < 0 {
 				// key < iter-key
 				break
 			}
@@ -339,7 +339,7 @@ func (m *mergingIter) switchToMaxHeap() {
 			iterKey, _ = i.Prev()
 		}
 		for ; iterKey != nil; iterKey, _ = i.Prev() {
-			if db.InternalCompare(m.heap.cmp, key, *iterKey) > 0 {
+			if base.InternalCompare(m.heap.cmp, key, *iterKey) > 0 {
 				// key > iter-key
 				break
 			}
@@ -407,7 +407,7 @@ func (m *mergingIter) isNextEntryDeleted(item *mergingIterItem) bool {
 	return false
 }
 
-func (m *mergingIter) findNextEntry() (*db.InternalKey, []byte) {
+func (m *mergingIter) findNextEntry() (*InternalKey, []byte) {
 	for m.heap.len() > 0 && m.err == nil {
 		item := &m.heap.items[0]
 		if m.rangeDelIters != nil && m.isNextEntryDeleted(item) {
@@ -475,7 +475,7 @@ func (m *mergingIter) isPrevEntryDeleted(item *mergingIterItem) bool {
 	return false
 }
 
-func (m *mergingIter) findPrevEntry() (*db.InternalKey, []byte) {
+func (m *mergingIter) findPrevEntry() (*InternalKey, []byte) {
 	for m.heap.len() > 0 && m.err == nil {
 		item := &m.heap.items[0]
 		if m.rangeDelIters != nil && m.isPrevEntryDeleted(item) {
@@ -539,13 +539,13 @@ func (m *mergingIter) seekGE(key []byte, level int) {
 	m.initMinHeap()
 }
 
-func (m *mergingIter) SeekGE(key []byte) (*db.InternalKey, []byte) {
+func (m *mergingIter) SeekGE(key []byte) (*InternalKey, []byte) {
 	m.prefix = nil
 	m.seekGE(key, 0 /* start level */)
 	return m.findNextEntry()
 }
 
-func (m *mergingIter) SeekPrefixGE(prefix, key []byte) (*db.InternalKey, []byte) {
+func (m *mergingIter) SeekPrefixGE(prefix, key []byte) (*InternalKey, []byte) {
 	m.prefix = prefix
 	m.seekGE(key, 0 /* start level */)
 	return m.findNextEntry()
@@ -573,13 +573,13 @@ func (m *mergingIter) seekLT(key []byte, level int) {
 	m.initMaxHeap()
 }
 
-func (m *mergingIter) SeekLT(key []byte) (*db.InternalKey, []byte) {
+func (m *mergingIter) SeekLT(key []byte) (*InternalKey, []byte) {
 	m.prefix = nil
 	m.seekLT(key, 0 /* start level */)
 	return m.findPrevEntry()
 }
 
-func (m *mergingIter) First() (*db.InternalKey, []byte) {
+func (m *mergingIter) First() (*InternalKey, []byte) {
 	m.prefix = nil
 	m.heap.items = m.heap.items[:0]
 	for _, t := range m.iters {
@@ -591,7 +591,7 @@ func (m *mergingIter) First() (*db.InternalKey, []byte) {
 	return m.findNextEntry()
 }
 
-func (m *mergingIter) Last() (*db.InternalKey, []byte) {
+func (m *mergingIter) Last() (*InternalKey, []byte) {
 	m.prefix = nil
 	for _, t := range m.iters {
 		// TODO(peter): save key and value so we don't have to access t.Key() and
@@ -602,7 +602,7 @@ func (m *mergingIter) Last() (*db.InternalKey, []byte) {
 	return m.findPrevEntry()
 }
 
-func (m *mergingIter) Next() (*db.InternalKey, []byte) {
+func (m *mergingIter) Next() (*InternalKey, []byte) {
 	if m.err != nil {
 		return nil, nil
 	}
@@ -620,7 +620,7 @@ func (m *mergingIter) Next() (*db.InternalKey, []byte) {
 	return m.findNextEntry()
 }
 
-func (m *mergingIter) Prev() (*db.InternalKey, []byte) {
+func (m *mergingIter) Prev() (*InternalKey, []byte) {
 	if m.err != nil {
 		return nil, nil
 	}
@@ -638,7 +638,7 @@ func (m *mergingIter) Prev() (*db.InternalKey, []byte) {
 	return m.findPrevEntry()
 }
 
-func (m *mergingIter) Key() *db.InternalKey {
+func (m *mergingIter) Key() *InternalKey {
 	return &m.heap.items[0].key
 }
 

--- a/merging_iter_heap.go
+++ b/merging_iter_heap.go
@@ -4,16 +4,14 @@
 
 package pebble
 
-import "github.com/petermattis/pebble/db"
-
 type mergingIterItem struct {
 	index int
-	key   db.InternalKey
+	key   InternalKey
 	value []byte
 }
 
 type mergingIterHeap struct {
-	cmp     db.Compare
+	cmp     Compare
 	reverse bool
 	items   []mergingIterItem
 }

--- a/open.go
+++ b/open.go
@@ -13,13 +13,12 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/internal/arenaskl"
 	"github.com/petermattis/pebble/internal/record"
 	"github.com/petermattis/pebble/vfs"
 )
 
-func createDB(dirname string, opts *db.Options) (retErr error) {
+func createDB(dirname string, opts *Options) (retErr error) {
 	const manifestFileNum = 1
 	ve := versionEdit{
 		comparatorName: opts.Comparer.Name,
@@ -54,7 +53,7 @@ func createDB(dirname string, opts *db.Options) (retErr error) {
 }
 
 // Open opens a LevelDB whose files live in the given directory.
-func Open(dirname string, opts *db.Options) (*DB, error) {
+func Open(dirname string, opts *Options) (*DB, error) {
 	opts = opts.EnsureDefaults()
 	d := &DB{
 		dirname:        dirname,
@@ -331,7 +330,7 @@ func (d *DB) replayWAL(
 	return maxSeqNum, nil
 }
 
-func checkOptions(opts *db.Options, path string) error {
+func checkOptions(opts *Options, path string) error {
 	f, err := opts.FS.Open(path)
 	if err != nil {
 		return err

--- a/open_test.go
+++ b/open_test.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +21,7 @@ import (
 func TestErrorIfDBExists(t *testing.T) {
 	for _, b := range [...]bool{false, true} {
 		mem := vfs.NewMem()
-		d0, err := Open("", &db.Options{
+		d0, err := Open("", &Options{
 			FS: mem,
 		})
 		if err != nil {
@@ -34,7 +33,7 @@ func TestErrorIfDBExists(t *testing.T) {
 			continue
 		}
 
-		d1, err := Open("", &db.Options{
+		d1, err := Open("", &Options{
 			FS:              mem,
 			ErrorIfDBExists: b,
 		})
@@ -51,7 +50,7 @@ func TestErrorIfDBExists(t *testing.T) {
 func TestNewDBFilenames(t *testing.T) {
 	fooBar := filepath.Join("foo", "bar")
 	mem := vfs.NewMem()
-	d, err := Open(fooBar, &db.Options{
+	d, err := Open(fooBar, &Options{
 		FS: mem,
 	})
 	if err != nil {
@@ -77,7 +76,7 @@ func TestNewDBFilenames(t *testing.T) {
 }
 
 func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
-	opts := &db.Options{
+	opts := &Options{
 		FS: fs,
 	}
 
@@ -195,7 +194,7 @@ func TestOpenCloseOpenClose(t *testing.T) {
 
 func TestOpenOptionsCheck(t *testing.T) {
 	mem := vfs.NewMem()
-	opts := &db.Options{FS: mem}
+	opts := &Options{FS: mem}
 
 	d, err := Open("", opts)
 	if err != nil {
@@ -205,15 +204,15 @@ func TestOpenOptionsCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	opts = &db.Options{
-		Comparer: &db.Comparer{Name: "foo"},
+	opts = &Options{
+		Comparer: &Comparer{Name: "foo"},
 		FS:       mem,
 	}
 	_, err = Open("", opts)
 	require.Regexp(t, `comparer name from file.*!=.*`, err)
 
-	opts = &db.Options{
-		Merger: &db.Merger{Name: "bar"},
+	opts = &Options{
+		Merger: &Merger{Name: "bar"},
 		FS:     mem,
 	}
 	_, err = Open("", opts)

--- a/options.go
+++ b/options.go
@@ -1,0 +1,120 @@
+// Copyright 2011 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import "github.com/petermattis/pebble/internal/base"
+
+// Compression exports the base.Compression type.
+type Compression = base.Compression
+
+// Exported Compression constants.
+const (
+	DefaultCompression = base.DefaultCompression
+	NoCompression      = base.NoCompression
+	SnappyCompression  = base.SnappyCompression
+)
+
+// FilterType exports the base.FilterType type.
+type FilterType = base.FilterType
+
+// Exported TableFilter constants.
+const (
+	TableFilter = base.TableFilter
+)
+
+// FilterWriter exports the base.FilterWriter type.
+type FilterWriter = base.FilterWriter
+
+// FilterPolicy exports the base.FilterPolicy type.
+type FilterPolicy = base.FilterPolicy
+
+// TableFormat exports the base.TableFormat type.
+type TableFormat = base.TableFormat
+
+// Exported TableFormat constants.
+const (
+	TableFormatRocksDBv2 = base.TableFormatRocksDBv2
+	TableFormatLevelDB   = base.TableFormatLevelDB
+)
+
+// TablePropertyCollector exports the base.TablePropertyCollector type.
+type TablePropertyCollector = base.TablePropertyCollector
+
+// LevelOptions exports the base.LevelOptions type.
+type LevelOptions = base.LevelOptions
+
+// Options exports the base.Options type.
+type Options = base.Options
+
+// IterOptions hold the optional per-query parameters for NewIter.
+//
+// Like Options, a nil *IterOptions is valid and means to use the default
+// values.
+type IterOptions struct {
+	// LowerBound specifies the smallest key (inclusive) that the iterator will
+	// return during iteration. If the iterator is seeked or iterated past this
+	// boundary the iterator will return Valid()==false. Setting LowerBound
+	// effectively truncates the key space visible to the iterator.
+	LowerBound []byte
+	// UpperBound specifies the largest key (exclusive) that the iterator will
+	// return during iteration. If the iterator is seeked or iterated past this
+	// boundary the iterator will return Valid()==false. Setting UpperBound
+	// effectively truncates the key space visible to the iterator.
+	UpperBound []byte
+	// TableFilter can be used to filter the tables that are scanned during
+	// iteration based on the user properties. Return true to scan the table and
+	// false to skip scanning.
+	TableFilter func(userProps map[string]string) bool
+}
+
+// GetLowerBound returns the LowerBound or nil if the receiver is nil.
+func (o *IterOptions) GetLowerBound() []byte {
+	if o == nil {
+		return nil
+	}
+	return o.LowerBound
+}
+
+// GetUpperBound returns the UpperBound or nil if the receiver is nil.
+func (o *IterOptions) GetUpperBound() []byte {
+	if o == nil {
+		return nil
+	}
+	return o.UpperBound
+}
+
+// WriteOptions hold the optional per-query parameters for Set and Delete
+// operations.
+//
+// Like Options, a nil *WriteOptions is valid and means to use the default
+// values.
+type WriteOptions struct {
+	// Sync is whether to sync underlying writes from the OS buffer cache
+	// through to actual disk, if applicable. Setting Sync can result in
+	// slower writes.
+	//
+	// If false, and the machine crashes, then some recent writes may be lost.
+	// Note that if it is just the process that crashes (and the machine does
+	// not) then no writes will be lost.
+	//
+	// In other words, Sync being false has the same semantics as a write
+	// system call. Sync being true means write followed by fsync.
+	//
+	// The default value is true.
+	Sync bool
+}
+
+// Sync specifies the default write options for writes which synchronize to
+// disk.
+var Sync = &WriteOptions{Sync: true}
+
+// NoSync specifies the default write options for writes which do not
+// synchronize to disk.
+var NoSync = &WriteOptions{Sync: false}
+
+// GetSync returns the Sync value or true if the receiver is nil.
+func (o *WriteOptions) GetSync() bool {
+	return o == nil || o.Sync
+}

--- a/ptable/reader.go
+++ b/ptable/reader.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/petermattis/pebble/cache"
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/crc"
 	"github.com/petermattis/pebble/vfs"
 )
@@ -21,7 +21,7 @@ import (
 // Iter ...
 type Iter struct {
 	reader *Reader
-	cmp    db.Compare
+	cmp    base.Compare
 	index  Block
 	data   Block
 	pos    int32
@@ -128,11 +128,11 @@ type Reader struct {
 	err     error
 	index   []byte
 	cache   *cache.Cache
-	cmp     db.Compare
+	cmp     base.Compare
 }
 
 // NewReader ...
-func NewReader(f vfs.File, fileNum uint64, o *db.Options) *Reader {
+func NewReader(f vfs.File, fileNum uint64, o *base.Options) *Reader {
 	o = o.EnsureDefaults()
 	r := &Reader{
 		file:    f,

--- a/ptable/table_test.go
+++ b/ptable/table_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/petermattis/pebble/cache"
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/vfs"
 	"golang.org/x/exp/rand"
 )
@@ -105,7 +105,7 @@ func TestTable(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		w := NewWriter(f, env, nil, &db.LevelOptions{BlockSize: 100})
+		w := NewWriter(f, env, nil, &base.LevelOptions{BlockSize: 100})
 		for i := int64(0); i < count; i++ {
 			if err := w.AddRow(makeRow(i)); err != nil {
 				t.Fatal(err)
@@ -170,7 +170,7 @@ func buildBenchmarkTable(b *testing.B, blockSize int, nullValues bool) (*Reader,
 	defer f0.Close()
 
 	env := newEnv(ColumnDef{Type: ColumnTypeInt64}, ColumnDef{Type: ColumnTypeInt64})
-	w := NewWriter(f0, env, nil, &db.LevelOptions{BlockSize: blockSize})
+	w := NewWriter(f0, env, nil, &base.LevelOptions{BlockSize: blockSize})
 	var keys [][]byte
 	for i := int64(0); i < 1e6; i++ {
 		var r testRow
@@ -192,7 +192,7 @@ func buildBenchmarkTable(b *testing.B, blockSize int, nullValues bool) (*Reader,
 	if err != nil {
 		b.Fatal(err)
 	}
-	return NewReader(f1, 0, &db.Options{
+	return NewReader(f1, 0, &base.Options{
 		Cache: cache.New(128 << 20),
 	}), keys
 }

--- a/ptable/writer.go
+++ b/ptable/writer.go
@@ -11,7 +11,7 @@ import (
 	"io"
 
 	"github.com/golang/snappy"
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/crc"
 	"github.com/petermattis/pebble/vfs"
 )
@@ -74,7 +74,7 @@ type Writer struct {
 	err       error
 	// The next four fields are copied from a db.Options.
 	blockSize   int
-	compression db.Compression
+	compression base.Compression
 	// The data block and index block writers.
 	block      blockWriter
 	indexBlock blockWriter
@@ -93,7 +93,7 @@ type Writer struct {
 var indexColTypes = []ColumnType{ColumnTypeBytes, ColumnTypeInt64}
 
 // NewWriter ...
-func NewWriter(f vfs.File, env *Env, _ *db.Options, lo *db.LevelOptions) *Writer {
+func NewWriter(f vfs.File, env *Env, _ *base.Options, lo *base.LevelOptions) *Writer {
 	lo = lo.EnsureDefaults()
 	w := &Writer{
 		env:         env,
@@ -238,7 +238,7 @@ func (w *Writer) maybeFinishBlock() {
 func (w *Writer) finishBlock(block *blockWriter) (blockHandle, error) {
 	b := block.Finish()
 	blockType := byte(noCompressionBlockType)
-	if w.compression == db.SnappyCompression {
+	if w.compression == base.SnappyCompression {
 		compressed := snappy.Encode(w.compressedBuf, b)
 		w.compressedBuf = compressed[:cap(compressed)]
 		if len(compressed) < len(b)-len(b)/8 {

--- a/range_del_test.go
+++ b/range_del_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/petermattis/pebble/cache"
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 	"github.com/petermattis/pebble/sstable"
 	"github.com/petermattis/pebble/vfs"
@@ -50,7 +50,7 @@ func TestRangeDel(t *testing.T) {
 		case "get":
 			snap := Snapshot{
 				db:     d,
-				seqNum: db.InternalKeySeqNumMax,
+				seqNum: InternalKeySeqNumMax,
 			}
 
 			for _, arg := range td.CmdArgs {
@@ -83,7 +83,7 @@ func TestRangeDel(t *testing.T) {
 		case "iter":
 			snap := Snapshot{
 				db:     d,
-				seqNum: db.InternalKeySeqNumMax,
+				seqNum: InternalKeySeqNumMax,
 			}
 
 			for _, arg := range td.CmdArgs {
@@ -118,9 +118,9 @@ func TestRangeDel(t *testing.T) {
 // disk, only in memory.
 func TestRangeDelCompactionTruncation(t *testing.T) {
 	// Use a small target file size so that there is a single key per sstable.
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
-		Levels: []db.LevelOptions{
+		Levels: []LevelOptions{
 			{TargetFileSize: 100},
 			{TargetFileSize: 100},
 			{TargetFileSize: 1},
@@ -255,7 +255,7 @@ func BenchmarkRangeDelIterate(b *testing.B) {
 			for _, deleted := range []int{entries, entries - 1} {
 				b.Run(fmt.Sprintf("deleted=%d", deleted), func(b *testing.B) {
 					mem := vfs.NewMem()
-					d, err := Open("", &db.Options{
+					d, err := Open("", &Options{
 						Cache: cache.New(128 << 20), // 128 MB
 						FS:    mem,
 					})
@@ -274,11 +274,11 @@ func BenchmarkRangeDelIterate(b *testing.B) {
 					if err != nil {
 						b.Fatal(err)
 					}
-					w := sstable.NewWriter(f, nil, db.LevelOptions{
+					w := sstable.NewWriter(f, nil, LevelOptions{
 						BlockSize: 32 << 10, // 32 KB
 					})
 					for i := 0; i < entries; i++ {
-						key := db.MakeInternalKey(makeKey(i), 0, db.InternalKeyKindSet)
+						key := base.MakeInternalKey(makeKey(i), 0, InternalKeyKindSet)
 						if err := w.Add(key, nil); err != nil {
 							b.Fatal(err)
 						}

--- a/read_state_test.go
+++ b/read_state_test.go
@@ -9,13 +9,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/vfs"
 	"golang.org/x/exp/rand"
 )
 
 func BenchmarkReadState(b *testing.B) {
-	d, err := Open("", &db.Options{
+	d, err := Open("", &Options{
 		FS: vfs.NewMem(),
 	})
 	if err != nil {

--- a/snapshot.go
+++ b/snapshot.go
@@ -4,8 +4,6 @@
 
 package pebble
 
-import "github.com/petermattis/pebble/db"
-
 // Snapshot provides a read-only point-in-time view of the DB state.
 type Snapshot struct {
 	// The db the snapshot was created from.
@@ -33,7 +31,7 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 // NewIter returns an iterator that is unpositioned (Iterator.Valid() will
 // return false). The iterator can be positioned via a call to SeekGE,
 // SeekLT, First or Last.
-func (s *Snapshot) NewIter(o *db.IterOptions) *Iterator {
+func (s *Snapshot) NewIter(o *IterOptions) *Iterator {
 	return s.db.newIterInternal(nil /* batchIter */, nil /* batchRangeDelIter */, s, o)
 }
 

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/internal/datadriven"
 	"github.com/petermattis/pebble/vfs"
 )
@@ -48,7 +47,7 @@ func TestSnapshot(t *testing.T) {
 		switch td.Cmd {
 		case "define":
 			var err error
-			d, err = Open("", &db.Options{
+			d, err = Open("", &Options{
 				FS: vfs.NewMem(),
 			})
 			if err != nil {

--- a/sstable/block_test.go
+++ b/sstable/block_test.go
@@ -12,14 +12,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 	"golang.org/x/exp/rand"
 )
 
 func TestBlockWriter(t *testing.T) {
-	ikey := func(s string) db.InternalKey {
-		return db.InternalKey{UserKey: []byte(s)}
+	ikey := func(s string) InternalKey {
+		return InternalKey{UserKey: []byte(s)}
 	}
 
 	w := &rawBlockWriter{
@@ -114,13 +114,13 @@ func TestBlockIter(t *testing.T) {
 }
 
 func TestBlockIter2(t *testing.T) {
-	makeIkey := func(s string) db.InternalKey {
+	makeIkey := func(s string) InternalKey {
 		j := strings.Index(s, ":")
 		seqNum, err := strconv.Atoi(s[j+1:])
 		if err != nil {
 			panic(err)
 		}
-		return db.MakeInternalKey([]byte(s[:j]), uint64(seqNum), db.InternalKeyKindSet)
+		return base.MakeInternalKey([]byte(s[:j]), uint64(seqNum), InternalKeyKindSet)
 	}
 
 	var block []byte
@@ -214,7 +214,7 @@ func BenchmarkBlockIterSeekGE(b *testing.B) {
 					restartInterval: restartInterval,
 				}
 
-				var ikey db.InternalKey
+				var ikey InternalKey
 				var keys [][]byte
 				for i := 0; w.estimatedSize() < blockSize; i++ {
 					key := []byte(fmt.Sprintf("%05d", i))
@@ -256,7 +256,7 @@ func BenchmarkBlockIterSeekLT(b *testing.B) {
 					restartInterval: restartInterval,
 				}
 
-				var ikey db.InternalKey
+				var ikey InternalKey
 				var keys [][]byte
 				for i := 0; w.estimatedSize() < blockSize; i++ {
 					key := []byte(fmt.Sprintf("%05d", i))
@@ -305,7 +305,7 @@ func BenchmarkBlockIterNext(b *testing.B) {
 					restartInterval: restartInterval,
 				}
 
-				var ikey db.InternalKey
+				var ikey InternalKey
 				for i := 0; w.estimatedSize() < blockSize; i++ {
 					ikey.UserKey = []byte(fmt.Sprintf("%05d", i))
 					w.add(ikey, nil)
@@ -337,7 +337,7 @@ func BenchmarkBlockIterPrev(b *testing.B) {
 					restartInterval: restartInterval,
 				}
 
-				var ikey db.InternalKey
+				var ikey InternalKey
 				for i := 0; w.estimatedSize() < blockSize; i++ {
 					ikey.UserKey = []byte(fmt.Sprintf("%05d", i))
 					w.add(ikey, nil)

--- a/sstable/comparer.go
+++ b/sstable/comparer.go
@@ -1,0 +1,31 @@
+// Copyright 2011 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import "github.com/petermattis/pebble/internal/base"
+
+// Compare exports the base.Compare type.
+type Compare = base.Compare
+
+// Equal exports the base.Equal type.
+type Equal = base.Equal
+
+// AbbreviatedKey exports the base.AbbreviatedKey type.
+type AbbreviatedKey = base.AbbreviatedKey
+
+// Separator exports the base.Separator type.
+type Separator = base.Separator
+
+// Successor exports the base.Successor type.
+type Successor = base.Successor
+
+// Split exports the base.Split type.
+type Split = base.Split
+
+// Comparer exports the base.Comparer type.
+type Comparer = base.Comparer
+
+// DefaultComparer exports the base.DefaultComparer variable.
+var DefaultComparer = base.DefaultComparer

--- a/sstable/filter.go
+++ b/sstable/filter.go
@@ -4,10 +4,6 @@
 
 package sstable
 
-import (
-	"github.com/petermattis/pebble/db"
-)
-
 type filterWriter interface {
 	addKey(key []byte)
 	finishBlock(blockOffset uint64) error
@@ -17,30 +13,30 @@ type filterWriter interface {
 }
 
 type tableFilterReader struct {
-	policy db.FilterPolicy
+	policy FilterPolicy
 }
 
-func newTableFilterReader(policy db.FilterPolicy) *tableFilterReader {
+func newTableFilterReader(policy FilterPolicy) *tableFilterReader {
 	return &tableFilterReader{
 		policy: policy,
 	}
 }
 
 func (f *tableFilterReader) mayContain(data, key []byte) bool {
-	return f.policy.MayContain(db.TableFilter, data, key)
+	return f.policy.MayContain(TableFilter, data, key)
 }
 
 type tableFilterWriter struct {
-	policy db.FilterPolicy
-	writer db.FilterWriter
+	policy FilterPolicy
+	writer FilterWriter
 	// count is the count of the number of keys added to the filter.
 	count int
 }
 
-func newTableFilterWriter(policy db.FilterPolicy) *tableFilterWriter {
+func newTableFilterWriter(policy FilterPolicy) *tableFilterWriter {
 	return &tableFilterWriter{
 		policy: policy,
-		writer: policy.NewWriter(db.TableFilter),
+		writer: policy.NewWriter(TableFilter),
 	}
 }
 

--- a/sstable/internal.go
+++ b/sstable/internal.go
@@ -1,0 +1,29 @@
+// Copyright 2018 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"github.com/petermattis/pebble/internal/base"
+)
+
+// InternalKeyKind exports the base.InternalKeyKind type.
+type InternalKeyKind = base.InternalKeyKind
+
+// These constants are part of the file format, and should not be changed.
+const (
+	InternalKeyKindDelete          = base.InternalKeyKindDelete
+	InternalKeyKindSet             = base.InternalKeyKindSet
+	InternalKeyKindMerge           = base.InternalKeyKindMerge
+	InternalKeyKindLogData         = base.InternalKeyKindLogData
+	InternalKeyKindRangeDelete     = base.InternalKeyKindRangeDelete
+	InternalKeyKindMax             = base.InternalKeyKindMax
+	InternalKeyKindInvalid         = base.InternalKeyKindInvalid
+	InternalKeySeqNumBatch         = base.InternalKeySeqNumBatch
+	InternalKeySeqNumMax           = base.InternalKeySeqNumMax
+	InternalKeyRangeDeleteSentinel = base.InternalKeyRangeDeleteSentinel
+)
+
+// InternalKey exports the base.InternalKey type.
+type InternalKey = base.InternalKey

--- a/sstable/options.go
+++ b/sstable/options.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import "github.com/petermattis/pebble/internal/base"
+
+// Compression exports the base.Compression type.
+type Compression = base.Compression
+
+// Exported Compression constants.
+const (
+	DefaultCompression = base.DefaultCompression
+	NoCompression      = base.NoCompression
+	SnappyCompression  = base.SnappyCompression
+)
+
+// FilterType exports the base.FilterType type.
+type FilterType = base.FilterType
+
+// Exported TableFilter constants.
+const (
+	TableFilter = base.TableFilter
+)
+
+// FilterWriter exports the base.FilterWriter type.
+type FilterWriter = base.FilterWriter
+
+// FilterPolicy exports the base.FilterPolicy type.
+type FilterPolicy = base.FilterPolicy
+
+// TableFormat exports the base.TableFormat type.
+type TableFormat = base.TableFormat
+
+// Exported TableFormat constants.
+const (
+	TableFormatRocksDBv2 = base.TableFormatRocksDBv2
+	TableFormatLevelDB   = base.TableFormatLevelDB
+)
+
+// TablePropertyCollector exports the base.TablePropertyCollector type.
+type TablePropertyCollector = base.TablePropertyCollector
+
+// TableOptions exports the base.LevelOptions type.
+type TableOptions = base.LevelOptions
+
+// Options exports the base.Options type.
+type Options = base.Options

--- a/sstable/properties.go
+++ b/sstable/properties.go
@@ -12,8 +12,6 @@ import (
 	"reflect"
 	"sort"
 	"unsafe"
-
-	"github.com/petermattis/pebble/db"
 )
 
 var propTagMap = make(map[string]reflect.StructField)
@@ -300,6 +298,6 @@ func (p *Properties) save(w *rawBlockWriter) {
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		w.add(db.InternalKey{UserKey: []byte(key)}, m[key])
+		w.add(InternalKey{UserKey: []byte(key)}, m[key])
 	}
 }

--- a/sstable/raw_block.go
+++ b/sstable/raw_block.go
@@ -9,15 +9,13 @@ import (
 	"errors"
 	"sort"
 	"unsafe"
-
-	"github.com/petermattis/pebble/db"
 )
 
 type rawBlockWriter struct {
 	blockWriter
 }
 
-func (w *rawBlockWriter) add(key db.InternalKey, value []byte) {
+func (w *rawBlockWriter) add(key InternalKey, value []byte) {
 	w.curKey, w.prevKey = w.prevKey, w.curKey
 
 	size := len(key.UserKey)
@@ -36,7 +34,7 @@ func (w *rawBlockWriter) add(key db.InternalKey, value []byte) {
 // reducing duplication is difficult due to the blockIter being performance
 // critical.
 type rawBlockIter struct {
-	cmp         db.Compare
+	cmp         Compare
 	offset      int
 	nextOffset  int
 	restarts    int
@@ -44,18 +42,18 @@ type rawBlockIter struct {
 	ptr         unsafe.Pointer
 	data        []byte
 	key, val    []byte
-	ikey        db.InternalKey
+	ikey        InternalKey
 	cached      []blockEntry
 	cachedBuf   []byte
 	err         error
 }
 
-func newRawBlockIter(cmp db.Compare, block block) (*rawBlockIter, error) {
+func newRawBlockIter(cmp Compare, block block) (*rawBlockIter, error) {
 	i := &rawBlockIter{}
 	return i, i.init(cmp, block)
 }
 
-func (i *rawBlockIter) init(cmp db.Compare, block block) error {
+func (i *rawBlockIter) init(cmp Compare, block block) error {
 	numRestarts := int(binary.LittleEndian.Uint32(block[len(block)-4:]))
 	if numRestarts == 0 {
 		return errors.New("pebble/table: invalid table (block has no restart points)")
@@ -237,7 +235,7 @@ func (i *rawBlockIter) Prev() bool {
 }
 
 // Key implements internalIterator.Key, as documented in the pebble package.
-func (i *rawBlockIter) Key() db.InternalKey {
+func (i *rawBlockIter) Key() InternalKey {
 	return i.ikey
 }
 

--- a/sstable/table.go
+++ b/sstable/table.go
@@ -67,7 +67,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/vfs"
 )
 
@@ -149,8 +148,8 @@ const (
 
 	// The block type gives the per-block compression format.
 	// These constants are part of the file format and should not be changed.
-	// They are different from the db.Compression constants because the latter
-	// are designed so that the zero value of the db.Compression type means to
+	// They are different from the Compression constants because the latter
+	// are designed so that the zero value of the Compression type means to
 	// use the default compression (which is snappy).
 	noCompressionBlockType     byte = 0
 	snappyCompressionBlockType byte = 1
@@ -173,7 +172,7 @@ const (
 //    footer version (4 bytes)
 //    table_magic_number (8 bytes)
 type footer struct {
-	format      db.TableFormat
+	format      TableFormat
 	checksum    uint8
 	metaindexBH blockHandle
 	indexBH     blockHandle
@@ -206,7 +205,7 @@ func readFooter(f vfs.File) (footer, error) {
 			return footer, fmt.Errorf("pebble/table: invalid table (footer too short): %d", len(buf))
 		}
 		buf = buf[len(buf)-levelDBFooterLen:]
-		footer.format = db.TableFormatLevelDB
+		footer.format = TableFormatLevelDB
 		footer.checksum = checksumCRC32c
 
 	case rocksDBMagic:
@@ -218,7 +217,7 @@ func readFooter(f vfs.File) (footer, error) {
 		if version != rocksDBFormatVersion2 {
 			return footer, fmt.Errorf("pebble/table: unsupported format version %d", version)
 		}
-		footer.format = db.TableFormatRocksDBv2
+		footer.format = TableFormatRocksDBv2
 		footer.checksum = uint8(buf[0])
 		if footer.checksum != checksumCRC32c {
 			return footer, fmt.Errorf("pebble/table: unsupported checksum type %d", footer.checksum)
@@ -248,7 +247,7 @@ func readFooter(f vfs.File) (footer, error) {
 
 func (f footer) encode(buf []byte) []byte {
 	switch f.format {
-	case db.TableFormatLevelDB:
+	case TableFormatLevelDB:
 		buf = buf[:levelDBFooterLen]
 		for i := range buf {
 			buf[i] = 0
@@ -257,7 +256,7 @@ func (f footer) encode(buf []byte) []byte {
 		n += encodeBlockHandle(buf[n:], f.indexBH)
 		copy(buf[len(buf)-len(levelDBMagic):], levelDBMagic)
 
-	case db.TableFormatRocksDBv2:
+	case TableFormatRocksDBv2:
 		buf = buf[:rocksDBFooterLen]
 		for i := range buf {
 			buf[i] = 0

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 	"github.com/petermattis/pebble/internal/rangedel"
 	"github.com/petermattis/pebble/vfs"
@@ -33,20 +33,20 @@ func TestWriter(t *testing.T) {
 				return err.Error()
 			}
 
-			w := NewWriter(f0, nil, db.LevelOptions{})
+			w := NewWriter(f0, nil, TableOptions{})
 			var tombstones []rangedel.Tombstone
 			f := rangedel.Fragmenter{
-				Cmp: db.DefaultComparer.Compare,
+				Cmp: DefaultComparer.Compare,
 				Emit: func(fragmented []rangedel.Tombstone) {
 					tombstones = append(tombstones, fragmented...)
 				},
 			}
 			for _, data := range strings.Split(td.Input, "\n") {
 				j := strings.Index(data, ":")
-				key := db.ParseInternalKey(data[:j])
+				key := base.ParseInternalKey(data[:j])
 				value := []byte(data[j+1:])
 				switch key.Kind() {
-				case db.InternalKeyKindRangeDelete:
+				case InternalKeyKindRangeDelete:
 					var err error
 					func() {
 						defer func() {
@@ -101,10 +101,10 @@ func TestWriter(t *testing.T) {
 				return err.Error()
 			}
 
-			w := NewWriter(f0, nil, db.LevelOptions{})
+			w := NewWriter(f0, nil, TableOptions{})
 			for _, data := range strings.Split(td.Input, "\n") {
 				j := strings.Index(data, ":")
-				key := db.ParseInternalKey(data[:j])
+				key := base.ParseInternalKey(data[:j])
 				value := []byte(data[j+1:])
 				if err := w.Add(key, value); err != nil {
 					return err.Error()

--- a/table_cache.go
+++ b/table_cache.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/sstable"
 	"github.com/petermattis/pebble/vfs"
 )
@@ -22,7 +21,7 @@ var emptyIter = &errorIter{err: nil}
 type tableCache struct {
 	dirname string
 	fs      vfs.FS
-	opts    *db.Options
+	opts    *Options
 	size    int
 
 	mu struct {
@@ -36,7 +35,7 @@ type tableCache struct {
 	}
 }
 
-func (c *tableCache) init(dirname string, fs vfs.FS, opts *db.Options, size int) {
+func (c *tableCache) init(dirname string, fs vfs.FS, opts *Options, size int) {
 	c.dirname = dirname
 	c.fs = fs
 	c.opts = opts
@@ -52,7 +51,7 @@ func (c *tableCache) init(dirname string, fs vfs.FS, opts *db.Options, size int)
 }
 
 func (c *tableCache) newIters(
-	meta *fileMetadata, opts *db.IterOptions,
+	meta *fileMetadata, opts *IterOptions,
 ) (internalIterator, internalIterator, error) {
 	// Calling findNode gives us the responsibility of decrementing n's
 	// refCount. If opening the underlying table resulted in error, then we

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/sstable"
 	"github.com/petermattis/pebble/vfs"
 	"golang.org/x/exp/rand"
@@ -131,8 +131,8 @@ func newTableCache() (*tableCache, *tableCacheTestFS, error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("fs.Create: %v", err)
 		}
-		tw := sstable.NewWriter(f, nil, db.LevelOptions{})
-		ik := db.ParseInternalKey(fmt.Sprintf("k.SET.%d", i))
+		tw := sstable.NewWriter(f, nil, LevelOptions{})
+		ik := base.ParseInternalKey(fmt.Sprintf("k.SET.%d", i))
 		if err := tw.Add(ik, xxx[:i]); err != nil {
 			return nil, nil, fmt.Errorf("tw.Set: %v", err)
 		}
@@ -146,7 +146,7 @@ func newTableCache() (*tableCache, *tableCacheTestFS, error) {
 	fs.closeCounts = map[string]int{}
 	fs.mu.Unlock()
 
-	opts := &db.Options{}
+	opts := &Options{}
 	opts.EnsureDefaults()
 	c := &tableCache{}
 	c.init("", fs, opts, tableCacheTestCacheSize)

--- a/version_edit.go
+++ b/version_edit.go
@@ -14,7 +14,7 @@ import (
 	"sort"
 	"sync/atomic"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 )
 
 // TODO(peter): describe the MANIFEST file format, independently of the C++
@@ -219,8 +219,8 @@ func (v *versionEdit) decode(r io.Reader) error {
 				meta: fileMetadata{
 					fileNum:             fileNum,
 					size:                size,
-					smallest:            db.DecodeInternalKey(smallest),
-					largest:             db.DecodeInternalKey(largest),
+					smallest:            base.DecodeInternalKey(smallest),
+					largest:             base.DecodeInternalKey(largest),
 					smallestSeqNum:      smallestSeqNum,
 					largestSeqNum:       largestSeqNum,
 					markedForCompaction: markedForCompaction,
@@ -349,7 +349,7 @@ func (e versionEditEncoder) writeBytes(p []byte) {
 	e.Write(p)
 }
 
-func (e versionEditEncoder) writeKey(k db.InternalKey) {
+func (e versionEditEncoder) writeKey(k InternalKey) {
 	e.writeUvarint(uint64(k.Size()))
 	e.Write(k.UserKey)
 	buf := k.EncodeTrailer()
@@ -399,7 +399,7 @@ func (b *bulkVersionEdit) accumulate(ve *versionEdit) {
 //
 // base may be nil, which is equivalent to a pointer to a zero version.
 func (b *bulkVersionEdit) apply(
-	opts *db.Options, base *version, cmp db.Compare,
+	opts *Options, base *version, cmp Compare,
 ) (*version, error) {
 	v := new(version)
 	for level := range v.files {

--- a/version_edit_test.go
+++ b/version_edit_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	"github.com/kr/pretty"
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/record"
 )
 
@@ -61,8 +61,8 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					meta: fileMetadata{
 						fileNum:  805,
 						size:     8050,
-						smallest: db.DecodeInternalKey([]byte("abc\x00\x01\x02\x03\x04\x05\x06\x07")),
-						largest:  db.DecodeInternalKey([]byte("xyz\x01\xff\xfe\xfd\xfc\xfb\xfa\xf9")),
+						smallest: base.DecodeInternalKey([]byte("abc\x00\x01\x02\x03\x04\x05\x06\x07")),
+						largest:  base.DecodeInternalKey([]byte("xyz\x01\xff\xfe\xfd\xfc\xfb\xfa\xf9")),
 					},
 				},
 				{
@@ -70,8 +70,8 @@ func TestVersionEditRoundTrip(t *testing.T) {
 					meta: fileMetadata{
 						fileNum:             806,
 						size:                8060,
-						smallest:            db.DecodeInternalKey([]byte("A\x00\x01\x02\x03\x04\x05\x06\x07")),
-						largest:             db.DecodeInternalKey([]byte("Z\x01\xff\xfe\xfd\xfc\xfb\xfa\xf9")),
+						smallest:            base.DecodeInternalKey([]byte("A\x00\x01\x02\x03\x04\x05\x06\x07")),
+						largest:             base.DecodeInternalKey([]byte("Z\x01\xff\xfe\xfd\xfc\xfb\xfa\xf9")),
 						smallestSeqNum:      3,
 						largestSeqNum:       5,
 						markedForCompaction: true,
@@ -131,8 +131,8 @@ func TestVersionEditDecode(t *testing.T) {
 							meta: fileMetadata{
 								fileNum:        4,
 								size:           986,
-								smallest:       db.MakeInternalKey([]byte("bar"), 5, db.InternalKeyKindDelete),
-								largest:        db.MakeInternalKey([]byte("foo"), 4, db.InternalKeyKindSet),
+								smallest:       base.MakeInternalKey([]byte("bar"), 5, InternalKeyKindDelete),
+								largest:        base.MakeInternalKey([]byte("foo"), 4, InternalKeyKindSet),
 								smallestSeqNum: 3,
 								largestSeqNum:  5,
 							},

--- a/version_set.go
+++ b/version_set.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/petermattis/pebble/db"
 	"github.com/petermattis/pebble/internal/record"
 	"github.com/petermattis/pebble/vfs"
 )
@@ -25,9 +24,9 @@ type versionSet struct {
 	// Immutable fields.
 	dirname string
 	mu      *sync.Mutex
-	opts    *db.Options
+	opts    *Options
 	fs      vfs.FS
-	cmp     db.Compare
+	cmp     Compare
 	cmpName string
 	// Dynamic base level allows the dynamic base level computation to be
 	// disabled. Used by tests which want to create specific LSM structures.
@@ -58,7 +57,7 @@ type versionSet struct {
 }
 
 // load loads the version set from the manifest file.
-func (vs *versionSet) load(dirname string, opts *db.Options, mu *sync.Mutex) error {
+func (vs *versionSet) load(dirname string, opts *Options, mu *sync.Mutex) error {
 	vs.dirname = dirname
 	vs.mu = mu
 	vs.versions.mu = mu
@@ -123,7 +122,7 @@ func (vs *versionSet) load(dirname string, opts *db.Options, mu *sync.Mutex) err
 		if ve.comparatorName != "" {
 			if ve.comparatorName != vs.cmpName {
 				return fmt.Errorf("pebble: manifest file %q for DB %q: "+
-					"comparer name from file %q != comparer name from db.Options %q",
+					"comparer name from file %q != comparer name from Options %q",
 					b, dirname, ve.comparatorName, vs.cmpName)
 			}
 		}
@@ -233,7 +232,7 @@ func (vs *versionSet) logAndApply(jobID int, ve *versionEdit, dir vfs.File) erro
 				return err
 			}
 			if vs.opts.EventListener.ManifestDeleted != nil {
-				vs.opts.EventListener.ManifestCreated(db.ManifestCreateInfo{
+				vs.opts.EventListener.ManifestCreated(ManifestCreateInfo{
 					JobID:   jobID,
 					Path:    dbFilename(vs.dirname, fileTypeManifest, newManifestFileNumber),
 					FileNum: newManifestFileNumber,

--- a/version_test.go
+++ b/version_test.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/petermattis/pebble/db"
+	"github.com/petermattis/pebble/internal/base"
 )
 
 func TestIkeyRange(t *testing.T) {
@@ -65,13 +65,13 @@ func TestIkeyRange(t *testing.T) {
 			}
 		}
 
-		smallest0, largest0 := ikeyRange(db.DefaultComparer.Compare, f, nil)
+		smallest0, largest0 := ikeyRange(DefaultComparer.Compare, f, nil)
 		got0 := string(smallest0.UserKey) + "-" + string(largest0.UserKey)
 		if got0 != tc.want {
 			t.Errorf("first []fileMetadata is %v\ngot  %s\nwant %s", tc.input, got0, tc.want)
 		}
 
-		smallest1, largest1 := ikeyRange(db.DefaultComparer.Compare, nil, f)
+		smallest1, largest1 := ikeyRange(DefaultComparer.Compare, nil, f)
 		got1 := string(smallest1.UserKey) + "-" + string(largest1.UserKey)
 		if got1 != tc.want {
 			t.Errorf("second []fileMetadata is %v\ngot  %s\nwant %s", tc.input, got1, tc.want)
@@ -83,81 +83,81 @@ func TestOverlaps(t *testing.T) {
 	m00 := fileMetadata{
 		fileNum:  700,
 		size:     1,
-		smallest: db.ParseInternalKey("b.SET.7008"),
-		largest:  db.ParseInternalKey("e.SET.7009"),
+		smallest: base.ParseInternalKey("b.SET.7008"),
+		largest:  base.ParseInternalKey("e.SET.7009"),
 	}
 	m01 := fileMetadata{
 		fileNum:  701,
 		size:     1,
-		smallest: db.ParseInternalKey("c.SET.7018"),
-		largest:  db.ParseInternalKey("f.SET.7019"),
+		smallest: base.ParseInternalKey("c.SET.7018"),
+		largest:  base.ParseInternalKey("f.SET.7019"),
 	}
 	m02 := fileMetadata{
 		fileNum:  702,
 		size:     1,
-		smallest: db.ParseInternalKey("f.SET.7028"),
-		largest:  db.ParseInternalKey("g.SET.7029"),
+		smallest: base.ParseInternalKey("f.SET.7028"),
+		largest:  base.ParseInternalKey("g.SET.7029"),
 	}
 	m03 := fileMetadata{
 		fileNum:  703,
 		size:     1,
-		smallest: db.ParseInternalKey("x.SET.7038"),
-		largest:  db.ParseInternalKey("y.SET.7039"),
+		smallest: base.ParseInternalKey("x.SET.7038"),
+		largest:  base.ParseInternalKey("y.SET.7039"),
 	}
 	m04 := fileMetadata{
 		fileNum:  704,
 		size:     1,
-		smallest: db.ParseInternalKey("n.SET.7048"),
-		largest:  db.ParseInternalKey("p.SET.7049"),
+		smallest: base.ParseInternalKey("n.SET.7048"),
+		largest:  base.ParseInternalKey("p.SET.7049"),
 	}
 	m05 := fileMetadata{
 		fileNum:  705,
 		size:     1,
-		smallest: db.ParseInternalKey("p.SET.7058"),
-		largest:  db.ParseInternalKey("p.SET.7059"),
+		smallest: base.ParseInternalKey("p.SET.7058"),
+		largest:  base.ParseInternalKey("p.SET.7059"),
 	}
 	m06 := fileMetadata{
 		fileNum:  706,
 		size:     1,
-		smallest: db.ParseInternalKey("p.SET.7068"),
-		largest:  db.ParseInternalKey("u.SET.7069"),
+		smallest: base.ParseInternalKey("p.SET.7068"),
+		largest:  base.ParseInternalKey("u.SET.7069"),
 	}
 	m07 := fileMetadata{
 		fileNum:  707,
 		size:     1,
-		smallest: db.ParseInternalKey("r.SET.7078"),
-		largest:  db.ParseInternalKey("s.SET.7079"),
+		smallest: base.ParseInternalKey("r.SET.7078"),
+		largest:  base.ParseInternalKey("s.SET.7079"),
 	}
 
 	m10 := fileMetadata{
 		fileNum:  710,
 		size:     1,
-		smallest: db.ParseInternalKey("d.SET.7108"),
-		largest:  db.ParseInternalKey("g.SET.7109"),
+		smallest: base.ParseInternalKey("d.SET.7108"),
+		largest:  base.ParseInternalKey("g.SET.7109"),
 	}
 	m11 := fileMetadata{
 		fileNum:  711,
 		size:     1,
-		smallest: db.ParseInternalKey("g.SET.7118"),
-		largest:  db.ParseInternalKey("j.SET.7119"),
+		smallest: base.ParseInternalKey("g.SET.7118"),
+		largest:  base.ParseInternalKey("j.SET.7119"),
 	}
 	m12 := fileMetadata{
 		fileNum:  712,
 		size:     1,
-		smallest: db.ParseInternalKey("n.SET.7128"),
-		largest:  db.ParseInternalKey("p.SET.7129"),
+		smallest: base.ParseInternalKey("n.SET.7128"),
+		largest:  base.ParseInternalKey("p.SET.7129"),
 	}
 	m13 := fileMetadata{
 		fileNum:  713,
 		size:     1,
-		smallest: db.ParseInternalKey("p.SET.7138"),
-		largest:  db.ParseInternalKey("p.SET.7139"),
+		smallest: base.ParseInternalKey("p.SET.7138"),
+		largest:  base.ParseInternalKey("p.SET.7139"),
 	}
 	m14 := fileMetadata{
 		fileNum:  714,
 		size:     1,
-		smallest: db.ParseInternalKey("p.SET.7148"),
-		largest:  db.ParseInternalKey("u.SET.7149"),
+		smallest: base.ParseInternalKey("p.SET.7148"),
+		largest:  base.ParseInternalKey("u.SET.7149"),
 	}
 
 	v := version{
@@ -238,7 +238,7 @@ func TestOverlaps(t *testing.T) {
 		{2, "a", "z", ""},
 	}
 
-	cmp := db.DefaultComparer.Compare
+	cmp := DefaultComparer.Compare
 	for _, tc := range testCases {
 		o := v.overlaps(tc.level, cmp, []byte(tc.ukey0), []byte(tc.ukey1))
 		s := make([]string, len(o))


### PR DESCRIPTION
The `pebble/db` package name is somewhat problematic as it consumes the
name `db` or requires the user to rename that package during import to
something like `pebble_db`. The reason that package existed was to
provide a base location for types that need to be shared between the
`pebble` package and various sub-packages such as
`pebble/sstable`. Rather than a shared package that is also available to
the user, the types are now defined in `pebble/internal/base` and
exposed in `pebble` and `pebble/sstable` via type aliases.