### PR TITLE
Convert v1 to v2 range-del blocks on the fly

### DIFF
--- a/sstable/testdata/writer
+++ b/sstable/testdata/writer
@@ -147,3 +147,73 @@ c.RANGEDEL.2:d
 point:   [#0,0,#0,0]
 range:   [a#1,15,d#72057594037927935,15]
 seqnums: [1,2]
+
+# The range-del-v1 format supports unfragmented and unsorted range
+# tombstones.
+
+build-raw range-del-v1
+a.RANGEDEL.1:c
+a.RANGEDEL.2:c
+----
+point:   [#0,0,#0,0]
+range:   [a#2,15,c#72057594037927935,15]
+seqnums: [1,2]
+
+scan-range-del
+----
+a#2,15:c
+a#1,15:c
+
+build-raw range-del-v1
+a.RANGEDEL.1:c
+b.RANGEDEL.2:d
+----
+point:   [#0,0,#0,0]
+range:   [a#1,15,d#72057594037927935,15]
+seqnums: [1,2]
+
+scan-range-del
+----
+a#1,15:b
+b#2,15:c
+b#1,15:c
+c#2,15:d
+
+build-raw range-del-v1
+a.RANGEDEL.2:c
+a.RANGEDEL.1:d
+----
+point:   [#0,0,#0,0]
+range:   [a#2,15,d#72057594037927935,15]
+seqnums: [1,2]
+
+scan-range-del
+----
+a#2,15:c
+a#1,15:c
+c#1,15:d
+
+# This matches an early test case, except we're passing overlapping
+# range tombstones to the sstable writer and requiring them to be
+# fragmented at read time.
+
+build-raw range-del-v1
+j.RANGEDEL.1:z
+f.RANGEDEL.2:s
+a.RANGEDEL.3:m
+----
+point:   [#0,0,#0,0]
+range:   [a#3,15,z#72057594037927935,15]
+seqnums: [1,3]
+
+scan-range-del
+----
+a#3,15:f
+f#3,15:j
+f#2,15:j
+j#3,15:m
+j#2,15:m
+j#1,15:m
+m#2,15:s
+m#1,15:s
+s#1,15:z

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -102,6 +102,14 @@ func TestWriter(t *testing.T) {
 			}
 
 			w := NewWriter(f0, nil, TableOptions{})
+			for i := range td.CmdArgs {
+				arg := &td.CmdArgs[i]
+				if arg.Key == "range-del-v1" {
+					w.rangeDelV1Format = true
+					break
+				}
+			}
+
 			for _, data := range strings.Split(td.Input, "\n") {
 				j := strings.Index(data, ":")
 				key := base.ParseInternalKey(data[:j])


### PR DESCRIPTION
RocksDB generates range-del blocks that contain range tombstones that are
not fragmented and sorted. Pebble generates range-del blocks containing
tombstones that are fragmented and sorted. The fragmented and sorted
range-del blocks are suitable for serving from directly, while the
unfragmented/unsorted blocks are not. We now transform RocksDB format
range-del blocks into Pebble format blocks on the fly.

The transformation is done via a hook that allows passing a block through a
function after it has been read from disk but before it is added to the
cache.

Fixes #68

Provide key stability across blockIter positioning calls

Provide stability for the keys returned from a blockIter across positioning
calls (Seek*, First, Last, Prev, Next) when the block has a restart
interval of 1. This is achieved by noticing when a key does not share any
bytes with the previous key and changing the returned key to point directly
into the block instead of the key buffer. This behavior was already being
expected by `rangedel.Truncate` and by forthcoming code to transform v1
range-del blocks to v2 format on the fly.