### PR TITLE
Fix Iterator.{Next,Prev} boundary cases

### DIFF
--- a/db.go
+++ b/db.go
@@ -266,7 +266,7 @@ func (d *DB) getInternal(key []byte, b *Batch, s *Snapshot) ([]byte, error) {
 	i.readState = readState
 
 	defer i.Close()
-	if !i.Next() {
+	if !i.First() {
 		err := i.Error()
 		if err != nil {
 			return nil, err

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -522,7 +522,7 @@ func TestGetIter(t *testing.T) {
 			i.iter = get
 
 			defer i.Close()
-			if !i.Next() {
+			if !i.First() {
 				err := i.Error()
 				if err != nil {
 					return nil, err

--- a/testdata/iterator
+++ b/testdata/iterator
@@ -9,7 +9,7 @@ prev
 ----
 a:b
 .
-a:b
+.
 
 iter seq=2
 seek-ge b
@@ -34,7 +34,7 @@ prev
 ----
 a:b
 .
-a:b
+.
 
 iter seq=3
 seek-ge a
@@ -43,7 +43,7 @@ prev
 ----
 a:c
 .
-a:c
+.
 
 iter seq=2
 seek-prefix-ge a
@@ -52,7 +52,7 @@ prev
 ----
 a:b
 .
-a:b
+.
 
 iter seq=3
 seek-prefix-ge a
@@ -61,7 +61,7 @@ prev
 ----
 a:c
 .
-a:c
+.
 
 
 define
@@ -93,7 +93,7 @@ next
 ----
 a:b
 .
-a:b
+.
 
 iter seq=3
 seek-prefix-ge a
@@ -185,7 +185,7 @@ next
 ----
 a:a
 .
-a:a
+.
 
 iter seq=4
 seek-lt c
@@ -196,7 +196,7 @@ next
 b:b
 a:a
 .
-a:a
+.
 
 
 iter seq=4
@@ -210,7 +210,7 @@ c:c
 b:b
 a:a
 .
-a:a
+.
 
 iter seq=4
 seek-prefix-ge a
@@ -253,7 +253,7 @@ prev
 ----
 a:b
 .
-a:b
+.
 
 iter seq=2
 seek-ge b
@@ -272,7 +272,7 @@ next
 ----
 a:b
 .
-a:b
+.
 
 iter seq=2
 seek-lt c
@@ -281,7 +281,7 @@ next
 ----
 a:b
 .
-a:b
+.
 
 iter seq=2
 seek-prefix-ge a
@@ -290,7 +290,7 @@ prev
 ----
 a:b
 .
-a:b
+.
 
 iter seq=2
 seek-prefix-ge b
@@ -488,7 +488,7 @@ prev
 a:bcd
 b:ab
 .
-b:ab
+.
 
 iter seq=3
 seek-ge a
@@ -513,7 +513,7 @@ next
 b:ab
 a:bcd
 .
-a:bcd
+.
 
 iter seq=3
 seek-lt c
@@ -994,6 +994,46 @@ last
 ----
 .
 a:a
+
+iter seq=2
+last
+next
+set-bounds upper=c
+prev
+----
+d:d
+.
+.
+.
+
+iter seq=2
+first
+prev
+set-bounds lower=b
+next
+----
+a:a
+.
+.
+.
+
+iter seq=2
+set-bounds lower=b
+seek-lt c
+next
+----
+.
+b:b
+c:c
+
+iter seq=2
+set-bounds upper=d
+seek-ge c
+prev
+----
+.
+c:c
+b:b
 
 define
 a.SET.1:a

--- a/testdata/snapshot
+++ b/testdata/snapshot
@@ -14,20 +14,18 @@ prev
 ----
 a:1
 .
-a:1
+.
 
 iter snapshot=2
 first
 next
 next
 prev
-prev
 ----
 a:1
 b:2
 .
-b:2
-a:1
+.
 
 iter snapshot=3
 first
@@ -35,16 +33,12 @@ next
 next
 next
 prev
-prev
-prev
 ----
 a:1
 b:2
 c:3
 .
-c:3
-b:2
-a:1
+.
 
 define
 set a 1
@@ -62,7 +56,7 @@ prev
 ----
 a:1
 .
-a:1
+.
 
 iter snapshot=2
 first
@@ -71,7 +65,7 @@ prev
 ----
 a:2
 .
-a:2
+.
 
 iter snapshot=3
 first
@@ -80,7 +74,7 @@ prev
 ----
 a:3
 .
-a:3
+.
 
 define
 set a 1
@@ -99,7 +93,7 @@ prev
 ----
 a:1
 .
-a:1
+.
 
 iter snapshot=2
 first
@@ -108,7 +102,7 @@ prev
 ----
 a:2
 .
-a:2
+.
 
 iter snapshot=3
 first
@@ -117,7 +111,7 @@ prev
 ----
 a:3
 .
-a:3
+.
 
 define
 merge a 1
@@ -136,7 +130,7 @@ prev
 ----
 a:1
 .
-a:1
+.
 
 iter snapshot=2
 first
@@ -145,7 +139,7 @@ prev
 ----
 a:21
 .
-a:21
+.
 
 iter snapshot=3
 first
@@ -154,4 +148,4 @@ prev
 ----
 a:321
 .
-a:321
+.


### PR DESCRIPTION
When the iterator is invalid, a call to `{Next,Prev}` needs to consider
the lower and upper bounds. Previously it was ignoring them allowing the
iterator to return keys outside of the bounds.