### PR TITLE
Provide guard rails for various invalid operations

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -11,6 +11,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/petermattis/pebble/internal/base"
@@ -576,7 +577,7 @@ type manualCompaction struct {
 //
 // d.mu must be held when calling this.
 func (d *DB) maybeScheduleFlush() {
-	if d.mu.compact.flushing || d.mu.closed {
+	if d.mu.compact.flushing || atomic.LoadInt32(&d.closed) != 0 {
 		return
 	}
 	if len(d.mu.mem.queue) <= 1 {
@@ -701,7 +702,7 @@ func (d *DB) flush1() error {
 //
 // d.mu must be held when calling this.
 func (d *DB) maybeScheduleCompaction() {
-	if d.mu.compact.compacting || d.mu.closed {
+	if d.mu.compact.compacting || atomic.LoadInt32(&d.closed) != 0 {
 		return
 	}
 

--- a/iterator.go
+++ b/iterator.go
@@ -279,12 +279,12 @@ func (i *Iterator) SeekGE(key []byte) bool {
 // the Comparer. Also note that the iterator will not observe keys not matching
 // the prefix.
 func (i *Iterator) SeekPrefixGE(key []byte) bool {
-	if i.split == nil {
-		panic("pebble: split must be provided for SeekPrefixGE")
-	}
-
 	if i.err != nil {
 		return false
+	}
+
+	if i.split == nil {
+		panic("pebble: split must be provided for SeekPrefixGE")
 	}
 
 	// Make a copy of the prefix so that modifications to the key after

--- a/snapshot.go
+++ b/snapshot.go
@@ -25,6 +25,9 @@ var _ Reader = (*Snapshot)(nil)
 // The caller should not modify the contents of the returned slice, but it is
 // safe to modify the contents of the argument after Get returns.
 func (s *Snapshot) Get(key []byte) ([]byte, error) {
+	if s.db == nil {
+		panic(ErrClosed)
+	}
 	return s.db.getInternal(key, nil /* batch */, s)
 }
 
@@ -32,6 +35,9 @@ func (s *Snapshot) Get(key []byte) ([]byte, error) {
 // return false). The iterator can be positioned via a call to SeekGE,
 // SeekLT, First or Last.
 func (s *Snapshot) NewIter(o *IterOptions) *Iterator {
+	if s.db == nil {
+		panic(ErrClosed)
+	}
 	return s.db.newIterInternal(nil /* batchIter */, nil /* batchRangeDelIter */, s, o)
 }
 
@@ -40,9 +46,13 @@ func (s *Snapshot) NewIter(o *IterOptions) *Iterator {
 // leak of resources on disk due to the entries the snapshot is preventing from
 // being deleted.
 func (s *Snapshot) Close() error {
+	if s.db == nil {
+		panic(ErrClosed)
+	}
 	s.db.mu.Lock()
 	s.db.mu.snapshots.remove(s)
 	s.db.mu.Unlock()
+	s.db = nil
 	return nil
 }
 


### PR DESCRIPTION
Return errors from operations on snapshots that have been closed.