### PR TITLE
Export BatchReader

### DIFF
--- a/mem_table.go
+++ b/mem_table.go
@@ -144,8 +144,8 @@ func (m *memTable) apply(batch *Batch, seqNum uint64) error {
 	var ins arenaskl.Inserter
 	var tombstoneCount uint32
 	startSeqNum := seqNum
-	for iter := batch.iter(); ; seqNum++ {
-		kind, ukey, value, ok := iter.next()
+	for r := batch.Reader(); ; seqNum++ {
+		kind, ukey, value, ok := r.Next()
 		if !ok {
 			break
 		}


### PR DESCRIPTION
Export BatchReader so users can have a tool for iterating over the contents
of a batch.