### PR TITLE
Dynamically test for sync_file_range support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PKG := ./...
 BENCH_PKGS := internal/arenaskl internal/batchskl internal/record sstable .
 STRESSFLAGS :=
 TESTS := .
+BUILDER := ../../cockroachdb/cockroach/build/builder.sh
 
 .PHONY: all
 all:
@@ -17,7 +18,11 @@ all:
 
 .PHONY: test
 test:
-	$(GO) test ${GOFLAGS} -run ${TESTS} ${PKG}
+	${GO} test ${GOFLAGS} -run ${TESTS} ${PKG}
+
+.PHONY: test
+test-linux:
+	${BUILDER} ${GO} test ${GOFLAGS} -run ${TESTS} $(shell go list ${PKG})
 
 .PHONY: testrace
 testrace: GOFLAGS += -race
@@ -26,7 +31,7 @@ testrace: test
 .PHONY: stress stressrace
 stressrace: GOFLAGS += -race
 stress stressrace:
-	$(GO) test -v ${GOFLAGS} -exec 'stress ${STRESSFLAGS}' -run "${TESTS}" -timeout 0 ${PKG}
+	${GO} test -v ${GOFLAGS} -exec 'stress ${STRESSFLAGS}' -run "${TESTS}" -timeout 0 ${PKG}
 
 .PHONY: bench
 bench: GOFLAGS += -timeout 1h
@@ -35,7 +40,7 @@ bench: $(patsubst %,%.bench,$(if $(findstring ./...,${PKG}),${BENCH_PKGS},${PKG}
 internal/arenaskl.bench: GOFLAGS += -cpu 1,8
 
 %.bench:
-	$(GO) test -run - -bench . -count 10 ${GOFLAGS} ./$* 2>&1 | tee $*/bench.txt.new
+	${GO} test -run - -bench . -count 10 ${GOFLAGS} ./$* 2>&1 | tee $*/bench.txt.new
 
 .PHONY: clean
 clean:

--- a/vfs/syncing_file_linux.go
+++ b/vfs/syncing_file_linux.go
@@ -11,6 +11,17 @@ import (
 	"syscall"
 )
 
+type syncFileRange func(fd int, off int64, n int64, flags int) (err error)
+
+// sync_file_range depends on both the filesystem, and the broader kernel
+// support. In particular, Windows Subsystem for Linux does not support
+// sync_file_range, even when used with ext{2,3,4}. syncRangeSmokeTest performs
+// a test of of sync_file_range, returning false on ENOSYS, and true otherwise.
+func syncRangeSmokeTest(fd uintptr, fn syncFileRange) bool {
+	err := fn(int(fd), 0 /* offset */, 0 /* nbytes */, 0 /* flags */)
+	return err != syscall.ENOSYS
+}
+
 func isSyncRangeSupported(fd uintptr) bool {
 	var stat syscall.Statfs_t
 	if err := syscall.Fstatfs(int(fd), &stat); err != nil {
@@ -25,7 +36,7 @@ func isSyncRangeSupported(fd uintptr) bool {
 	const extMagic = 0xef53
 	switch stat.Type {
 	case extMagic:
-		return true
+		return syncRangeSmokeTest(fd, syscall.SyncFileRange)
 	}
 	return false
 }

--- a/vfs/syncing_file_linux_test.go
+++ b/vfs/syncing_file_linux_test.go
@@ -15,6 +15,31 @@ import (
 	"unsafe"
 )
 
+func TestSyncRangeSmokeTest(t *testing.T) {
+	testCases := []struct {
+		err      error
+		expected bool
+	}{
+		{nil, true},
+		{syscall.EINVAL, true},
+		{syscall.ENOSYS, false},
+	}
+	for i, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			ok := syncRangeSmokeTest(uintptr(i),
+				func(fd int, off int64, n int64, flags int) (err error) {
+					if i != fd {
+						t.Fatalf("expected fd %d, but got %d", i, fd)
+					}
+					return c.err
+				})
+			if c.expected != ok {
+				t.Fatalf("expected %t, but got %t: %v", c.expected, ok, c.err)
+			}
+		})
+	}
+}
+
 func BenchmarkDirectIOWrite(b *testing.B) {
 	const targetSize = 16 << 20
 	const alignment = 4096


### PR DESCRIPTION
Simply checking the filesystem is not sufficient to determine if
sync_file_range is supported. We need to perform a "smoke test" call to
determine if the kernel supports the call (Windows Subsystem for Linux does
not).