### PR TITLE
Fatal on MANIFEST write errors

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,242 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package pebble
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/petermattis/pebble/vfs"
+)
+
+type panicLogger struct{}
+
+func (l panicLogger) Infof(format string, args ...interface{}) {
+}
+
+func (l panicLogger) Fatalf(format string, args ...interface{}) {
+	panic(fmt.Errorf("fatal: "+format, args...))
+}
+
+type errorFS struct {
+	fs    vfs.FS
+	index int32
+}
+
+func newErrorFS(index int32) *errorFS {
+	return &errorFS{
+		fs:    vfs.NewMem(),
+		index: index,
+	}
+}
+
+func (fs *errorFS) maybeError() error {
+	if atomic.AddInt32(&fs.index, -1) == -1 {
+		return fmt.Errorf("injected error")
+	}
+	return nil
+}
+
+func (fs *errorFS) Create(name string) (vfs.File, error) {
+	if err := fs.maybeError(); err != nil {
+		return nil, err
+	}
+	f, err := fs.fs.Create(name)
+	if err != nil {
+		return nil, err
+	}
+	return errorFile{f, fs}, nil
+}
+
+func (fs *errorFS) Link(oldname, newname string) error {
+	if err := fs.maybeError(); err != nil {
+		return err
+	}
+	return fs.fs.Link(oldname, newname)
+}
+
+func (fs *errorFS) Open(name string) (vfs.File, error) {
+	if err := fs.maybeError(); err != nil {
+		return nil, err
+	}
+	f, err := fs.fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return errorFile{f, fs}, nil
+}
+
+func (fs *errorFS) OpenDir(name string) (vfs.File, error) {
+	if err := fs.maybeError(); err != nil {
+		return nil, err
+	}
+	f, err := fs.fs.OpenDir(name)
+	if err != nil {
+		return nil, err
+	}
+	return errorFile{f, fs}, nil
+}
+
+func (fs *errorFS) Remove(name string) error {
+	if _, err := fs.fs.Stat(name); os.IsNotExist(err) {
+		return nil
+	}
+
+	if err := fs.maybeError(); err != nil {
+		return err
+	}
+	return fs.fs.Remove(name)
+}
+
+func (fs *errorFS) Rename(oldname, newname string) error {
+	if err := fs.maybeError(); err != nil {
+		return err
+	}
+	return fs.fs.Rename(oldname, newname)
+}
+
+func (fs *errorFS) MkdirAll(dir string, perm os.FileMode) error {
+	if err := fs.maybeError(); err != nil {
+		return err
+	}
+	return fs.fs.MkdirAll(dir, perm)
+}
+
+func (fs *errorFS) Lock(name string) (io.Closer, error) {
+	if err := fs.maybeError(); err != nil {
+		return nil, err
+	}
+	return fs.fs.Lock(name)
+}
+
+func (fs *errorFS) List(dir string) ([]string, error) {
+	if err := fs.maybeError(); err != nil {
+		return nil, err
+	}
+	return fs.fs.List(dir)
+}
+
+func (fs *errorFS) Stat(name string) (os.FileInfo, error) {
+	if err := fs.maybeError(); err != nil {
+		return nil, err
+	}
+	return fs.fs.Stat(name)
+}
+
+type errorFile struct {
+	file vfs.File
+	fs   *errorFS
+}
+
+func (f errorFile) Close() error {
+	// We don't inject errors during close as those calls should never fail in
+	// practice.
+	return f.file.Close()
+}
+
+func (f errorFile) Read(p []byte) (int, error) {
+	if err := f.fs.maybeError(); err != nil {
+		return 0, err
+	}
+	return f.file.Read(p)
+}
+
+func (f errorFile) ReadAt(p []byte, off int64) (int, error) {
+	if err := f.fs.maybeError(); err != nil {
+		return 0, err
+	}
+	return f.file.ReadAt(p, off)
+}
+
+func (f errorFile) Write(p []byte) (int, error) {
+	if err := f.fs.maybeError(); err != nil {
+		return 0, err
+	}
+	return f.file.Write(p)
+}
+
+func (f errorFile) Stat() (os.FileInfo, error) {
+	if err := f.fs.maybeError(); err != nil {
+		return nil, err
+	}
+	return f.file.Stat()
+}
+
+func (f errorFile) Sync() error {
+	if err := f.fs.maybeError(); err != nil {
+		return err
+	}
+	return f.file.Sync()
+}
+
+// TestErrors repeatedly runs a short sequence of operations, injecting FS
+// errors at different points, until success is achieved.
+func TestErrors(t *testing.T) {
+	run := func(fs *errorFS) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				if e, ok := r.(error); ok {
+					err = e
+				} else {
+					err = fmt.Errorf("%v", r)
+				}
+			}
+		}()
+
+		d, err := Open("", &Options{
+			FS:     fs,
+			Logger: panicLogger{},
+		})
+		if err != nil {
+			return err
+		}
+
+		key := []byte("a")
+		value := []byte("b")
+		if err := d.Set(key, value, nil); err != nil {
+			return err
+		}
+		if err := d.Flush(); err != nil {
+			return err
+		}
+		if err := d.Compact(nil, nil); err != nil {
+			return err
+		}
+
+		iter := d.NewIter(nil)
+		for valid := iter.First(); valid; valid = iter.Next() {
+		}
+		if err := iter.Close(); err != nil {
+			return err
+		}
+		return d.Close()
+	}
+
+	errorCounts := make(map[string]int)
+	for i := int32(0); ; i++ {
+		fs := newErrorFS(i)
+		err := run(fs)
+		if err == nil {
+			t.Logf("success %d\n", i)
+			break
+		}
+		errorCounts[err.Error()]++
+	}
+
+	expectedErrors := []string{
+		"fatal: MANIFEST flush failed: injected error",
+		"fatal: MANIFEST sync failed: injected error",
+		"fatal: MANIFEST set current failed: injected error",
+		"fatal: MANIFEST dirsync failed: injected error",
+	}
+	for _, expected := range expectedErrors {
+		if errorCounts[expected] == 0 {
+			t.Errorf("expected error %q did not occur", expected)
+		}
+	}
+}

--- a/open.go
+++ b/open.go
@@ -150,6 +150,13 @@ func Open(dirname string, opts *Options) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	if d.dirname != d.walDirname {
+		ls2, err := opts.FS.List(d.dirname)
+		if err != nil {
+			return nil, err
+		}
+		ls = append(ls, ls2...)
+	}
 
 	// Replay any newer log files than the ones named in the manifest.
 	type fileNumAndName struct {
@@ -227,7 +234,7 @@ func Open(dirname string, opts *Options) (*DB, error) {
 
 	jobID := d.mu.nextJobID
 	d.mu.nextJobID++
-	d.scanObsoleteFiles()
+	d.scanObsoleteFiles(ls)
 	d.deleteObsoleteFiles(jobID)
 	d.maybeScheduleFlush()
 	d.maybeScheduleCompaction()

--- a/open_test.go
+++ b/open_test.go
@@ -83,9 +83,9 @@ func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 	for _, startFromEmpty := range []bool{false, true} {
 		for _, walDirname := range []string{"", "wal"} {
 			for _, length := range []int{-1, 0, 1, 1000, 10000, 100000} {
-				dirname := "sharedDatabase"
+				dirname := "sharedDatabase" + walDirname
 				if startFromEmpty {
-					dirname = "startFromEmpty" + strconv.Itoa(length)
+					dirname = "startFromEmpty" + walDirname + strconv.Itoa(length)
 				}
 				dirname = filepath.Join(root, dirname)
 				if walDirname == "" {
@@ -101,7 +101,7 @@ func testOpenCloseOpenClose(t *testing.T, fs vfs.FS, root string) {
 
 				d0, err := Open(dirname, opts)
 				if err != nil {
-					t.Errorf("sfe=%t, length=%d: Open #0: %v",
+					t.Fatalf("sfe=%t, length=%d: Open #0: %v",
 						startFromEmpty, length, err)
 					continue
 				}


### PR DESCRIPTION
When a MANIFEST write fails, recovery is difficult because it is unclear
what has made it to disk and what hasn't. Rather than trying to perfom
inline recovery to a good state, we fatal and rely on the standard
recovery mechanism run when a database is open. In particular, that
mechanism generates a new MANIFEST and ensures it is synced.

Fixes #153