### PR TITLE
Add memtable flush pacing mechanism

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -412,6 +412,27 @@ func TestFlushableBatchDeleteRange(t *testing.T) {
 	})
 }
 
+func TestFlushableBatchBytesIterated(t *testing.T) {
+	batch := newBatch(nil)
+	for j := 0; j < 1000; j++ {
+		key := make([]byte, 8 + j%3)
+		value := make([]byte, 7 + j%5)
+		batch.Set(key, value, nil)
+
+		fb := newFlushableBatch(batch, DefaultComparer)
+
+		var bytesIterated uint64
+		it := fb.newFlushIter(nil, &bytesIterated)
+
+		for it.First(); it.Valid(); it.Next() {}
+
+		expected := fb.totalBytes()
+		if bytesIterated != expected {
+			t.Fatalf("bytesIterated: got %d, want %d", bytesIterated, expected)
+		}
+	}
+}
+
 func BenchmarkBatchSet(b *testing.B) {
 	value := make([]byte, 10)
 	for i := range value {

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -56,7 +56,6 @@ func newPebbleDB(dir string) DB {
 		MemTableStopWritesThreshold: 4,
 		MinFlushRate:                4 << 20,
 		L0CompactionThreshold:       2,
-		L0SlowdownWritesThreshold:   20,
 		L0StopWritesThreshold:       32,
 		LBaseMaxBytes:               64 << 20, // 64 MB
 		Levels: []pebble.LevelOptions{{

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -54,6 +54,7 @@ func newPebbleDB(dir string) DB {
 		DisableWAL:                  disableWAL,
 		MemTableSize:                64 << 20,
 		MemTableStopWritesThreshold: 4,
+		MinFlushRate:                4 << 20,
 		L0CompactionThreshold:       2,
 		L0SlowdownWritesThreshold:   20,
 		L0StopWritesThreshold:       32,

--- a/db_test.go
+++ b/db_test.go
@@ -421,6 +421,7 @@ func TestLargeBatch(t *testing.T) {
 		FS:                          vfs.NewMem(),
 		MemTableSize:                1400,
 		MemTableStopWritesThreshold: 100,
+		MinFlushRate:                4 << 20,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/get_iter.go
+++ b/get_iter.go
@@ -132,7 +132,10 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 			// Create iterators from L0 from newest to oldest.
 			if n := len(g.l0); n > 0 {
 				l := &g.l0[n-1]
-				g.iter, g.rangeDelIter, g.err = g.newIters(l, nil /* iter options */)
+				g.iter, g.rangeDelIter, g.err = g.newIters(
+					l,
+					nil /* iter options */,
+					nil /* bytes iterated */)
 				if g.err != nil {
 					return nil, nil
 				}
@@ -151,7 +154,7 @@ func (g *getIter) Next() (*InternalKey, []byte) {
 			continue
 		}
 
-		g.levelIter.init(nil, g.cmp, g.newIters, g.version.files[g.level])
+		g.levelIter.init(nil, g.cmp, g.newIters, g.version.files[g.level], nil)
 		g.levelIter.initRangeDel(&g.rangeDelIter)
 		g.level++
 		g.iter = &g.levelIter

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -441,7 +441,7 @@ func TestGetIter(t *testing.T) {
 		// m is a map from file numbers to DBs.
 		m := map[uint64]*memTable{}
 		newIter := func(
-			meta *fileMetadata, _ *IterOptions,
+			meta *fileMetadata, _ *IterOptions, _ *uint64,
 		) (internalIterator, internalIterator, error) {
 			d, ok := m[meta.fileNum]
 			if !ok {

--- a/internal/arenaskl/arena.go
+++ b/internal/arenaskl/arena.go
@@ -63,11 +63,11 @@ func (a *Arena) Capacity() uint32 {
 	return uint32(len(a.buf))
 }
 
-func (a *Arena) alloc(size, align uint32) (uint32, error) {
+func (a *Arena) alloc(size, align uint32) (uint32, uint32, error) {
 	// Verify that the arena isn't already full.
 	origSize := atomic.LoadUint64(&a.n)
 	if int(origSize) > len(a.buf) {
-		return 0, ErrArenaFull
+		return 0, 0, ErrArenaFull
 	}
 
 	// Pad the allocation with enough bytes to ensure the requested alignment.
@@ -75,12 +75,12 @@ func (a *Arena) alloc(size, align uint32) (uint32, error) {
 
 	newSize := atomic.AddUint64(&a.n, uint64(padded))
 	if int(newSize) > len(a.buf) {
-		return 0, ErrArenaFull
+		return 0, 0, ErrArenaFull
 	}
 
 	// Return the aligned offset.
 	offset := (uint32(newSize) - padded + uint32(align)) & ^uint32(align)
-	return offset, nil
+	return offset, padded, nil
 }
 
 func (a *Arena) getBytes(offset uint32, size uint32) []byte {

--- a/internal/arenaskl/arena_test.go
+++ b/internal/arenaskl/arena_test.go
@@ -30,19 +30,19 @@ func TestArenaSizeOverflow(t *testing.T) {
 	a := NewArena(math.MaxUint32, 0)
 
 	// Allocating under the limit throws no error.
-	offset, err := a.alloc(math.MaxUint16, 0)
+	offset, _, err := a.alloc(math.MaxUint16, 0)
 	require.Nil(t, err)
 	require.Equal(t, uint32(1), offset)
 	require.Equal(t, uint32(math.MaxUint16)+1, a.Size())
 
 	// Allocating over the limit could cause an accounting
 	// overflow if 32-bit arithmetic was used. It shouldn't.
-	_, err = a.alloc(math.MaxUint32, 0)
+	_, _, err = a.alloc(math.MaxUint32, 0)
 	require.Equal(t, ErrArenaFull, err)
 	require.Equal(t, uint32(math.MaxUint32), a.Size())
 
 	// Continuing to allocate continues to throw an error.
-	_, err = a.alloc(math.MaxUint16, 0)
+	_, _, err = a.alloc(math.MaxUint16, 0)
 	require.Equal(t, ErrArenaFull, err)
 	require.Equal(t, uint32(math.MaxUint32), a.Size())
 }

--- a/internal/arenaskl/flush_iterator.go
+++ b/internal/arenaskl/flush_iterator.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Dgraph Labs, Inc. and Contributors
+ * Modifications copyright (C) 2017 Andy Kimball and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package arenaskl
+
+import (
+	"github.com/petermattis/pebble/internal/base"
+)
+
+// flushIterator is an iterator over the skiplist object. Use Skiplist.NewFlushIter
+// to construct an iterator. The current state of the iterator can be cloned by
+// simply value copying the struct.
+type flushIterator struct {
+	Iterator
+	bytesIterated *uint64
+}
+
+func (it *flushIterator) SeekGE(key []byte) (*base.InternalKey, []byte) {
+	panic("pebble: SeekGE unimplemented")
+}
+
+func (it *flushIterator) SeekPrefixGE(prefix, key []byte) (*base.InternalKey, []byte) {
+	panic("pebble: SeekPrefixGE unimplemented")
+}
+
+func (it *flushIterator) SeekLT(key []byte) (*base.InternalKey, []byte) {
+	panic("pebble: SeekLT unimplemented")
+}
+
+// First seeks position at the first entry in list. Returns the key and value
+// if the iterator is pointing at a valid entry, and (nil, nil) otherwise. Note
+// that First only checks the upper bound. It is up to the caller to ensure
+// that key is greater than or equal to the lower bound.
+func (it *flushIterator) First() (*base.InternalKey, []byte) {
+	key, val := it.Iterator.First()
+	if key == nil {
+		return nil, nil
+	}
+	*it.bytesIterated += uint64(it.nd.allocSize)
+	return key, val
+}
+
+// Next advances to the next position. Returns the key and value if the
+// iterator is pointing at a valid entry, and (nil, nil) otherwise.
+// Note: flushIterator.Next mirrors the implementation of Iterator.Next
+// due to performance. Keep the two in sync.
+func (it *flushIterator) Next() (*base.InternalKey, []byte) {
+	it.nd = it.list.getNext(it.nd, 0)
+	if it.nd == it.list.tail {
+		return nil, nil
+	}
+	it.decodeKey()
+	*it.bytesIterated += uint64(it.nd.allocSize)
+	return &it.key, it.Value()
+}
+
+func (it *flushIterator) Prev() (*base.InternalKey, []byte) {
+	panic("pebble: Prev unimplemented")
+}

--- a/internal/arenaskl/iterator.go
+++ b/internal/arenaskl/iterator.go
@@ -143,6 +143,8 @@ func (it *Iterator) Last() (*base.InternalKey, []byte) {
 
 // Next advances to the next position. Returns the key and value if the
 // iterator is pointing at a valid entry, and (nil, nil) otherwise.
+// Note: flushIterator.Next mirrors the implementation of Iterator.Next
+// due to performance. Keep the two in sync.
 func (it *Iterator) Next() (*base.InternalKey, []byte) {
 	it.nd = it.list.getNext(it.nd, 0)
 	if it.nd == it.list.tail {

--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -47,6 +47,7 @@ type node struct {
 	// If valueSize is negative, the value is stored separately from the node in
 	// arena.extValues.
 	valueSize int32
+	allocSize uint32
 
 	// Most nodes do not need to use the full height of the tower, since the
 	// probability of each successive level decreases exponentially. Because
@@ -90,7 +91,7 @@ func newRawNode(arena *Arena, height uint32, keySize, valueSize uint32) (nd *nod
 	nodeSize := uint32(maxNodeSize - unusedSize)
 	valueIndex := int32(valueSize)
 
-	nodeOffset, err := arena.alloc(nodeSize+keySize+valueSize, align4)
+	nodeOffset, allocSize, err := arena.alloc(nodeSize+keySize+valueSize, align4)
 	if err != nil {
 		return
 	}
@@ -99,6 +100,7 @@ func newRawNode(arena *Arena, height uint32, keySize, valueSize uint32) (nd *nod
 	nd.keyOffset = nodeOffset + nodeSize
 	nd.keySize = uint32(keySize)
 	nd.valueSize = valueIndex
+	nd.allocSize = allocSize
 	return
 }
 

--- a/internal/arenaskl/skl.go
+++ b/internal/arenaskl/skl.go
@@ -313,6 +313,16 @@ func (s *Skiplist) NewIter(lower, upper []byte) *Iterator {
 	return it
 }
 
+// NewFlushIter returns a new flushIterator, which is similar to an Iterator
+// but also sets the current number of the bytes that have been iterated
+// through.
+func (s *Skiplist) NewFlushIter(bytesFlushed *uint64) *flushIterator {
+	return &flushIterator{
+		Iterator:      Iterator{list: s, nd: s.head},
+		bytesIterated: bytesFlushed,
+	}
+}
+
 func (s *Skiplist) newNode(
 	key base.InternalKey, value []byte,
 ) (nd *node, height uint32, err error) {

--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -300,6 +300,10 @@ type Options struct {
 	// The default merger concatenates values.
 	Merger *Merger
 
+	// MinFlushRate sets the minimum rate at which the MemTables are flushed. The
+	// default is 4 MB/s.
+	MinFlushRate int
+
 	// TableFormat specifies the format version for sstables. The default is
 	// TableFormatRocksDBv2 which creates RocksDB compatible sstables. Use
 	// TableFormatLevelDB to create LevelDB compatible sstable which can be used
@@ -380,6 +384,9 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.Merger == nil {
 		o.Merger = DefaultMerger
 	}
+	if o.MinFlushRate == 0 {
+		o.MinFlushRate = 4 << 20 // 4 MB/s
+	}
 	if o.FS == nil {
 		o.FS = vfs.Default
 	}
@@ -418,6 +425,7 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  max_open_files=%d\n", o.MaxOpenFiles)
 	fmt.Fprintf(&buf, "  mem_table_size=%d\n", o.MemTableSize)
 	fmt.Fprintf(&buf, "  mem_table_stop_writes_threshold=%d\n", o.MemTableStopWritesThreshold)
+	fmt.Fprintf(&buf, "  min_flush_rate=%d\n", o.MinFlushRate)
 	fmt.Fprintf(&buf, "  merger=%s\n", o.Merger.Name)
 	fmt.Fprintf(&buf, "  table_property_collectors=[")
 	for i := range o.TablePropertyCollectors {

--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -247,10 +247,6 @@ type Options struct {
 	// The number of files necessary to trigger an L0 compaction.
 	L0CompactionThreshold int
 
-	// Soft limit on the number of L0 files. Writes are slowed down when this
-	// threshold is reached.
-	L0SlowdownWritesThreshold int
-
 	// Hard limit on the number of L0 files. Writes are stopped when this
 	// threshold is reached.
 	L0StopWritesThreshold int
@@ -340,9 +336,6 @@ func (o *Options) EnsureDefaults() *Options {
 	if o.L0CompactionThreshold <= 0 {
 		o.L0CompactionThreshold = 4
 	}
-	if o.L0SlowdownWritesThreshold <= 0 {
-		o.L0SlowdownWritesThreshold = 8
-	}
 	if o.L0StopWritesThreshold <= 0 {
 		o.L0StopWritesThreshold = 12
 	}
@@ -418,7 +411,6 @@ func (o *Options) String() string {
 	fmt.Fprintf(&buf, "  comparer=%s\n", o.Comparer.Name)
 	fmt.Fprintf(&buf, "  disable_wal=%t\n", o.DisableWAL)
 	fmt.Fprintf(&buf, "  l0_compaction_threshold=%d\n", o.L0CompactionThreshold)
-	fmt.Fprintf(&buf, "  l0_slowdown_writes_threshold=%d\n", o.L0SlowdownWritesThreshold)
 	fmt.Fprintf(&buf, "  l0_stop_writes_threshold=%d\n", o.L0StopWritesThreshold)
 	fmt.Fprintf(&buf, "  lbase_max_bytes=%d\n", o.LBaseMaxBytes)
 	fmt.Fprintf(&buf, "  max_manifest_file_size=%d\n", o.MaxManifestFileSize)

--- a/internal/base/options_test.go
+++ b/internal/base/options_test.go
@@ -45,7 +45,6 @@ func TestOptionsString(t *testing.T) {
   comparer=leveldb.BytewiseComparator
   disable_wal=false
   l0_compaction_threshold=4
-  l0_slowdown_writes_threshold=8
   l0_stop_writes_threshold=12
   lbase_max_bytes=67108864
   max_manifest_file_size=134217728

--- a/internal/base/options_test.go
+++ b/internal/base/options_test.go
@@ -52,6 +52,7 @@ func TestOptionsString(t *testing.T) {
   max_open_files=1000
   mem_table_size=4194304
   mem_table_stop_writes_threshold=2
+  min_flush_rate=4194304
   merger=pebble.concatenate
   table_property_collectors=[]
   wal_dir=

--- a/mem_table.go
+++ b/mem_table.go
@@ -179,12 +179,20 @@ func (m *memTable) newIter(o *IterOptions) internalIterator {
 	return m.skl.NewIter(o.GetLowerBound(), o.GetUpperBound())
 }
 
+func (m *memTable) newFlushIter(o *IterOptions, bytesFlushed *uint64) internalIterator {
+	return m.skl.NewFlushIter(bytesFlushed)
+}
+
 func (m *memTable) newRangeDelIter(*IterOptions) internalIterator {
 	tombstones := m.tombstones.get(m)
 	if tombstones == nil {
 		return nil
 	}
 	return rangedel.NewIter(m.cmp, tombstones)
+}
+
+func (m *memTable) totalBytes() uint64 {
+	return uint64(m.skl.Size() - m.emptySize)
 }
 
 func (m *memTable) close() error {

--- a/open.go
+++ b/open.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 
 	"github.com/petermattis/pebble/internal/arenaskl"
+	"github.com/petermattis/pebble/internal/rate"
 	"github.com/petermattis/pebble/internal/record"
 	"github.com/petermattis/pebble/vfs"
 )
@@ -81,6 +82,7 @@ func Open(dirname string, opts *Options) (*DB, error) {
 		apply:         d.commitApply,
 		write:         d.commitWrite,
 	})
+	d.flushLimiter = rate.NewLimiter(rate.Limit(d.opts.MinFlushRate), d.opts.MinFlushRate)
 	d.mu.nextJobID = 1
 	d.mu.mem.cond.L = &d.mu.Mutex
 	d.mu.mem.mutable = newMemTable(d.opts)

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -170,7 +170,10 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 			rngMu.Lock()
 			fileNum, sleepTime := rng.Intn(tableCacheTestNumTables), rng.Intn(1000)
 			rngMu.Unlock()
-			iter, _, err := c.newIters(&fileMetadata{fileNum: uint64(fileNum)}, nil /* iter options */)
+			iter, _, err := c.newIters(
+				&fileMetadata{fileNum: uint64(fileNum)},
+				nil /* iter options */,
+				nil /* bytes iterated */)
 			if err != nil {
 				errc <- fmt.Errorf("i=%d, fileNum=%d: find: %v", i, fileNum, err)
 				return
@@ -229,7 +232,10 @@ func TestTableCacheFrequentlyUsed(t *testing.T) {
 
 	for i := 0; i < N; i++ {
 		for _, j := range [...]int{pinned0, i % tableCacheTestNumTables, pinned1} {
-			iter, _, err := c.newIters(&fileMetadata{fileNum: uint64(j)}, nil /* iter options */)
+			iter, _, err := c.newIters(
+				&fileMetadata{fileNum: uint64(j)},
+				nil /* iter options */,
+				nil /* bytes iterated */)
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 			}
@@ -264,7 +270,10 @@ func TestTableCacheEvictions(t *testing.T) {
 	rng := rand.New(rand.NewSource(2))
 	for i := 0; i < N; i++ {
 		j := rng.Intn(tableCacheTestNumTables)
-		iter, _, err := c.newIters(&fileMetadata{fileNum: uint64(j)}, nil /* iter options */)
+		iter, _, err := c.newIters(
+			&fileMetadata{fileNum: uint64(j)},
+			nil /* iter options */,
+			nil /* bytes iterated */)
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
 		}
@@ -304,7 +313,10 @@ func TestTableCacheIterLeak(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := c.newIters(&fileMetadata{fileNum: 0}, nil /* iter options */); err != nil {
+	if _, _, err := c.newIters(
+		&fileMetadata{fileNum: 0},
+		nil /* iter options */,
+		nil /* bytes iterated */); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.Close(); err == nil {


### PR DESCRIPTION
Added a flush iterator which tracks the number of bytes iterated through. This allows us to see how much of the memtable has been flushed so that we can slow down flushing to match the speed of incoming writes.

This implements a portion of #7

Initially, I tried to expose an API on the iterator itself to determine the node size of the current node, something like `FlushIterator.NodeSize()`. However, the `internalIterator` interface doesn't expose this API so that wasn't an option. The compaction iterator wraps an `internalIterator` so there is no way to access the `FlushIterator.NodeSize()` API during the actual flushing. To get past this issue, I've extended the `flushable` interface. FlushIterator updates a `bytesIterated` field in the underlying skiplist, which then exposes the field through the `flushable` interface. This means that only one flush iterator can run concurrently for a skiplist. I'm not sure if this is the best way to do it, do you have any suggestions?

The same thing needs to be done with `flushableBatchIter`. The iterator needs to update a field in the underlying `flushableBatch` and expose the iteration progress through the `flushable` interface.

An alternative I can think of includes extending `internalIterator` but that would result in "panic: unimplemented" in a lot of iterators. Another alternative would be to create a new "MergeIter" which would be a copy of the current "MergeIter" except it iterates over just a flush iterator instead of an `internalIterator`.


