### PR TITLE
Add support for using RocksDB instead of Pebble

### DIFF
--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -1,0 +1,113 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package main
+
+import (
+	"log"
+
+	"github.com/petermattis/pebble"
+	"github.com/petermattis/pebble/cache"
+	"github.com/petermattis/pebble/internal/bytealloc"
+)
+
+// DB specifies the minimal interfaces that need to be implemented to support
+// the pebble command.
+type DB interface {
+	NewIter(*pebble.IterOptions) iterator
+	NewBatch() batch
+	Scan(key []byte, count int64) error
+	Metrics() *pebble.VersionMetrics
+	Flush() error
+}
+
+type iterator interface {
+	SeekGE(key []byte) bool
+	Valid() bool
+	Key() []byte
+	Value() []byte
+	First() bool
+	Next() bool
+	Last() bool
+	Prev() bool
+	Close() error
+}
+
+type batch interface {
+	Commit(opts *pebble.WriteOptions) error
+	Set(key, value []byte, opts *pebble.WriteOptions) error
+	LogData(data []byte, opts *pebble.WriteOptions) error
+	Repr() []byte
+}
+
+// Adapters for Pebble. Since the interfaces above are based on Pebble's
+// interfaces, it can simply forward calls for everything.
+type pebbleDB struct {
+	d *pebble.DB
+}
+
+func newPebbleDB(dir string) DB {
+	opts := &pebble.Options{
+		Cache:                       cache.New(1 << 30),
+		Comparer:                    mvccComparer,
+		DisableWAL:                  disableWAL,
+		MemTableSize:                64 << 20,
+		MemTableStopWritesThreshold: 4,
+		L0CompactionThreshold:       2,
+		L0SlowdownWritesThreshold:   20,
+		L0StopWritesThreshold:       32,
+		LBaseMaxBytes:               64 << 20, // 64 MB
+		Levels: []pebble.LevelOptions{{
+			BlockSize: 32 << 10,
+		}},
+		Merger: &pebble.Merger{
+			Name: "cockroach_merge_operator",
+		},
+	}
+	opts.EnsureDefaults()
+
+	if verbose {
+		opts.EventListener = pebble.MakeLoggingEventListener(nil)
+		opts.EventListener.TableDeleted = nil
+		opts.EventListener.TableIngested = nil
+		opts.EventListener.WALCreated = nil
+		opts.EventListener.WALDeleted = nil
+	}
+
+	p, err := pebble.Open(dir, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return pebbleDB{p}
+}
+
+func (p pebbleDB) Flush() error {
+	return p.d.Flush()
+}
+
+func (p pebbleDB) NewIter(opts *pebble.IterOptions) iterator {
+	return p.d.NewIter(opts)
+}
+
+func (p pebbleDB) NewBatch() batch {
+	return p.d.NewBatch()
+}
+
+func (p pebbleDB) Scan(key []byte, count int64) error {
+	var data bytealloc.A
+	iter := p.d.NewIter(nil)
+	for i, valid := 0, iter.SeekGE(key); valid; valid = iter.Next() {
+		data, _ = data.Copy(iter.Key())
+		data, _ = data.Copy(iter.Value())
+		i++
+		if i >= int(count) {
+			break
+		}
+	}
+	return iter.Close()
+}
+
+func (p pebbleDB) Metrics() *pebble.VersionMetrics {
+	return p.d.Metrics()
+}

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -16,6 +16,7 @@ var (
 	concurrency     int
 	disableWAL      bool
 	duration        time.Duration
+	rocksdb         bool
 	verbose         bool
 	walOnly         bool
 	waitCompactions bool
@@ -45,6 +46,9 @@ func main() {
 			&disableWAL, "disable-wal", false, "disable the WAL (voiding persistence guarantees)")
 		cmd.Flags().DurationVarP(
 			&duration, "duration", "d", 10*time.Second, "the duration to run (0, run forever)")
+		cmd.Flags().BoolVar(
+			&rocksdb, "rocksdb", false,
+			"use rocksdb storage engine instead of pebble")
 		cmd.Flags().BoolVarP(
 			&verbose, "verbose", "v", false, "enable verbose event logging")
 		cmd.Flags().BoolVar(

--- a/cmd/pebble/mvcc.go
+++ b/cmd/pebble/mvcc.go
@@ -90,7 +90,7 @@ func mvccEncode(dst, key []byte, walltime uint64, logical uint32) []byte {
 	return dst
 }
 
-func mvccForwardScan(d *pebble.DB, start, end, ts []byte) (int, int64) {
+func mvccForwardScan(d DB, start, end, ts []byte) (int, int64) {
 	it := d.NewIter(&pebble.IterOptions{
 		LowerBound: mvccEncode(nil, start, 0, 0),
 		UpperBound: mvccEncode(nil, end, 0, 0),
@@ -113,7 +113,7 @@ func mvccForwardScan(d *pebble.DB, start, end, ts []byte) (int, int64) {
 	return count, nbytes
 }
 
-func mvccReverseScan(d *pebble.DB, start, end, ts []byte) (int, int64) {
+func mvccReverseScan(d DB, start, end, ts []byte) (int, int64) {
 	it := d.NewIter(&pebble.IterOptions{
 		LowerBound: mvccEncode(nil, start, 0, 0),
 		UpperBound: mvccEncode(nil, end, 0, 0),

--- a/cmd/pebble/rocksdb.go
+++ b/cmd/pebble/rocksdb.go
@@ -1,0 +1,244 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build rocksdb
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/petermattis/pebble"
+)
+
+// Adapters for rocksDB
+type rocksDB struct {
+	d *engine.RocksDB
+}
+
+func newRocksDB(dir string) DB {
+	// TODO: match Pebble / Rocks options
+	r, err := engine.NewRocksDB(
+		engine.RocksDBConfig{
+			Dir: dir,
+		},
+		engine.NewRocksDBCache(1<<30 /* 1GB */),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return rocksDB{r}
+}
+
+type rocksDBIterator struct {
+	iter       engine.Iterator
+	lowerBound []byte
+	upperBound []byte
+}
+
+type rocksDBBatch struct {
+	batch engine.Batch
+}
+
+func (i rocksDBIterator) SeekGE(key []byte) bool {
+	// TODO: unnecessary overhead here. Change the interface.
+	userKey, _, ok := mvccSplitKey(key)
+	if !ok {
+		panic("mvccSplitKey failed")
+	}
+	i.iter.Seek(engine.MVCCKey{
+		Key: userKey,
+	})
+	return i.Valid()
+}
+
+func (i rocksDBIterator) Valid() bool {
+	valid, _ := i.iter.Valid()
+	return valid
+}
+
+func (i rocksDBIterator) Key() []byte {
+	key := i.iter.Key()
+	return []byte(key.Key)
+}
+
+func (i rocksDBIterator) Value() []byte {
+	return i.iter.Value()
+}
+
+func (i rocksDBIterator) First() bool {
+	return i.SeekGE(i.lowerBound)
+}
+
+func (i rocksDBIterator) Next() bool {
+	i.iter.Next()
+	valid, _ := i.iter.Valid()
+	return valid
+}
+
+func (i rocksDBIterator) Last() bool {
+	// TODO: unnecessary overhead here. Change the interface.
+	userKey, _, ok := mvccSplitKey(i.upperBound)
+	if !ok {
+		panic("mvccSplitKey failed")
+	}
+	i.iter.SeekReverse(engine.MVCCKey{
+		Key: userKey,
+	})
+	return i.Valid()
+}
+
+func (i rocksDBIterator) Prev() bool {
+	i.iter.Prev()
+	valid, _ := i.iter.Valid()
+	return valid
+}
+
+func (i rocksDBIterator) Close() error {
+	i.iter.Close()
+	return nil
+}
+
+func (b rocksDBBatch) Commit(opts *pebble.WriteOptions) error {
+	return b.batch.Commit(opts.Sync)
+}
+
+func (b rocksDBBatch) Set(key, value []byte, _ *pebble.WriteOptions) error {
+	// TODO: unnecessary overhead here. Change the interface.
+	userKey, _, ok := mvccSplitKey(key)
+	if !ok {
+		panic("mvccSplitKey failed")
+	}
+	ts := hlc.Timestamp{WallTime: 1}
+	return b.batch.Put(engine.MVCCKey{Key: userKey, Timestamp: ts}, value)
+}
+
+func (b rocksDBBatch) LogData(data []byte, _ *pebble.WriteOptions) error {
+	return b.batch.LogData(data)
+}
+
+func (b rocksDBBatch) Repr() []byte {
+	return b.batch.Repr()
+}
+
+func (r rocksDB) Flush() error {
+	return r.d.Flush()
+}
+
+func (r rocksDB) NewIter(opts *pebble.IterOptions) iterator {
+	ropts := engine.IterOptions{}
+	if opts != nil {
+		ropts.LowerBound = opts.LowerBound
+		ropts.UpperBound = opts.UpperBound
+	} else {
+		ropts.UpperBound = roachpb.KeyMax
+	}
+	iter := r.d.NewIterator(ropts)
+	return rocksDBIterator{
+		iter:       iter,
+		lowerBound: ropts.LowerBound,
+		upperBound: ropts.UpperBound,
+	}
+}
+
+func (r rocksDB) NewBatch() batch {
+	return rocksDBBatch{r.d.NewBatch()}
+}
+
+func (r rocksDB) Scan(key []byte, count int64) error {
+	// TODO: unnecessary overhead here. Change the interface.
+	beginKey, _, ok := mvccSplitKey(key)
+	if !ok {
+		panic("mvccSplitKey failed")
+	}
+	ropts := engine.IterOptions{
+		LowerBound: key,
+	}
+	iter := r.d.NewIterator(ropts)
+	defer iter.Close()
+	// We hard code a timestamp with walltime=1 in the data, so we just have to
+	// use a larger timestamp here (walltime=10).
+	ts := hlc.Timestamp{WallTime: 10}
+	_, numKVs, _, intents, err := iter.MVCCScan(
+		beginKey, roachpb.KeyMax, count, ts, engine.MVCCScanOptions{},
+	)
+	if numKVs > count {
+		panic("MVCCScan returned too many keys")
+	}
+	if len(intents) > 0 {
+		panic("MVCCScan found intents")
+	}
+	return err
+}
+
+func (r rocksDB) Metrics() *pebble.VersionMetrics {
+	stats := r.d.GetCompactionStats()
+	fmt.Printf(stats)
+	var inLevelsSection bool
+	var vMetrics pebble.VersionMetrics
+	for _, line := range strings.Split(stats, "\n") {
+		if strings.HasPrefix(line, "-----") {
+			continue
+		}
+		if !inLevelsSection && strings.HasPrefix(line, "Level") {
+			inLevelsSection = true
+			continue
+		}
+		if strings.HasPrefix(line, "Flush(GB):") {
+			// line looks like:
+			// "Flush(GB): cumulative 0.302, interval 0.302"
+			// pretend cumulative flush is WAL size and L0 input since we don't have
+			// access to WAL stats in rocks.
+			// TODO: this is slightly different than Pebble which uses the real physical
+			// WAL size. This way prevents compression ratio from affecting write-amp,
+			// but it also prevents apples-to-apples w-amp comparison.
+			fields := strings.Fields(line)
+			field := fields[2]
+			walWrittenGB, _ := strconv.ParseFloat(field[0:len(field)-1], 64)
+			vMetrics.Levels[0].BytesIn = uint64(1024.0 * 1024.0 * 1024.0 * walWrittenGB)
+			vMetrics.WAL.BytesWritten = vMetrics.Levels[0].BytesIn
+		}
+		if inLevelsSection && strings.HasPrefix(line, " Sum") {
+			inLevelsSection = false
+			continue
+		}
+		if inLevelsSection {
+			fields := strings.Fields(line)
+			level, _ := strconv.Atoi(fields[0][1:])
+			if level < 0 || level > 6 {
+				panic("expected at most 7 levels")
+			}
+			vMetrics.Levels[level].NumFiles, _ = strconv.ParseUint(strings.Split(fields[1], "/")[0], 10, 64)
+			size, _ := strconv.ParseFloat(fields[2], 64)
+			if fields[3] == "KB" {
+				size *= 1024.0
+			} else if fields[3] == "MB" {
+				size *= 1024.0 * 1024.0
+			} else if fields[3] == "GB" {
+				size *= 1024.0 * 1024.0 * 1024.0
+			} else {
+				panic("unknown unit")
+			}
+			vMetrics.Levels[level].Size = uint64(size)
+			vMetrics.Levels[level].Score, _ = strconv.ParseFloat(fields[4], 64)
+			if level > 0 {
+				bytesInGB, _ := strconv.ParseFloat(fields[6], 64)
+				vMetrics.Levels[level].BytesIn = uint64(1024.0 * 1024.0 * 1024.0 * bytesInGB)
+			}
+			bytesMovedGB, _ := strconv.ParseFloat(fields[10], 64)
+			vMetrics.Levels[level].BytesMoved = uint64(1024.0 * 1024.0 * 1024.0 * bytesMovedGB)
+			bytesReadGB, _ := strconv.ParseFloat(fields[5], 64)
+			vMetrics.Levels[level].BytesRead = uint64(1024.0 * 1024.0 * 1024.0 * bytesReadGB)
+			bytesWrittenGB, _ := strconv.ParseFloat(fields[8], 64)
+			vMetrics.Levels[level].BytesWritten = uint64(1024.0 * 1024.0 * 1024.0 * bytesWrittenGB)
+		}
+	}
+	return &vMetrics
+}

--- a/cmd/pebble/rocksdb_disabled.go
+++ b/cmd/pebble/rocksdb_disabled.go
@@ -1,0 +1,14 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !rocksdb
+
+package main
+
+import "log"
+
+func newRocksDB(dir string) DB {
+	log.Fatalf("pebble not compiled with RocksDB support: recompile with \"-tags rocksdb\"\n")
+	return nil
+}

--- a/cmd/pebble/scan.go
+++ b/cmd/pebble/scan.go
@@ -68,7 +68,7 @@ func runScan(cmd *cobra.Command, args []string) {
 	}
 
 	runTest(args[0], test{
-		init: func(d *pebble.DB, wg *sync.WaitGroup) {
+		init: func(d DB, wg *sync.WaitGroup) {
 			const count = 100000
 			const batch = 1000
 

--- a/cmd/pebble/sync.go
+++ b/cmd/pebble/sync.go
@@ -63,7 +63,7 @@ func runSync(cmd *cobra.Command, args []string) {
 	}
 
 	runTest(args[0], test{
-		init: func(d *pebble.DB, wg *sync.WaitGroup) {
+		init: func(d DB, wg *sync.WaitGroup) {
 			wg.Add(concurrency)
 			for i := 0; i < concurrency; i++ {
 				latency := reg.Register("ops")


### PR DESCRIPTION
The RocksDB support utilizes cockroachdb/cockroach/pkg/storage/engine,
which is a very heavyweight dependency. To make this more palatable,
that dependency is optional and RocksDB support is only compiled in if
`-tags rocksdb` is specified.

Much of this code was written by @ajkr.