### PR TITLE
Disable SyncFileRange on arm

### DIFF
--- a/internal/arenaskl/node.go
+++ b/internal/arenaskl/node.go
@@ -65,11 +65,11 @@ func newNode(
 		panic("height cannot be less than one or greater than the max height")
 	}
 	keySize := key.Size()
-	if keySize > math.MaxUint32 {
+	if int64(keySize) > math.MaxUint32 {
 		panic("key is too large")
 	}
 	valueSize := len(value)
-	if len(value) > math.MaxUint32 {
+	if int64(len(value)) > math.MaxUint32 {
 		panic("value is too large")
 	}
 

--- a/vfs/syncing_file_generic.go
+++ b/vfs/syncing_file_generic.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build !linux
+// +build !linux arm
 
 package vfs
 

--- a/vfs/syncing_file_linux.go
+++ b/vfs/syncing_file_linux.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build linux
+// +build linux,!arm
 
 package vfs
 

--- a/vfs/syncing_file_linux_test.go
+++ b/vfs/syncing_file_linux_test.go
@@ -2,7 +2,7 @@
 // of this source code is governed by a BSD-style license that can be found in
 // the LICENSE file.
 
-// +build linux
+// +build linux,!arm
 
 package vfs
 


### PR DESCRIPTION
syscall.SyncFileRange is not defined on arm (though it is for arm64?).

Fix a warning about a comparison that is always true when ints are
32-bits.

Fixes #171