### PR TITLE
Add lightweight manual memory management for the block cache

### DIFF
--- a/cache/alloc.go
+++ b/cache/alloc.go
@@ -1,0 +1,77 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package cache
+
+const (
+	// The min size of a byte slice held in an allocCache instance. Byte slices
+	// smaller than this value will not be cached.
+	allocCacheMinSize = 1024
+	// The max size of a byte slice held in an allocCache instance. Byte slices
+	// larger than this value will not be cached.
+	allocCacheMaxSize    = 64 * 1024
+	allocCacheCountLimit = 16
+	// The maximum size of data held in a single allocCache instance. There will
+	// be O(num-cpus) allocCaches per Cache.
+	allocCacheSizeLimit = 512 * 1024
+)
+
+// allocCache implements a small cache for the byte slice allocations used by
+// the Cache. If an allocCache is empty, allocations are passed through to the
+// Go runtime allocator. An allocCache holds a list of recently freed buffers
+// that is capped at 16 entries and 512KB in size. When a buffer is freed, the
+// existing cached buffers are trimmed until the new entry can fit with the
+// count and size limits. When a buffer is allocated, this cached list is
+// walked from beginning to end looking for the first buffer which is the same
+// size class as the allocation. Size classes are multiples of 1024.
+type allocCache struct {
+	size int
+	bufs [][]byte
+}
+
+func sizeToClass(size int) int {
+	return (size - 1) / 1024
+}
+
+func classToSize(class int) int {
+	return (class + 1) * 1024
+}
+
+func (c *allocCache) alloc(n int) []byte {
+	if n < allocCacheMinSize || n >= allocCacheMaxSize {
+		return make([]byte, n)
+	}
+
+	class := sizeToClass(n)
+	for i := range c.bufs {
+		if t := c.bufs[i]; sizeToClass(len(t)) == class {
+			j := len(c.bufs) - 1
+			c.bufs[i], c.bufs[j] = c.bufs[j], c.bufs[i]
+			c.bufs[j] = nil
+			c.bufs = c.bufs[:j]
+			c.size -= len(t)
+			return t[:n]
+		}
+	}
+
+	return make([]byte, n, classToSize(class))
+}
+
+func (c *allocCache) free(b []byte) {
+	n := cap(b)
+	if n < allocCacheMinSize || n >= allocCacheMaxSize {
+		return
+	}
+	b = b[:n:n]
+
+	for c.size+n >= allocCacheSizeLimit || len(c.bufs) >= allocCacheCountLimit {
+		i := len(c.bufs) - 1
+		t := c.bufs[i]
+		c.size -= len(t)
+		c.bufs[i] = nil
+		c.bufs = c.bufs[:i]
+	}
+	c.bufs = append(c.bufs, b)
+	c.size += n
+}

--- a/cache/alloc_test.go
+++ b/cache/alloc_test.go
@@ -1,0 +1,32 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package cache
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestAllocCache(t *testing.T) {
+	c := &allocCache{}
+	for i := 0; i < 64; i++ {
+		c.free(make([]byte, 1025))
+		if c.size == 0 {
+			t.Fatalf("expected cache size to be non-zero")
+		}
+	}
+	m := make(map[unsafe.Pointer]bool)
+	for i := 0; i < 64; i++ {
+		b := c.alloc(1025)
+		p := unsafe.Pointer(&b[0])
+		if m[p] {
+			t.Fatalf("%p already allocated", p)
+		}
+		m[p] = true
+	}
+	if c.size != 0 {
+		t.Fatalf("expected cache size to be zero, found %d", c.size)
+	}
+}

--- a/cmd/pebble/db.go
+++ b/cmd/pebble/db.go
@@ -49,7 +49,7 @@ type pebbleDB struct {
 
 func newPebbleDB(dir string) DB {
 	opts := &pebble.Options{
-		Cache:                       cache.New(1 << 30),
+		Cache:                       cache.New(cacheSize),
 		Comparer:                    mvccComparer,
 		DisableWAL:                  disableWAL,
 		MemTableSize:                64 << 20,

--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 var (
+	cacheSize       int64
 	concurrency     int
 	disableWAL      bool
 	duration        time.Duration
@@ -40,6 +41,8 @@ func main() {
 	)
 
 	for _, cmd := range []*cobra.Command{scanCmd, syncCmd, ycsbCmd} {
+		cmd.Flags().Int64Var(
+			&cacheSize, "cache", 1<<30, "cache size")
 		cmd.Flags().IntVarP(
 			&concurrency, "concurrency", "c", 1, "number of concurrent workers")
 		cmd.Flags().BoolVar(

--- a/cmd/pebble/rocksdb.go
+++ b/cmd/pebble/rocksdb.go
@@ -29,7 +29,7 @@ func newRocksDB(dir string) DB {
 		engine.RocksDBConfig{
 			Dir: dir,
 		},
-		engine.NewRocksDBCache(1<<30 /* 1GB */),
+		engine.NewRocksDBCache(cacheSize),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/pebble/rocksdb.go
+++ b/cmd/pebble/rocksdb.go
@@ -20,7 +20,8 @@ import (
 
 // Adapters for rocksDB
 type rocksDB struct {
-	d *engine.RocksDB
+	d       *engine.RocksDB
+	ballast []byte
 }
 
 func newRocksDB(dir string) DB {
@@ -34,7 +35,10 @@ func newRocksDB(dir string) DB {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return rocksDB{r}
+	return rocksDB{
+		d:       r,
+		ballast: make([]byte, 1<<30),
+	}
 }
 
 type rocksDBIterator struct {

--- a/sstable/block.go
+++ b/sstable/block.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"unsafe"
 
+	"github.com/petermattis/pebble/cache"
 	"github.com/petermattis/pebble/internal/base"
 )
 
@@ -117,6 +118,7 @@ type blockIter struct {
 	ikey         InternalKey
 	cached       []blockEntry
 	cachedBuf    []byte
+	cacheHandle  cache.Handle
 	err          error
 }
 
@@ -144,6 +146,11 @@ func (i *blockIter) init(cmp Compare, block block, globalSeqNum uint64) error {
 	i.val = nil
 	i.clearCache()
 	return nil
+}
+
+func (i *blockIter) setCacheHandle(h cache.Handle) {
+	i.cacheHandle.Release()
+	i.cacheHandle = h
 }
 
 func (i *blockIter) readEntry() {
@@ -651,6 +658,7 @@ func (i *blockIter) Error() error {
 // Close implements internalIterator.Close, as documented in the pebble
 // package.
 func (i *blockIter) Close() error {
+	i.cacheHandle.Release()
 	i.val = nil
 	return i.err
 }


### PR DESCRIPTION
Add support for lightweight manual memmory management to the block cache.
Memory is still allocated using the Go runtime, yet we track blocks that
are either in the cache, or still in use by an iterator. When the final
reference to a block is released, the byte slice is added to a per-thread
list of recently freed blocks. Allocations for block memory are first
satisfied from this cache before falling back to the Go allocator.

The allocation cache groups allocation sizes into 1024-byte classes. There
is some space wastage in this setup which we could reduce with finer
granularity classes such as those used in the Go runtime.

Experimentation shows that 99% of allocation sizes for blocks cluster
within a single size class: the configured target block size. In a workload
where the working set exceeds the block cache size, the allocation cache
effectively eliminates 99% of the allocations that would occur as blocks
are evicted from the cache and then another block is added.

Fixes #31