### PR TITLE
Fix a "memory leak" in caching entries during reverse iteration

### DIFF
--- a/sstable/raw_block.go
+++ b/sstable/raw_block.go
@@ -96,12 +96,13 @@ func (i *rawBlockIter) clearCache() {
 }
 
 func (i *rawBlockIter) cacheEntry() {
-	i.cachedBuf = append(i.cachedBuf, i.key...)
 	i.cached = append(i.cached, blockEntry{
-		offset: i.offset,
-		key:    i.cachedBuf[len(i.cachedBuf)-len(i.key) : len(i.cachedBuf) : len(i.cachedBuf)],
-		val:    i.val,
+		offset:   i.offset,
+		keyStart: len(i.cachedBuf),
+		keyEnd:   len(i.cachedBuf) + len(i.key),
+		val:      i.val,
 	})
+	i.cachedBuf = append(i.cachedBuf, i.key...)
 }
 
 // SeekGE implements internalIterator.SeekGE, as documented in the pebble
@@ -199,7 +200,7 @@ func (i *rawBlockIter) Prev() bool {
 		e := &i.cached[n-1]
 		i.offset = e.offset
 		i.val = e.val
-		i.ikey.UserKey = e.key
+		i.ikey.UserKey = i.cachedBuf[e.keyStart:e.keyEnd]
 		i.cached = i.cached[:n]
 		return true
 	}

--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -507,7 +507,7 @@ func (i *compactionIterator) First() (*InternalKey, []byte) {
 	}
 	// If the sstable only has 1 entry, we are at the last entry in the block and we must
 	// increment bytes iterated by the size of the block trailer and restart points.
-	if i.data.nextOffset+(4*(i.data.numRestarts+1)) == len(i.data.data) {
+	if i.data.nextOffset+(4*(i.data.numRestarts+1)) == int32(len(i.data.data)) {
 		i.prevOffset = blockTrailerLen + i.dataBH.length
 	} else {
 		// i.dataBH.length/len(i.data.data) is the compression ratio. If uncompressed, this is 1.
@@ -555,7 +555,7 @@ func (i *compactionIterator) Next() (*InternalKey, []byte) {
 	curOffset := i.dataBH.offset + recordOffset
 	// Last entry in the block must increment bytes iterated by the size of the block trailer
 	// and restart points.
-	if i.data.nextOffset+(4*(i.data.numRestarts+1)) == len(i.data.data) {
+	if i.data.nextOffset+(4*(i.data.numRestarts+1)) == int32(len(i.data.data)) {
 		curOffset += blockTrailerLen + uint64(4*(i.data.numRestarts+1))
 	}
 	*i.bytesIterated += uint64(curOffset - i.prevOffset)


### PR DESCRIPTION
During reverse iteration, the cache of entries to the previous restart
point was holding a pointer into `blockIter.cachedBuf`. That buffer started
size at 0 and then increased on every entry added. If the buffer had to be
resized, existing cached entries would still point to the old buffer. The
result was not incorrect, but it used more memory than expected.