### PR TITLE
Write heap profile at the end of the benchmark

### DIFF
--- a/cmd/pebble/test.go
+++ b/cmd/pebble/test.go
@@ -39,6 +39,17 @@ func startCPUProfile() func() {
 		pprof.StopCPUProfile()
 		f.Close()
 
+		if p := pprof.Lookup("heap"); p != nil {
+			f, err := os.Create("heap.prof")
+			if err != nil {
+				log.Fatal(err)
+			}
+			if err := p.WriteTo(f, 0); err != nil {
+				log.Fatal(err)
+			}
+			f.Close()
+		}
+
 		// if p := pprof.Lookup("mutex"); p != nil {
 		// 	f, err := os.Create("mutex.prof")
 		// 	if err != nil {


### PR DESCRIPTION
Heap sampling is always enabled, so might as well write the heap profile.