### PR TITLE
Add max ops/sec to benchmarks

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"log"
+	"math"
 	"os"
 	"time"
 
@@ -16,6 +17,7 @@ var (
 	concurrency     int
 	disableWAL      bool
 	duration        time.Duration
+	maxOpsPerSec    int
 	rocksdb         bool
 	verbose         bool
 	walOnly         bool
@@ -46,6 +48,8 @@ func main() {
 			&disableWAL, "disable-wal", false, "disable the WAL (voiding persistence guarantees)")
 		cmd.Flags().DurationVarP(
 			&duration, "duration", "d", 10*time.Second, "the duration to run (0, run forever)")
+		cmd.Flags().IntVarP(
+			&maxOpsPerSec, "max-ops-per-sec", "m", math.MaxInt32, "max ops per second")
 		cmd.Flags().BoolVar(
 			&rocksdb, "rocksdb", false,
 			"use rocksdb storage engine instead of pebble")


### PR DESCRIPTION
Add a flag to specify max operations per second in scan, sync, and ycsb benchmarks.

This allows us to properly measure read/write latencies at specified rates. Concurrency should be set high enough so that the go routines are stopped by the rate limiter. This way, even if read/write latencies are high on certain go routines, new reads/writes can still come in.