### PR TITLE
Increase the number of block cache shards to 2*NumCPU

### DIFF
--- a/cache/clockpro.go
+++ b/cache/clockpro.go
@@ -468,7 +468,7 @@ type Cache struct {
 // New creates a new cache of the specified size. Memory for the cache is
 // allocated on demand, not during initialization.
 func New(size int64) *Cache {
-	return newShards(size, runtime.NumCPU())
+	return newShards(size, 2*runtime.NumCPU())
 }
 
 func newShards(size int64, shards int) *Cache {


### PR DESCRIPTION
The previous setting of NumCPU shards was causing `shard.Set` to show up
as a contention point in concurrent read-only workloads where the
working set is larger than the block cache size.