### PR TITLE
Fix ingestSortAndVerify overlapping check

### DIFF
--- a/internal/base/internal.go
+++ b/internal/base/internal.go
@@ -218,10 +218,7 @@ func (k InternalKey) EncodeTrailer() [8]byte {
 // to store the returned InternalKey.UserKey, though it is valid to pass a
 // nil. See the Separator type for details on separator keys.
 func (k InternalKey) Separator(
-	cmp Compare,
-	sep Separator,
-	buf []byte,
-	other InternalKey,
+	cmp Compare, sep Separator, buf []byte, other InternalKey,
 ) InternalKey {
 	buf = sep(buf, k.UserKey, other.UserKey)
 	if len(buf) <= len(k.UserKey) && cmp(k.UserKey, buf) < 0 {

--- a/testdata/ingest_sort_and_verify
+++ b/testdata/ingest_sort_and_verify
@@ -1,0 +1,180 @@
+# Default comparator specific tests.
+
+ingest cmp=default
+a.SET.0-b.SET.0
+----
+a#0,1-b#0,1
+
+ingest cmp=default
+a.SET.0-b.SET.0
+c.SET.0-d.SET.0
+e.SET.0-f.SET.0
+----
+a#0,1-b#0,1
+c#0,1-d#0,1
+e#0,1-f#0,1
+
+ingest cmp=default
+c.SET.0-d.SET.0
+a.SET.0-b.SET.0
+e.SET.0-f.SET.0
+----
+a#0,1-b#0,1
+c#0,1-d#0,1
+e#0,1-f#0,1
+
+ingest cmp=default
+a.SET.0-b.SET.0
+b.SET.0-d.SET.0
+e.SET.0-f.SET.0
+----
+files have overlapping ranges
+
+ingest cmp=default
+c.SET.0-d.SET.0
+d.SET.0-e.SET.0
+a.SET.0-b.SET.0
+----
+files have overlapping ranges
+
+ingest cmp=default
+a.SET.1-b.SET.1
+b.SET.0-c.SET.0
+----
+files have overlapping ranges
+
+ingest cmp=default
+a.RANGEDEL.0-b.RANGEDEL.72057594037927935
+b.RANGEDEL.0-d.RANGEDEL.72057594037927935
+e.RANGEDEL.0-f.RANGEDEL.72057594037927935
+----
+a#0,15-b#72057594037927935,15
+b#0,15-d#72057594037927935,15
+e#0,15-f#72057594037927935,15
+
+ingest cmp=default
+a.RANGEDEL.0-b.RANGEDEL.72057594037927935
+c.RANGEDEL.0-e.RANGEDEL.72057594037927935
+e.RANGEDEL.0-f.RANGEDEL.72057594037927935
+----
+a#0,15-b#72057594037927935,15
+c#0,15-e#72057594037927935,15
+e#0,15-f#72057594037927935,15
+
+ingest cmp=default
+a.RANGEDEL.0-b.RANGEDEL.72057594037927935
+b.RANGEDEL.0-e.RANGEDEL.72057594037927935
+e.RANGEDEL.0-f.RANGEDEL.72057594037927935
+----
+a#0,15-b#72057594037927935,15
+b#0,15-e#72057594037927935,15
+e#0,15-f#72057594037927935,15
+
+ingest cmp=default
+a.RANGEDEL.0-c.RANGEDEL.72057594037927935
+b.SET.0-d.SET.0
+----
+files have overlapping ranges
+
+ingest cmp=default
+b.RANGEDEL.0-d.RANGEDEL.72057594037927935
+a.SET.0-c.SET.0
+----
+files have overlapping ranges
+
+ingest cmp=default
+a.RANGEDEL.0-b.RANGEDEL.72057594037927935
+b.SET.0-c.SET.0
+----
+a#0,15-b#72057594037927935,15
+b#0,1-c#0,1
+
+# Reverse comparator specific tests.
+
+ingest cmp=reverse
+b.SET.0-a.SET.0
+----
+b#0,1-a#0,1
+
+ingest cmp=reverse
+f.SET.0-e.SET.0
+d.SET.0-c.SET.0
+b.SET.0-a.SET.0
+----
+f#0,1-e#0,1
+d#0,1-c#0,1
+b#0,1-a#0,1
+
+ingest cmp=reverse
+f.SET.0-e.SET.0
+b.SET.0-a.SET.0
+d.SET.0-c.SET.0
+----
+f#0,1-e#0,1
+d#0,1-c#0,1
+b#0,1-a#0,1
+
+ingest cmp=reverse
+f.SET.0-e.SET.0
+d.SET.0-b.SET.0
+b.SET.0-a.SET.0
+----
+files have overlapping ranges
+
+ingest cmp=reverse
+b.SET.0-a.SET.0
+e.SET.0-d.SET.0
+d.SET.0-c.SET.0
+----
+files have overlapping ranges
+
+ingest cmp=reverse
+c.SET.0-b.SET.0
+b.SET.1-a.SET.1
+----
+files have overlapping ranges
+
+ingest cmp=reverse
+b.RANGEDEL.0-a.RANGEDEL.72057594037927935
+d.RANGEDEL.0-b.RANGEDEL.72057594037927935
+f.RANGEDEL.0-e.RANGEDEL.72057594037927935
+----
+f#0,15-e#72057594037927935,15
+d#0,15-b#72057594037927935,15
+b#0,15-a#72057594037927935,15
+
+ingest cmp=reverse
+b.RANGEDEL.0-a.RANGEDEL.72057594037927935
+e.RANGEDEL.0-c.RANGEDEL.72057594037927935
+f.RANGEDEL.0-e.RANGEDEL.72057594037927935
+----
+f#0,15-e#72057594037927935,15
+e#0,15-c#72057594037927935,15
+b#0,15-a#72057594037927935,15
+
+ingest cmp=reverse
+b.RANGEDEL.0-a.RANGEDEL.72057594037927935
+e.RANGEDEL.0-b.RANGEDEL.72057594037927935
+f.RANGEDEL.0-e.RANGEDEL.72057594037927935
+----
+f#0,15-e#72057594037927935,15
+e#0,15-b#72057594037927935,15
+b#0,15-a#72057594037927935,15
+
+ingest cmp=reverse
+c.RANGEDEL.0-a.RANGEDEL.72057594037927935
+d.SET.0-b.SET.0
+----
+files have overlapping ranges
+
+ingest cmp=reverse
+d.RANGEDEL.0-b.RANGEDEL.72057594037927935
+c.SET.0-a.SET.0
+----
+files have overlapping ranges
+
+ingest cmp=reverse
+b.RANGEDEL.0-a.RANGEDEL.72057594037927935
+c.SET.0-b.SET.0
+----
+files have overlapping ranges


### PR DESCRIPTION
Previously, the end key of a range deletion tombstone was considered exclusive for the purposes of deletion, but considered inclusive when checking if two SSTables overlap. For example, an SSTable with a range deletion tombstone [a, b) would be considered overlapping with an SSTable with a range deletion tombstone [b, c). This commit fixes this check.

Fixes #193.