### PR TITLE
cache: add a dbNum argument to cache methods

### DIFF
--- a/compaction_test.go
+++ b/compaction_test.go
@@ -624,7 +624,7 @@ func TestCompaction(t *testing.T) {
 					return "", "", fmt.Errorf("Open: %v", err)
 				}
 				defer f.Close()
-				r := sstable.NewReader(f, meta.fileNum, nil)
+				r := sstable.NewReader(f, 0, meta.fileNum, nil)
 				defer r.Close()
 				ss = append(ss, get1(r.NewIter(nil /* lower */, nil /* upper */))+".")
 			}

--- a/db.go
+++ b/db.go
@@ -140,6 +140,7 @@ type Writer interface {
 //		Comparer: myComparer,
 //	})
 type DB struct {
+	dbNum          uint64
 	dirname        string
 	walDirname     string
 	opts           *Options

--- a/ingest_test.go
+++ b/ingest_test.go
@@ -50,7 +50,7 @@ func TestIngestLoad(t *testing.T) {
 				Comparer: DefaultComparer,
 				FS:       mem,
 			}
-			meta, err := ingestLoad(opts, []string{"ext"}, []uint64{1})
+			meta, err := ingestLoad(opts, []string{"ext"}, 0, []uint64{1})
 			if err != nil {
 				return err.Error()
 			}
@@ -130,7 +130,7 @@ func TestIngestLoadRand(t *testing.T) {
 		Comparer: DefaultComparer,
 		FS:       mem,
 	}
-	meta, err := ingestLoad(opts, paths, pending)
+	meta, err := ingestLoad(opts, paths, 0, pending)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestIngestLoadNonExistent(t *testing.T) {
 		Comparer: DefaultComparer,
 		FS:       vfs.NewMem(),
 	}
-	if _, err := ingestLoad(opts, []string{"non-existent"}, []uint64{1}); err == nil {
+	if _, err := ingestLoad(opts, []string{"non-existent"}, 0, []uint64{1}); err == nil {
 		t.Fatalf("expected error, but found success")
 	}
 }
@@ -161,7 +161,7 @@ func TestIngestLoadEmpty(t *testing.T) {
 		Comparer: DefaultComparer,
 		FS:       mem,
 	}
-	if _, err := ingestLoad(opts, []string{"empty"}, []uint64{1}); err == nil {
+	if _, err := ingestLoad(opts, []string{"empty"}, 0, []uint64{1}); err == nil {
 		t.Fatalf("expected error, but found success")
 	}
 }

--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -213,7 +213,9 @@ type Options struct {
 	// The default value is 512KB.
 	BytesPerSync int
 
-	// TODO(peter): provide a cache interface.
+	// Cache is used to cache uncompressed blocks from sstables.
+	//
+	// The default cache size is 8 MB.
 	Cache *cache.Cache
 
 	// Comparer defines a total ordering over the space of []byte keys: a 'less
@@ -222,6 +224,14 @@ type Options struct {
 	//
 	// The default value uses the same ordering as bytes.Compare.
 	Comparer *Comparer
+
+	// Comparers is a map from comparer name to comparer. It is used for
+	// debugging tools which may be used on multiple databases configured with
+	// different comparers. It is not necessary to populate this comparers map
+	// during normal usage of a DB.
+	//
+	// TODO(peter): unimplemented.
+	Comparers map[string]*Comparer
 
 	// Disable the write-ahead log (WAL). Disabling the write-ahead log prohibits
 	// crash recovery, but can improve performance if crash recovery is not
@@ -238,6 +248,14 @@ type Options struct {
 	// EventListener provides hooks to listening to significant DB events such as
 	// flushes, compactions, and table deletion.
 	EventListener EventListener
+
+	// Filters is a map from filter policy name to filter policy. It is used for
+	// debugging tools which may be used on multiple databases configured with
+	// different filter policies. It is not necessary to populate this filters
+	// map during normal usage of a DB.
+	//
+	// TODO(peter): unimplemented.
+	Filters map[string]FilterPolicy
 
 	// FS provides the interface for persistent file storage.
 	//
@@ -296,6 +314,14 @@ type Options struct {
 	// The default merger concatenates values.
 	Merger *Merger
 
+	// Mergers is a map from merger name to merger. It is used for debugging
+	// tools which may be used on multiple databases configured with different
+	// mergers. It is not necessary to populate this mergers map during normal
+	// usage of a DB.
+	//
+	// TODO(peter): unimplemented.
+	Mergers map[string]*Merger
+
 	// MinCompactionRate sets the minimum rate at which compactions occur. The
 	// default is 4 MB/s.
 	MinCompactionRate int
@@ -332,7 +358,10 @@ func (o *Options) EnsureDefaults() *Options {
 		o = &Options{}
 	}
 	if o.BytesPerSync <= 0 {
-		o.BytesPerSync = 512 << 10
+		o.BytesPerSync = 512 << 10 // 512 KB
+	}
+	if o.Cache == nil {
+		o.Cache = cache.New(8 << 20) // 8 MB
 	}
 	if o.Comparer == nil {
 		o.Comparer = DefaultComparer

--- a/internal/base/options_test.go
+++ b/internal/base/options_test.go
@@ -41,7 +41,7 @@ func TestOptionsString(t *testing.T) {
 
 [Options]
   bytes_per_sync=524288
-  cache_size=0
+  cache_size=8388608
   comparer=leveldb.BytewiseComparator
   disable_wal=false
   l0_compaction_threshold=4

--- a/level_iter_test.go
+++ b/level_iter_test.go
@@ -187,7 +187,7 @@ func TestLevelIterBoundaries(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			readers = append(readers, sstable.NewReader(f1, 0, nil))
+			readers = append(readers, sstable.NewReader(f1, 0, 0, nil))
 			files = append(files, fileMetadata{
 				fileNum:  fileNum,
 				smallest: meta.Smallest(cmp),
@@ -258,7 +258,7 @@ func buildLevelIterTables(
 		if err != nil {
 			b.Fatal(err)
 		}
-		readers[i] = sstable.NewReader(f, uint64(i), &Options{
+		readers[i] = sstable.NewReader(f, 0, uint64(i), &Options{
 			Cache: cache,
 		})
 	}

--- a/merging_iter_test.go
+++ b/merging_iter_test.go
@@ -180,7 +180,7 @@ func buildMergingIterTables(
 		if err != nil {
 			b.Fatal(err)
 		}
-		readers[i] = sstable.NewReader(f, uint64(i), &Options{
+		readers[i] = sstable.NewReader(f, 0, uint64(i), &Options{
 			Cache: cache,
 		})
 	}

--- a/sstable/properties_test.go
+++ b/sstable/properties_test.go
@@ -78,7 +78,7 @@ func TestPropertiesLoad(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer f.Close()
-		r := NewReader(f, 0, nil)
+		r := NewReader(f, 0, 0, nil)
 
 		if diff := pretty.Diff(expected, r.Properties); diff != nil {
 			t.Fatalf("%s", strings.Join(diff, "\n"))

--- a/sstable/table_test.go
+++ b/sstable/table_test.go
@@ -114,7 +114,7 @@ func init() {
 }
 
 func check(f vfs.File, comparer *Comparer, fp FilterPolicy) error {
-	r := NewReader(f, 0, &Options{
+	r := NewReader(f, 0, 0, &Options{
 		Comparer: comparer,
 		Levels: []TableOptions{{
 			FilterPolicy: fp,
@@ -463,7 +463,7 @@ func TestBloomFilterFalsePositiveRate(t *testing.T) {
 	c := &countingFilterPolicy{
 		FilterPolicy: bloom.FilterPolicy(1),
 	}
-	r := NewReader(f, 0, &Options{
+	r := NewReader(f, 0, 0, &Options{
 		Levels: []TableOptions{{
 			FilterPolicy: c,
 		}},
@@ -592,7 +592,7 @@ func TestFinalBlockIsWritten(t *testing.T) {
 				t.Errorf("nk=%d, vLen=%d: memFS open: %v", nk, vLen, err)
 				continue
 			}
-			r := NewReader(rf, 0, nil)
+			r := NewReader(rf, 0, 0, nil)
 			i := iterAdapter{r.NewIter(nil /* lower */, nil /* upper */)}
 			for valid := i.First(); valid; valid = i.Next() {
 				got++
@@ -619,7 +619,7 @@ func TestReaderGlobalSeqNum(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r := NewReader(f, 0, nil)
+	r := NewReader(f, 0, 0, nil)
 	defer r.Close()
 
 	const globalSeqNum = 42

--- a/sstable/writer_test.go
+++ b/sstable/writer_test.go
@@ -83,7 +83,7 @@ func TestWriter(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			r = NewReader(f1, 0, nil)
+			r = NewReader(f1, 0, 0, nil)
 			return fmt.Sprintf("point:   [%s,%s]\nrange:   [%s,%s]\nseqnums: [%d,%d]\n",
 				meta.SmallestPoint, meta.LargestPoint,
 				meta.SmallestRange, meta.LargestRange,
@@ -130,7 +130,7 @@ func TestWriter(t *testing.T) {
 			if err != nil {
 				return err.Error()
 			}
-			r = NewReader(f1, 0, nil)
+			r = NewReader(f1, 0, 0, nil)
 			return fmt.Sprintf("point:   [%s,%s]\nrange:   [%s,%s]\nseqnums: [%d,%d]\n",
 				meta.SmallestPoint, meta.LargestPoint,
 				meta.SmallestRange, meta.LargestRange,

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -150,7 +150,7 @@ func newTableCache() (*tableCache, *tableCacheTestFS, error) {
 	opts := &Options{}
 	opts.EnsureDefaults()
 	c := &tableCache{}
-	c.init("", fs, opts, tableCacheTestCacheSize, tableCacheTestHitBufferSize)
+	c.init(0, "", fs, opts, tableCacheTestCacheSize, tableCacheTestHitBufferSize)
 	return c, fs, nil
 }
 
@@ -172,7 +172,7 @@ func testTableCacheRandomAccess(t *testing.T, concurrent bool) {
 			rngMu.Unlock()
 			iter, _, err := c.newIters(
 				&fileMetadata{fileNum: uint64(fileNum)},
-				nil /* iter options */,
+				nil, /* iter options */
 				nil /* bytes iterated */)
 			if err != nil {
 				errc <- fmt.Errorf("i=%d, fileNum=%d: find: %v", i, fileNum, err)
@@ -234,7 +234,7 @@ func TestTableCacheFrequentlyUsed(t *testing.T) {
 		for _, j := range [...]int{pinned0, i % tableCacheTestNumTables, pinned1} {
 			iter, _, err := c.newIters(
 				&fileMetadata{fileNum: uint64(j)},
-				nil /* iter options */,
+				nil, /* iter options */
 				nil /* bytes iterated */)
 			if err != nil {
 				t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
@@ -272,7 +272,7 @@ func TestTableCacheEvictions(t *testing.T) {
 		j := rng.Intn(tableCacheTestNumTables)
 		iter, _, err := c.newIters(
 			&fileMetadata{fileNum: uint64(j)},
-			nil /* iter options */,
+			nil, /* iter options */
 			nil /* bytes iterated */)
 		if err != nil {
 			t.Fatalf("i=%d, j=%d: find: %v", i, j, err)
@@ -315,7 +315,7 @@ func TestTableCacheIterLeak(t *testing.T) {
 	}
 	if _, _, err := c.newIters(
 		&fileMetadata{fileNum: 0},
-		nil /* iter options */,
+		nil, /* iter options */
 		nil /* bytes iterated */); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Allow a cache to be shared by multiple Pebble instances by adding a
`dbNum` argument to the cache methods which take a `fileNum`. Plumb this
through everywhere, which is the majority of changes.

Provide a global `dbNum` allocator. This "uniquifier" only needs to
provide uniqueness within a single process.

Change the default options to create an 8 MB cache rather than not
caching at all. This matches the RocksDB behavior.

Fixes #206