### PR TITLE
Add `EventListener` functions for write stalls

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -716,7 +716,7 @@ func TestDBClosed(t *testing.T) {
 
 	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Compact(nil, nil) }))
 	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Flush() }))
-	require.EqualValues(t, ErrClosed, catch(func() { _ = d.AsyncFlush() }))
+	require.EqualValues(t, ErrClosed, catch(func() { _, _ = d.AsyncFlush() }))
 
 	require.EqualValues(t, ErrClosed, catch(func() { _, _ = d.Get(nil) }))
 	require.EqualValues(t, ErrClosed, catch(func() { _ = d.Delete(nil, nil) }))
@@ -757,7 +757,7 @@ func TestDBConcurrentCommitCompactFlush(t *testing.T) {
 			case 1:
 				err = d.Flush()
 			case 2:
-				err = d.AsyncFlush()
+				_, err = d.AsyncFlush()
 			}
 			if err != nil {
 				t.Fatal(err)

--- a/event.go
+++ b/event.go
@@ -33,6 +33,9 @@ type WALCreateInfo = base.WALCreateInfo
 // WALDeleteInfo exports the base.WALDeleteInfo type.
 type WALDeleteInfo = base.WALDeleteInfo
 
+// WriteStallBeginInfo exports the base.WriteStallBeginInfo type.
+type WriteStallBeginInfo = base.WriteStallBeginInfo
+
 // EventListener exports the base.EventListener type.
 type EventListener = base.EventListener
 

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -8,13 +8,16 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 	"github.com/petermattis/pebble/sstable"
 	"github.com/petermattis/pebble/vfs"
+	"github.com/stretchr/testify/require"
 )
 
 type syncedBuffer struct {
@@ -172,4 +175,131 @@ func TestEventListener(t *testing.T) {
 			return fmt.Sprintf("unknown command: %s", td.Cmd)
 		}
 	})
+}
+
+type createDelayingFS struct {
+	vfs.FS
+	index          int32         // index of sstable whose creation will be delayed
+	createReleased chan struct{} // when closed, the delayed sstable creation can proceed
+	createDelayed  chan struct{} // if non-nil, will be closed before delaying sstable creation
+}
+
+func (fs *createDelayingFS) Create(name string) (vfs.File, error) {
+	if strings.HasSuffix(name, ".sst") && atomic.AddInt32(&fs.index, -1) == -1 {
+		if fs.createDelayed != nil {
+			close(fs.createDelayed)
+		}
+		<-fs.createReleased
+	}
+	return fs.FS.Create(name)
+}
+
+// Verify `WriteStallBegin()` and `WriteStallEnd()` events for stalls triggered
+// for reaching memtable count limit.
+func TestWriteStallForMemTableLimit(t *testing.T) {
+	const memTableLimitReason = "memtable count limit reached"
+	const memTableLimit = 2
+
+	stallBegan := make(chan struct{})
+	stallEnded := make(chan struct{})
+	mem := vfs.NewMem()
+	// `customFS` delays the sstable with index 0, which is the first flushed sstable.
+	// Delay until writes stall, which we trigger by calling `AsyncFlush()` again while
+	// the first flush is still delayed.
+	customFS := createDelayingFS{
+		FS:             mem,
+		index:          0,
+		createReleased: stallBegan,
+		createDelayed:  nil,
+	}
+	listener := EventListener{
+		WriteStallBegin: func(info WriteStallBeginInfo) {
+			require.EqualValues(t, memTableLimitReason, info.Reason)
+			close(stallBegan)
+		},
+		WriteStallEnd: func() {
+			close(stallEnded)
+		},
+	}
+	d, err := Open("db", &Options{
+		EventListener:               listener,
+		FS:                          &customFS,
+		MemTableStopWritesThreshold: memTableLimit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < memTableLimit; i++ {
+		if err := d.Set([]byte("a"), nil, NoSync); err != nil {
+			t.Fatal(err)
+		}
+		_, err := d.AsyncFlush()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	<-stallBegan
+	<-stallEnded
+}
+
+// Verify `WriteStallBegin()` and `WriteStallEnd()` events for stalls triggered
+// for reaching L0 file count limit.
+func TestWriteStallForL0FileLimit(t *testing.T) {
+	const l0FileLimitReason = "L0 file count limit exceeded"
+	const (
+		l0FileCompactionTrigger = 2
+		l0FileStopTrigger       = 4
+	)
+
+	stallBegan := make(chan struct{})
+	stallEnded := make(chan struct{})
+	createDelayed := make(chan struct{})
+	mem := vfs.NewMem()
+	// The indexes of the first few sstables are as follows:
+	//
+	// * index 0: first flushed sstable
+	// * index 1: second flushed sstable
+	// * index 2: first sstable created by L0->Lbase compaction
+	//
+	// `customFS` delays the sstable with index 2, i.e., an Lbase file created during
+	// compaction. Delay until writes stall, which we trigger by calling `Flush()`
+	// repeatedly while the L0->Lbase compaction is still delayed.
+	customFS := createDelayingFS{mem, l0FileCompactionTrigger /* index */, stallBegan, /* createReleased */
+		createDelayed}
+	listener := EventListener{
+		WriteStallBegin: func(info WriteStallBeginInfo) {
+			require.EqualValues(t, l0FileLimitReason, info.Reason)
+			close(stallBegan)
+		},
+		WriteStallEnd: func() {
+			close(stallEnded)
+		},
+	}
+	d, err := Open("db", &Options{
+		EventListener:         listener,
+		FS:                    &customFS,
+		L0CompactionThreshold: l0FileCompactionTrigger,
+		L0StopWritesThreshold: l0FileStopTrigger,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO(ajkr): Are the two files pending L0->Lbase not counted towards the
+	// limit? Shouldn't they be?
+	for i := 0; i < l0FileStopTrigger+l0FileCompactionTrigger; i++ {
+		if err := d.Set([]byte("a"), nil, NoSync); err != nil {
+			t.Fatal(err)
+		}
+		d.Flush()
+		if i == l0FileCompactionTrigger-1 {
+			// make sure compaction gets started on the Lbase file before
+			// we proceed to flushing the next sstable (we wouldn't want the
+			// delay to be applied on an L0 file accidentally).
+			<-createDelayed
+		}
+	}
+	<-stallBegan
+	<-stallEnded
 }

--- a/flush_test.go
+++ b/flush_test.go
@@ -46,7 +46,7 @@ func TestManualFlush(t *testing.T) {
 			cur := d.mu.versions.currentVersion()
 			d.mu.Unlock()
 
-			if err := d.AsyncFlush(); err != nil {
+			if _, err := d.AsyncFlush(); err != nil {
 				return err.Error()
 			}
 

--- a/internal/base/event.go
+++ b/internal/base/event.go
@@ -230,6 +230,14 @@ func (i WALDeleteInfo) String() string {
 	return fmt.Sprintf("[JOB %d] WAL deleted %06d", i.JobID, i.FileNum)
 }
 
+type WriteStallBeginInfo struct {
+	Reason string
+}
+
+func (i WriteStallBeginInfo) String() string {
+	return fmt.Sprintf("write stall beginning: %s", i.Reason)
+}
+
 // EventListener contains a set of functions that will be invoked when various
 // significant DB events occur. Note that the functions should not run for an
 // excessive amount of time as they are invokved synchronously by the DB and
@@ -274,6 +282,12 @@ type EventListener struct {
 
 	// WALDeleted is invoked after a WAL has been deleted.
 	WALDeleted func(WALDeleteInfo)
+
+	// WriteStallBegin is invoked when writes are intentionally delayed.
+	WriteStallBegin func(WriteStallBeginInfo)
+
+	// WriteStallEnd is invoked when delayed writes are released.
+	WriteStallEnd func()
 }
 
 // EnsureDefaults ensures that background error events are logged to the
@@ -327,6 +341,12 @@ func MakeLoggingEventListener(logger Logger) EventListener {
 		},
 		WALDeleted: func(info WALDeleteInfo) {
 			logger.Infof("%s", info.String())
+		},
+		WriteStallBegin: func(info WriteStallBeginInfo) {
+			logger.Infof("%s", info.String())
+		},
+		WriteStallEnd: func() {
+			logger.Infof("write stall ending")
 		},
 	}
 }


### PR DESCRIPTION
Call `WriteStallBegin()` when entering write stall mode and
`WriteStallEnd()` when leaving write stall mode.