### PR TITLE
sstable: fix curOffset calculation at end of compressed block

### DIFF
--- a/sstable/reader.go
+++ b/sstable/reader.go
@@ -556,7 +556,7 @@ func (i *compactionIterator) Next() (*InternalKey, []byte) {
 	// Last entry in the block must increment bytes iterated by the size of the block trailer
 	// and restart points.
 	if i.data.nextOffset+(4*(i.data.numRestarts+1)) == int32(len(i.data.data)) {
-		curOffset += blockTrailerLen + uint64(4*(i.data.numRestarts+1))
+		curOffset = i.dataBH.offset + i.dataBH.length + blockTrailerLen
 	}
 	*i.bytesIterated += uint64(curOffset - i.prevOffset)
 	i.prevOffset = curOffset

--- a/sstable/reader_test.go
+++ b/sstable/reader_test.go
@@ -263,9 +263,13 @@ func TestBytesIteratedCompressed(t *testing.T) {
 	for _, blockSize := range []int{10, 100, 1000, 4096} {
 		for _, numEntries := range []uint64{0, 1, 1e5} {
 			r := buildTestTable(t, numEntries, blockSize, SnappyCompression)
-			var bytesIterated uint64
+			var bytesIterated, prevIterated uint64
 			citer := r.NewCompactionIter(&bytesIterated)
 			for citer.First(); citer.Valid(); citer.Next() {
+				if bytesIterated < prevIterated {
+					t.Fatalf("bytesIterated moved backward: %d < %d", bytesIterated, prevIterated)
+				}
+				prevIterated = bytesIterated
 			}
 
 			expected := r.Properties.DataSize
@@ -281,9 +285,13 @@ func TestBytesIteratedUncompressed(t *testing.T) {
 	for _, blockSize := range []int{10, 100, 1000, 4096} {
 		for _, numEntries := range []uint64{0, 1, 1e5} {
 			r := buildTestTable(t, numEntries, blockSize, NoCompression)
-			var bytesIterated uint64
+			var bytesIterated, prevIterated uint64
 			citer := r.NewCompactionIter(&bytesIterated)
 			for citer.First(); citer.Valid(); citer.Next() {
+				if bytesIterated < prevIterated {
+					t.Fatalf("bytesIterated moved backward: %d < %d", bytesIterated, prevIterated)
+				}
+				prevIterated = bytesIterated
 			}
 
 			expected := r.Properties.DataSize


### PR DESCRIPTION
The previous calculation of `curOffset` at the end of a compressed
block caused the value to be larger than the end offset of the block on
disk. This is problematic because the next block would then set
`curOffset` to a smaller value. This in turn would lead to
`bytesIterated` being incremented by a very large value (a negative
value stuffed in a `uint64`) which would in turn cause the compaction
pacer to enter a loop which would take ~forever to terminate.