### PR TITLE
cmd/pebble: Fix MVCC encoding for keys

### DIFF
--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -385,7 +385,7 @@ func (y *ycsb) makeKey(keyNum uint64) []byte {
 	// Use the MVCC encoding for keys. This appends a timestamp with
 	// walltime=1. That knowledge is utilized by rocksDB.Scan.
 	key = append(key, '\x00', '\x00', '\x00', '\x00', '\x00',
-		'\x00', '\x00', '\x00', '\x01', '\x08')
+		'\x00', '\x00', '\x00', '\x01', '\x09')
 	return key
 }
 


### PR DESCRIPTION
The ycsb benchmarks implemented in pebble currently encode MVCC
keys incorrectly. As a result, rocksdb is unable to read and parse
these keys (assuming the db was generated without `--rocksdb`):

```
ubuntu@ip-10-12-37-11:~$ ./pebble ycsb /mnt/data1/bench_16G --workload scan=100 --concurrency 16 --prepopulated-keys $[16*1024*1024*1024/64] --initial-keys 0 --keys uniform --duration 2m --cache $[1*1024*1024*1024] --scans 1000 --rocksdb
dir /mnt/data1/bench_16G
concurrency 16
I190808 17:37:01.891432 1 storage/engine/rocksdb.go:602  opening rocksdb instance at "/mnt/data1/bench_16G"
I190808 17:37:01.971822 74 ???:1  bad log format: failed to split mvcc key
```

Bump the number of "timestamp bytes" at the end by 1 to account for
the zero byte (on top of the usual uint64 wall time).

Thanks to @ajkr for finding this.