### PR TITLE
vfs, table_cache: fadvise FADV_RANDOM on sstable files

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -60,7 +60,7 @@ func (fs *errorFS) Link(oldname, newname string) error {
 	return fs.fs.Link(oldname, newname)
 }
 
-func (fs *errorFS) Open(name string) (vfs.File, error) {
+func (fs *errorFS) Open(name string, opts ...vfs.OpenOption) (vfs.File, error) {
 	if err := fs.maybeError(); err != nil {
 		return nil, err
 	}
@@ -68,7 +68,11 @@ func (fs *errorFS) Open(name string) (vfs.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return errorFile{f, fs}, nil
+	ef := errorFile{f, fs}
+	for _, opt := range opts {
+		opt.Apply(ef)
+	}
+	return ef, nil
 }
 
 func (fs *errorFS) OpenDir(name string) (vfs.File, error) {

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/exp v0.0.0-20190426190305-956cc1757749
+	golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,5 +28,7 @@ golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa h1:KIDDMLT1O0Nr7TSxp8xM5tJcdn8tgyAONntO829og1M=
+golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/table_cache.go
+++ b/table_cache.go
@@ -327,7 +327,7 @@ type tableCacheNode struct {
 
 func (n *tableCacheNode) load(c *tableCacheShard) {
 	// Try opening the fileTypeTable first.
-	f, err := c.fs.Open(dbFilename(c.dirname, fileTypeTable, n.meta.fileNum))
+	f, err := c.fs.Open(dbFilename(c.dirname, fileTypeTable, n.meta.fileNum), vfs.RandomReadsOption)
 	if err != nil {
 		n.err = err
 		close(n.loaded)

--- a/table_cache_test.go
+++ b/table_cache_test.go
@@ -41,13 +41,16 @@ type tableCacheTestFS struct {
 	closeCounts map[string]int
 }
 
-func (fs *tableCacheTestFS) Open(name string) (vfs.File, error) {
+func (fs *tableCacheTestFS) Open(name string, opts ...vfs.OpenOption) (vfs.File, error) {
 	fs.mu.Lock()
 	if fs.openCounts != nil {
 		fs.openCounts[name]++
 	}
 	fs.mu.Unlock()
-	f, err := fs.FS.Open(name)
+	f, err := fs.FS.Open(name, opts...)
+	if len(opts) < 1 || opts[0] != vfs.RandomReadsOption {
+		return nil, fmt.Errorf("sstable file %s not opened with random reads option", name)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,3 +21,5 @@ github.com/stretchr/testify/require
 github.com/stretchr/testify/assert
 # golang.org/x/exp v0.0.0-20190426190305-956cc1757749
 golang.org/x/exp/rand
+# golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa
+golang.org/x/sys

--- a/vfs/fadvise_generic.go
+++ b/vfs/fadvise_generic.go
@@ -1,0 +1,11 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build !linux
+
+package vfs
+
+func fadviseRandom(f uintptr) error {
+	return nil
+}

--- a/vfs/fadvise_linux.go
+++ b/vfs/fadvise_linux.go
@@ -1,0 +1,14 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+// +build linux
+
+package vfs
+
+import "golang.org/x/sys/unix"
+
+// Calls Fadvise with FADV_RANDOM to disable readahead on a file descriptor.
+func fadviseRandom(f uintptr) error {
+	return unix.Fadvise(int(f), 0, 0, unix.FADV_RANDOM)
+}

--- a/vfs/mem_fs.go
+++ b/vfs/mem_fs.go
@@ -40,6 +40,8 @@ type memFS struct {
 	root *memNode
 }
 
+var _ FS = &memFS{}
+
 func (y *memFS) String() string {
 	y.mu.Lock()
 	defer y.mu.Unlock()
@@ -190,7 +192,7 @@ func (y *memFS) open(fullname string, allowEmptyName bool) (File, error) {
 	return ret, nil
 }
 
-func (y *memFS) Open(fullname string) (File, error) {
+func (y *memFS) Open(fullname string, opts ...OpenOption) (File, error) {
 	return y.open(fullname, false /* allowEmptyName */)
 }
 


### PR DESCRIPTION
This change calls fadvise with FADV_RANDOM on sstable file descriptors,
to ensure that readahead is disabled. This reduces wasted I/Os when
reading from sstables, since sstable reads especially for short to
medium range scans do not read large enough contiguous blocks to be
able to take advantage of readahead. Instead, readahead ends up reducing
user-visible I/O performance.

See #198 .