### PR TITLE
Assign distinct seqnums to ingested sstables

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -117,13 +117,13 @@ func TestCommitPipelineAllocateSeqNum(t *testing.T) {
 	wg.Add(n)
 	var prepareCount uint64
 	var applyCount uint64
-	for i := 0; i < n; i++ {
+	for i := 1; i <= n; i++ {
 		go func(i int) {
 			defer wg.Done()
-			p.AllocateSeqNum(func() {
-				atomic.AddUint64(&prepareCount, 1)
+			p.AllocateSeqNum(i, func() {
+				atomic.AddUint64(&prepareCount, uint64(1))
 			}, func(seqNum uint64) {
-				atomic.AddUint64(&applyCount, 1)
+				atomic.AddUint64(&applyCount, uint64(1))
 			})
 		}(i)
 	}
@@ -137,11 +137,12 @@ func TestCommitPipelineAllocateSeqNum(t *testing.T) {
 	}
 	// AllocateSeqNum always returns a non-zero sequence number causing the
 	// values we see to be offset from 1.
-	if s := atomic.LoadUint64(&e.logSeqNum); n+1 != s {
-		t.Fatalf("expected %d, but found %d", n+1, s)
+	const total = 1 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10
+	if s := atomic.LoadUint64(&e.logSeqNum); total != s {
+		t.Fatalf("expected %d, but found %d", total, s)
 	}
-	if s := atomic.LoadUint64(&e.visibleSeqNum); n+1 != s {
-		t.Fatalf("expected %d, but found %d", n+1, s)
+	if s := atomic.LoadUint64(&e.visibleSeqNum); total != s {
+		t.Fatalf("expected %d, but found %d", total, s)
 	}
 }
 

--- a/get_iter_test.go
+++ b/get_iter_test.go
@@ -372,45 +372,73 @@ func TestGetIter(t *testing.T) {
 		},
 
 		{
-			description: "broken invariants 0: non-increasing level 0 file numbers",
+			description: "broken invariants 0: non-increasing level 0 sequence numbers",
 			badOrdering: true,
 			tables: []testTable{
-				{
-					level:   0,
-					fileNum: 20,
-				},
 				{
 					level:   0,
 					fileNum: 19,
+					data: []string{
+						"a.SET.101 a",
+						"b.SET.102 b",
+					},
+				},
+				{
+					level:   0,
+					fileNum: 20,
+					data: []string{
+						"c.SET.101 c",
+					},
 				},
 			},
 		},
 
 		{
-			description: "broken invariants 1: non-increasing level 0 file numbers",
+			description: "broken invariants 1: non-increasing level 0 sequence numbers",
 			badOrdering: true,
 			tables: []testTable{
 				{
 					level:   0,
+					fileNum: 19,
+					data: []string{
+						"a.SET.101 a",
+						"b.SET.102 b",
+					},
+				},
+				{
+					level:   0,
 					fileNum: 20,
-				},
-				{
-					level:   0,
-					fileNum: 21,
-				},
-				{
-					level:   0,
-					fileNum: 21,
-				},
-				{
-					level:   0,
-					fileNum: 22,
+					data: []string{
+						"c.SET.100 c",
+						"d.SET.101 d",
+					},
 				},
 			},
 		},
 
 		{
-			description: "broken invariants 2: level non-0 overlapping internal key ranges",
+			description: "broken invariants 2: non-increasing level 0 sequence numbers",
+			badOrdering: true,
+			tables: []testTable{
+				{
+					level:   0,
+					fileNum: 19,
+					data: []string{
+						"a.SET.101 a",
+					},
+				},
+				{
+					level:   0,
+					fileNum: 20,
+					data: []string{
+						"a.SET.101 a",
+					},
+				},
+			},
+		},
+
+		{
+			description: "broken invariants 3: level non-0 overlapping internal key ranges",
 			badOrdering: true,
 			tables: []testTable{
 				{

--- a/ingest.go
+++ b/ingest.go
@@ -199,6 +199,7 @@ func ingestUpdateSeqNum(opts *Options, dirname string, seqNum uint64, meta []*fi
 		// Properties.GlobalSeqNum when an sstable is loaded.
 		m.smallestSeqNum = seqNum
 		m.largestSeqNum = seqNum
+		seqNum++
 
 		// TODO(peter): Update the global sequence number property. This is only
 		// necessary for compatibility with RocksDB.
@@ -357,7 +358,7 @@ func (d *DB) Ingest(paths []string) error {
 		ve, err = d.ingestApply(jobID, meta)
 	}
 
-	d.commit.AllocateSeqNum(prepare, apply)
+	d.commit.AllocateSeqNum(len(meta), prepare, apply)
 
 	if err != nil {
 		if err2 := ingestCleanup(d.opts.FS, d.dirname, meta); err2 != nil {

--- a/testdata/ingest
+++ b/testdata/ingest
@@ -1,6 +1,9 @@
-ingest
+build ext0
 set a 1
 set b 2
+----
+
+ingest ext0
 ----
 
 lsm
@@ -23,9 +26,12 @@ b
 a:1
 b:2
 
-ingest
+build ext1
 set a 3
 del b
+----
+
+ingest ext1
 ----
 
 lsm
@@ -47,10 +53,13 @@ b
 a:3
 b: pebble: not found
 
-ingest
+build ext2
 set a 4
 set b 5
 set c 6
+----
+
+ingest ext2
 ----
 
 lsm
@@ -77,9 +86,12 @@ a:4
 b:5
 c:6
 
-ingest
+build ext3
 merge b 5
 del c
+----
+
+ingest ext3
 ----
 
 lsm
@@ -107,9 +119,12 @@ a:4
 b:55
 c: pebble: not found
 
-ingest
+build ext4
 set x 7
 set y 8
+----
+
+ingest ext4
 ----
 
 lsm
@@ -140,8 +155,11 @@ set j 9
 set k 10
 ----
 
-ingest
+build ext5
 set k 11
+----
+
+ingest ext5
 ----
 
 lsm
@@ -170,8 +188,11 @@ batch
 set m 12
 ----
 
-ingest
+build ext6
 set n 13
+----
+
+ingest ext6
 ----
 
 lsm
@@ -189,9 +210,12 @@ n
 m:12
 n:13
 
-ingest
+build ext7
 del-range a c
 del-range x z
+----
+
+ingest ext7
 ----
 
 lsm
@@ -226,10 +250,13 @@ y: pebble: not found
 # A set operation takes precedence over a range deletion at the same
 # sequence number as can occur during ingestion.
 
-ingest
+build ext8
 set j 20
 del-range j k
 set m 30
+----
+
+ingest ext8
 ----
 
 get
@@ -240,3 +267,35 @@ m
 j:20
 k:11
 m:30
+
+build ext9
+del-range a x
+----
+
+build ext10
+set y 40
+----
+
+# Ingesting two files into L0 is allowed.
+
+ingest ext9 ext10
+----
+
+get
+j
+k
+m
+y
+----
+j: pebble: not found
+k: pebble: not found
+m: pebble: not found
+y:40
+
+lsm
+----
+0: j-k k-k m-m a-z j-m a-x y-y
+3: b-c
+4: a-c
+5: a-b
+6: a-b n-n x-y


### PR DESCRIPTION
When two or more files are ingested atomically, assign distinct global
sequence numbers to each sstable. This avoids an error that would
previously occur when two L0 sstables shared the same global sequence
number which violated the invariant about the ordering of L0
sstables. Rather than relaxing the error, assigning distinct sequence
numbers avoids it and opens up the possibility of ingesting overlapping
sstables in the future.