### PR TITLE
Add TableCreated event

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -304,7 +304,7 @@ func runDBDefineCmd(td *datadriven.TestData, opts *Options) (*DB, error) {
 		c := newFlush(d.opts, d.mu.versions.currentVersion(),
 			d.mu.versions.picker.baseLevel, []flushable{mem}, &d.bytesFlushed)
 		c.disableRangeTombstoneElision = true
-		newVE, _, err := d.runCompaction(c, nilPacer)
+		newVE, _, err := d.runCompaction(0, c, nilPacer)
 		if err != nil {
 			return nil
 		}

--- a/event.go
+++ b/event.go
@@ -21,6 +21,9 @@ type ManifestCreateInfo = base.ManifestCreateInfo
 // ManifestDeleteInfo exports the base.ManifestDeleteInfo type.
 type ManifestDeleteInfo = base.ManifestDeleteInfo
 
+// TableCreateInfo exports the base.TableCreateInfo type.
+type TableCreateInfo = base.TableCreateInfo
+
 // TableDeleteInfo exports the base.TableDeleteInfo type.
 type TableDeleteInfo = base.TableDeleteInfo
 

--- a/internal/base/event.go
+++ b/internal/base/event.go
@@ -143,6 +143,19 @@ func (i ManifestDeleteInfo) String() string {
 	return fmt.Sprintf("[JOB %d] MANIFEST deleted %06d", i.JobID, i.FileNum)
 }
 
+// TableCreateInfo contains the info for a table creation event.
+type TableCreateInfo struct {
+	JobID int
+	// Reason is the reason for the table creation (flushing or compacting).
+	Reason  string
+	Path    string
+	FileNum uint64
+}
+
+func (i TableCreateInfo) String() string {
+	return fmt.Sprintf("[JOB %d] %s: sstable created %06d", i.JobID, i.Reason, i.FileNum)
+}
+
 // TableDeleteInfo contains the info for a table deletion event.
 type TableDeleteInfo struct {
 	JobID   int
@@ -230,6 +243,7 @@ func (i WALDeleteInfo) String() string {
 	return fmt.Sprintf("[JOB %d] WAL deleted %06d", i.JobID, i.FileNum)
 }
 
+// WriteStallBeginInfo contains the info for a write stall begin event.
 type WriteStallBeginInfo struct {
 	Reason string
 }
@@ -269,6 +283,9 @@ type EventListener struct {
 
 	// ManifestDeleted is invoked after a manifest has been deleted.
 	ManifestDeleted func(ManifestDeleteInfo)
+
+	// TableCreated is invoked when a table has been created.
+	TableCreated func(TableCreateInfo)
 
 	// TableDeleted is invoked after a table has been deleted.
 	TableDeleted func(TableDeleteInfo)
@@ -328,6 +345,9 @@ func MakeLoggingEventListener(logger Logger) EventListener {
 			logger.Infof("%s", info.String())
 		},
 		ManifestDeleted: func(info ManifestDeleteInfo) {
+			logger.Infof("%s", info.String())
+		},
+		TableCreated: func(info TableCreateInfo) {
 			logger.Infof("%s", info.String())
 		},
 		TableDeleted: func(info TableDeleteInfo) {

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -29,6 +29,7 @@ sync: wal/000002.log
 [JOB 2] WAL created 000005
 [JOB 3] flushing to L0
 create: db/000006.sst
+[JOB 3] flushing: sstable created 000006
 sync: db/000006.sst
 sync: db
 [JOB 3] flushed to L0: 1 (825 B)
@@ -51,6 +52,7 @@ sync: wal/000005.log
 [JOB 4] WAL created 000008 (recycled 000002)
 [JOB 5] flushing to L0
 create: db/000009.sst
+[JOB 5] flushing: sstable created 000009
 sync: db/000009.sst
 sync: db
 [JOB 5] flushed to L0: 1 (825 B)
@@ -64,6 +66,7 @@ sync: db
 [JOB 5] MANIFEST deleted 000007
 [JOB 6] compacting L0 -> L6: 2+0 (1.6 K + 0 B)
 create: db/000011.sst
+[JOB 6] compacting: sstable created 000011
 sync: db/000011.sst
 sync: db
 [JOB 6] compacted L0 -> L6: 2+0 (1.6 K + 0 B) -> 1 (825 B)


### PR DESCRIPTION
Add an event for table creation. This event fires immediately after the
sstable file is created which means the file will be empty (nothing has
been written to it yet).

Refactor the write stall event tests to use the TableCreated event for
detecting when a table is created for flush vs compaction.