### PR TITLE
Restructure the tool commands

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -46,7 +46,7 @@ func main() {
 		Short: "pebble benchmarking/introspection tool",
 	}
 	rootCmd.AddCommand(benchCmd)
-	rootCmd.AddCommand(tool.AllCmds...)
+	rootCmd.AddCommand(tool.New().Commands...)
 
 	for _, cmd := range []*cobra.Command{scanCmd, syncCmd, ycsbCmd} {
 		cmd.Flags().Int64Var(

--- a/tool/db.go
+++ b/tool/db.go
@@ -7,78 +7,72 @@ package tool
 import (
 	"fmt"
 
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/spf13/cobra"
 )
 
-// AllCmds is a list of all of the tool commands.
-var AllCmds = []*cobra.Command{
-	DBCmd,
-	ManifestCmd,
-	SSTableCmd,
-	WALCmd,
+// dbT implements db-level tools, including both configuration state and the
+// commands themselves.
+type dbT struct {
+	Root  *cobra.Command
+	Check *cobra.Command
+	LSM   *cobra.Command
+	Scan  *cobra.Command
 }
 
-// DBCmd is the root of the DB commands.
-var DBCmd = &cobra.Command{
-	Use:   "db",
-	Short: "DB introspection tools",
-}
+func newDB(opts *base.Options) *dbT {
+	d := &dbT{}
 
-// DBCheckCmd implements db check.
-var DBCheckCmd = &cobra.Command{
-	Use:   "check <dir>",
-	Short: "verify checksums and metadata",
-	Long: `
+	d.Root = &cobra.Command{
+		Use:   "db",
+		Short: "DB introspection tools",
+	}
+	d.Check = &cobra.Command{
+		Use:   "check <dir>",
+		Short: "verify checksums and metadata",
+		Long: `
 Verify sstable, manifest, and WAL checksums. Requires that the specified
 database not be in use by another process.
 `,
-	Args: cobra.ExactArgs(1),
-	Run:  runDBCheck,
-}
-
-// DBLSMCmd implements db lsm.
-var DBLSMCmd = &cobra.Command{
-	Use:   "lsm <dir>",
-	Short: "print LSM structure",
-	Long: `
+		Args: cobra.ExactArgs(1),
+		Run:  d.runCheck,
+	}
+	d.LSM = &cobra.Command{
+		Use:   "lsm <dir>",
+		Short: "print LSM structure",
+		Long: `
 Print the structure of the LSM tree. Requires that the specified database not
 be in use by another process.
 `,
-	Args: cobra.ExactArgs(1),
-	Run:  runDBLSM,
-}
-
-// DBScanCmd implements db scan.
-var DBScanCmd = &cobra.Command{
-	Use:   "scan <dir>",
-	Short: "print db records",
-	Long: `
+		Args: cobra.ExactArgs(1),
+		Run:  d.runLSM,
+	}
+	d.Scan = &cobra.Command{
+		Use:   "scan <dir>",
+		Short: "print db records",
+		Long: `
 Print the records in the DB. Requires that the specified database not be in use
 by another process.
 `,
-	Args: cobra.ExactArgs(1),
-	Run:  runDBScan,
+		Args: cobra.ExactArgs(1),
+		Run:  d.runScan,
+	}
+
+	d.Root.AddCommand(d.Check, d.LSM, d.Scan)
+	return d
 }
 
-func init() {
-	DBCmd.AddCommand(
-		DBCheckCmd,
-		DBLSMCmd,
-		DBScanCmd,
-	)
-}
-
-func runDBCheck(cmd *cobra.Command, args []string) {
+func (d *dbT) runCheck(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(stderr, "TODO(peter): \"db check\" unimplemented\n")
 	osExit(1)
 }
 
-func runDBLSM(cmd *cobra.Command, args []string) {
+func (d *dbT) runLSM(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(stderr, "TODO(peter): \"db lsm\" unimplemented\n")
 	osExit(1)
 }
 
-func runDBScan(cmd *cobra.Command, args []string) {
+func (d *dbT) runScan(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(stderr, "TODO(peter): \"db scan\" unimplemented\n")
 	osExit(1)
 }

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -7,31 +7,39 @@ package tool
 import (
 	"fmt"
 
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/spf13/cobra"
 )
 
-// ManifestCmd is the root of the manifest commands.
-var ManifestCmd = &cobra.Command{
-	Use:   "manifest",
-	Short: "manifest introspection tools",
+// manifestT implements manifest-level tools, including both configuration
+// state and the commands themselves.
+type manifestT struct {
+	Root *cobra.Command
+	Dump *cobra.Command
 }
 
-// ManifestDumpCmd implements manifest dump.
-var ManifestDumpCmd = &cobra.Command{
-	Use:   "dump <manifest-files>",
-	Short: "print manifest contents",
-	Long: `
+func newManifest(opts *base.Options) *manifestT {
+	m := &manifestT{}
+
+	m.Root = &cobra.Command{
+		Use:   "manifest",
+		Short: "manifest introspection tools",
+	}
+	m.Dump = &cobra.Command{
+		Use:   "dump <manifest-files>",
+		Short: "print manifest contents",
+		Long: `
 Print the contents of the MANIFEST files.
 `,
-	Args: cobra.MinimumNArgs(1),
-	Run:  runManifestDump,
+		Args: cobra.MinimumNArgs(1),
+		Run:  m.runDump,
+	}
+
+	m.Root.AddCommand(m.Dump)
+	return m
 }
 
-func init() {
-	ManifestCmd.AddCommand(ManifestDumpCmd)
-}
-
-func runManifestDump(cmd *cobra.Command, args []string) {
+func (m *manifestT) runDump(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(stderr, "TODO(peter): \"manifest dump\" unimplemented\n")
 	osExit(1)
 }

--- a/tool/sstable_test.go
+++ b/tool/sstable_test.go
@@ -1,0 +1,13 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package tool
+
+import (
+	"testing"
+)
+
+func TestSSTable(t *testing.T) {
+	runTests(t, "testdata/sstable_*")
+}

--- a/tool/testdata/sstable_scan
+++ b/tool/testdata/sstable_scan
@@ -37,3 +37,40 @@ young#0,1 [36]
 your#0,1 [34 39]
 yourself#0,1 [37]
 youth#0,1 [35]
+
+sstable scan
+--key=%x
+--value=null
+--start=you
+../sstable/testdata/h.sst
+----
+../sstable/testdata/h.sst
+796f75#0,1
+796f756e67#0,1
+796f7572#0,1
+796f757273656c66#0,1
+796f757468#0,1
+
+sstable scan
+--key=%q
+--value=null
+--start=hex:796f75
+--end=raw:yourself
+../sstable/testdata/h.sst
+----
+../sstable/testdata/h.sst
+"you"#0,1
+"young"#0,1
+"your"#0,1
+
+sstable scan
+--key=null
+--value=[%x]
+--start=hex:796f75
+--end=raw:yourself
+../sstable/testdata/h.sst
+----
+../sstable/testdata/h.sst
+[313130]
+[36]
+[3439]

--- a/tool/tool.go
+++ b/tool/tool.go
@@ -1,0 +1,68 @@
+// Copyright 2019 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package tool
+
+import (
+	"github.com/petermattis/pebble/bloom"
+	"github.com/petermattis/pebble/internal/base"
+	"github.com/spf13/cobra"
+)
+
+// Comparer exports the base.Comparer type.
+type Comparer = base.Comparer
+
+// FilterPolicy exports the base.FilterPolicy type.
+type FilterPolicy = base.FilterPolicy
+
+// Merger exports the base.Merger type.
+type Merger = base.Merger
+
+// T is the container for all of the introspection tools.
+type T struct {
+	Commands []*cobra.Command
+	db       *dbT
+	manifest *manifestT
+	sstable  *sstableT
+	wal      *walT
+	opts     base.Options
+}
+
+// New creates a new introspection tool.
+func New() *T {
+	t := &T{}
+	t.opts.Comparers = make(map[string]*Comparer)
+	t.opts.Filters = make(map[string]FilterPolicy)
+	t.opts.Mergers = make(map[string]*Merger)
+	t.RegisterComparer(base.DefaultComparer)
+	t.RegisterFilter(bloom.FilterPolicy(10))
+	t.RegisterMerger(base.DefaultMerger)
+
+	t.db = newDB(&t.opts)
+	t.manifest = newManifest(&t.opts)
+	t.sstable = newSSTable(&t.opts)
+	t.wal = newWAL(&t.opts)
+	t.Commands = []*cobra.Command{
+		t.db.Root,
+		t.manifest.Root,
+		t.sstable.Root,
+		t.wal.Root,
+	}
+	return t
+}
+
+// RegisterComparer registers a comparer for use by the introspection tools.
+func (t *T) RegisterComparer(c *Comparer) {
+	t.opts.Comparers[c.Name] = c
+}
+
+// RegisterFilter registers a filter policy for use by the introspection tools.
+func (t *T) RegisterFilter(f FilterPolicy) {
+	t.opts.Filters[f.Name()] = f
+}
+
+// RegisterMerger registers a merger for use by the introspection tools.
+func (t *T) RegisterMerger(m *Merger) {
+	t.opts.Mergers[m.Name] = m
+}

--- a/tool/util.go
+++ b/tool/util.go
@@ -5,16 +5,115 @@
 package tool
 
 import (
+	"encoding/hex"
+	"fmt"
 	"io"
 	"os"
+	"strconv"
+	"strings"
+
+	"github.com/petermattis/pebble/internal/base"
 )
 
 var stdout = io.Writer(os.Stdout)
 var stderr = io.Writer(os.Stderr)
 var osExit = os.Exit
-var dbNum uint64
 
-func nextDBNum() uint64 {
-	dbNum++
-	return dbNum
+type key []byte
+
+func (k *key) String() string {
+	return string(*k)
+}
+
+func (k *key) Type() string {
+	return "key"
+}
+
+func (k *key) Set(v string) error {
+	switch {
+	case strings.HasPrefix(v, "hex:"):
+		v = strings.TrimPrefix(v, "hex:")
+		b, err := hex.DecodeString(v)
+		if err != nil {
+			return err
+		}
+		*k = key(b)
+
+	case strings.HasPrefix(v, "raw:"):
+		*k = key(strings.TrimPrefix(v, "raw:"))
+
+	default:
+		*k = key(v)
+	}
+	return nil
+}
+
+type formatter struct {
+	spec string
+	fn   func(w io.Writer, v []byte)
+}
+
+func (f *formatter) String() string {
+	return f.spec
+}
+
+func (f *formatter) Type() string {
+	return "formatter"
+}
+
+func (f *formatter) Set(spec string) error {
+	f.spec = spec
+	switch spec {
+	case "hex":
+		f.fn = formatHex
+	case "null":
+		f.fn = formatNull
+	case "quoted":
+		f.fn = formatQuoted
+	default:
+		if strings.Count(spec, "%") != 1 {
+			return fmt.Errorf("unknown formatter: %q", spec)
+		}
+		f.fn = func(w io.Writer, v []byte) {
+			fmt.Fprintf(w, f.spec, v)
+		}
+	}
+	return nil
+}
+
+func (f *formatter) mustSet(spec string) {
+	if err := f.Set(spec); err != nil {
+		panic(err)
+	}
+}
+
+func formatHex(w io.Writer, v []byte) {
+	fmt.Fprintf(w, "[% x]", v)
+}
+
+func formatNull(w io.Writer, v []byte) {
+}
+
+func formatQuoted(w io.Writer, v []byte) {
+	q := strconv.AppendQuote(make([]byte, 0, len(v)), string(v))
+	q = q[1 : len(q)-1]
+	w.Write(q)
+}
+
+func formatKeyValue(
+	w io.Writer, fmtKey formatter, fmtValue formatter, key *base.InternalKey, value []byte,
+) {
+	needDelimiter := false
+	if fmtKey.spec != "null" {
+		fmtKey.fn(w, key.UserKey)
+		fmt.Fprintf(w, "#%d,%d", key.SeqNum(), key.Kind())
+		needDelimiter = true
+	}
+	if fmtValue.spec != "null" {
+		if needDelimiter {
+			w.Write([]byte{' '})
+		}
+		fmtValue.fn(stdout, value)
+	}
+	w.Write([]byte{'\n'})
 }

--- a/tool/wal.go
+++ b/tool/wal.go
@@ -7,31 +7,39 @@ package tool
 import (
 	"fmt"
 
+	"github.com/petermattis/pebble/internal/base"
 	"github.com/spf13/cobra"
 )
 
-// WALCmd is the root of the WAL commands.
-var WALCmd = &cobra.Command{
-	Use:   "wal",
-	Short: "WAL introspection tools",
+// walT implements WAL-level tools, including both configuration state and the
+// commands themselves.
+type walT struct {
+	Root *cobra.Command
+	Dump *cobra.Command
 }
 
-// WALDumpCmd implements WAL dump.
-var WALDumpCmd = &cobra.Command{
-	Use:   "dump <wal-files>",
-	Short: "print WAL contents",
-	Long: `
+func newWAL(opts *base.Options) *walT {
+	w := &walT{}
+
+	w.Root = &cobra.Command{
+		Use:   "wal",
+		Short: "WAL introspection tools",
+	}
+	w.Dump = &cobra.Command{
+		Use:   "dump <wal-files>",
+		Short: "print WAL contents",
+		Long: `
 Print the contents of the WAL files.
 `,
-	Args: cobra.MinimumNArgs(1),
-	Run:  runWALDump,
+		Args: cobra.MinimumNArgs(1),
+		Run:  w.runDump,
+	}
+
+	w.Root.AddCommand(w.Dump)
+	return w
 }
 
-func init() {
-	WALCmd.AddCommand(WALDumpCmd)
-}
-
-func runWALDump(cmd *cobra.Command, args []string) {
+func (w *walT) runDump(cmd *cobra.Command, args []string) {
 	fmt.Fprintf(stderr, "TODO(peter): \"wal dump\" unimplemented\n")
 	osExit(1)
 }


### PR DESCRIPTION
Rather than global commands, provide the tool commands via structs. This
will make it more natural for configuring options associated with the
commands, such as registering pretty printers or additional comparers or
mergers.

Add support for specifying start and end keys for `sstable scan` in
hex. Add support for specifying the format of keys and values for
`sstable scan`.