### PR TITLE
[Do Not Merge] Add auto-tuned rate limiter

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -827,12 +827,7 @@ func (d *DB) compact1() (err error) {
 		d.opts.EventListener.CompactionBegin(info)
 	}
 
-	compactionPacer := newCompactionPacer(compactionPacerEnv{
-		limiter:      d.compactionLimiter,
-		memTableSize: uint64(d.opts.MemTableSize),
-		getInfo:      d.getCompactionPacerInfo,
-	})
-	ve, pendingOutputs, err := d.runCompaction(c, compactionPacer)
+	ve, pendingOutputs, err := d.runCompaction(c, d.autoTunedPacer)
 
 	if d.opts.EventListener.CompactionEnd != nil {
 		info.Err = err

--- a/compaction_test.go
+++ b/compaction_test.go
@@ -700,13 +700,6 @@ func TestCompaction(t *testing.T) {
 	if err := d.Close(); err != nil {
 		t.Fatalf("db Close: %v", err)
 	}
-
-	if !(mockLimiter.allowCount > 0) {
-		t.Errorf("limiter allow: got %d, want >%d", mockLimiter.allowCount, 0)
-	}
-	if mockLimiter.waitCount != 0 {
-		t.Errorf("limiter wait: got %d, want %d", mockLimiter.waitCount, 0)
-	}
 }
 
 func TestManualCompaction(t *testing.T) {

--- a/db.go
+++ b/db.go
@@ -185,6 +185,8 @@ type DB struct {
 
 	flushLimiter limiter
 
+	autoTunedPacer pacer
+
 	// TODO(peter): describe exactly what this mutex protects. So far: every
 	// field in the struct.
 	mu struct {

--- a/open.go
+++ b/open.go
@@ -84,6 +84,7 @@ func Open(dirname string, opts *Options) (*DB, error) {
 		split:          opts.Comparer.Split,
 		abbreviatedKey: opts.Comparer.AbbreviatedKey,
 		logRecycler:    logRecycler{limit: opts.MemTableStopWritesThreshold + 1},
+		autoTunedPacer: newAutoTunedCompactionPacer(),
 	}
 	if d.equal == nil {
 		d.equal = bytes.Equal


### PR DESCRIPTION
Implemented RocksDB's [Auto-tuned rate limiter](https://rocksdb.org/blog/2017/12/18/17-auto-tuned-rate-limiter.html) for comparing with Pebble's compaction pacing mechanism.

It's not exactly identical to RocksDB's mechanism because we only apply the auto tuning to the compaction pacing portion, since RocksDB uses a single multi-priority rate limiter for both flushes and compactions, which would require a lot more work to implement.

This should be sufficient for benchmarking against Pebble's current pacing mechanism.