### PR TITLE
Add Options.ReadOnly

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -601,7 +601,7 @@ func (d *DB) getCompactionPacerInfo() compactionPacerInfo {
 	d.mu.Lock()
 	estimatedMaxWAmp := d.mu.versions.picker.estimatedMaxWAmp
 	pacerInfo := compactionPacerInfo{
-		slowdownThreshold: uint64(estimatedMaxWAmp * float64(d.opts.MemTableSize)),
+		slowdownThreshold:   uint64(estimatedMaxWAmp * float64(d.opts.MemTableSize)),
 		totalCompactionDebt: d.mu.versions.picker.estimatedCompactionDebt(bytesFlushed),
 	}
 	d.mu.Unlock()
@@ -619,7 +619,7 @@ func (d *DB) getFlushPacerInfo() flushPacerInfo {
 //
 // d.mu must be held when calling this.
 func (d *DB) maybeScheduleFlush() {
-	if d.mu.compact.flushing || atomic.LoadInt32(&d.closed) != 0 {
+	if d.mu.compact.flushing || atomic.LoadInt32(&d.closed) != 0 || d.opts.ReadOnly {
 		return
 	}
 	if len(d.mu.mem.queue) <= 1 {
@@ -752,7 +752,7 @@ func (d *DB) flush1() error {
 //
 // d.mu must be held when calling this.
 func (d *DB) maybeScheduleCompaction() {
-	if d.mu.compact.compacting || atomic.LoadInt32(&d.closed) != 0 {
+	if d.mu.compact.compacting || atomic.LoadInt32(&d.closed) != 0 || d.opts.ReadOnly {
 		return
 	}
 

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -88,6 +89,11 @@ func (fs loggingFS) OpenDir(name string) (vfs.File, error) {
 func (fs loggingFS) Rename(oldname, newname string) error {
 	fmt.Fprintf(fs.w, "rename: %s -> %s\n", oldname, newname)
 	return fs.FS.Rename(oldname, newname)
+}
+
+func (fs loggingFS) MkdirAll(dir string, perm os.FileMode) error {
+	fmt.Fprintf(fs.w, "mkdir-all: %s %#o\n", dir, perm)
+	return fs.FS.MkdirAll(dir, perm)
 }
 
 type loggingFile struct {

--- a/internal/base/options.go
+++ b/internal/base/options.go
@@ -336,6 +336,12 @@ type Options struct {
 	// default is 1 MB/s.
 	MinFlushRate int
 
+	// ReadOnly indicates that the DB should be opened in read-only mode. Writes
+	// to the DB will return an error, background compactions are disabled, and
+	// the flush that normally occurs after replaying the WAL at startup is
+	// disabled.
+	ReadOnly bool
+
 	// TableFormat specifies the format version for sstables. The default is
 	// TableFormatRocksDBv2 which creates RocksDB compatible sstables. Use
 	// TableFormatLevelDB to create LevelDB compatible sstable which can be used

--- a/testdata/event_listener
+++ b/testdata/event_listener
@@ -1,6 +1,8 @@
 open
 ----
+mkdir-all: db 0755
 open-dir: db
+mkdir-all: wal 0755
 open-dir: wal
 create: db/MANIFEST-000001
 create: db/CURRENT.000001.dbtmp


### PR DESCRIPTION
Allow a DB to be opened in read-only mode, which disables writes,
background flushes and compactions, and the flush which normally occurs
after replay the WAL at startup. This is useful for introspection tools
which wish to inspect the state of a DB without modifying it.