### PR TITLE
Add Batch.Empty method

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -598,6 +598,11 @@ func (b *Batch) LogData(data []byte, _ *WriteOptions) error {
 	return nil
 }
 
+// Empty returns true if the batch is empty, and false otherwise.
+func (b *Batch) Empty() bool {
+	return len(b.storage.data) <= batchHeaderLen
+}
+
 // Repr returns the underlying batch representation. It is not safe to modify
 // the contents. Reset() will not change the contents of the returned value,
 // though any other mutation operation may do so.

--- a/batch_test.go
+++ b/batch_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/petermattis/pebble/internal/base"
 	"github.com/petermattis/pebble/internal/datadriven"
 	"github.com/petermattis/pebble/vfs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBatch(t *testing.T) {
@@ -112,6 +113,36 @@ func TestBatch(t *testing.T) {
 		}
 	}
 	verifyTestCases(b, testCases)
+}
+
+func TestBatchEmpty(t *testing.T) {
+	var b Batch
+	require.True(t, b.Empty())
+
+	b.Set(nil, nil, nil)
+	require.False(t, b.Empty())
+	b.Reset()
+	require.True(t, b.Empty())
+
+	b.Merge(nil, nil, nil)
+	require.False(t, b.Empty())
+	b.Reset()
+	require.True(t, b.Empty())
+
+	b.Delete(nil, nil)
+	require.False(t, b.Empty())
+	b.Reset()
+	require.True(t, b.Empty())
+
+	b.DeleteRange(nil, nil, nil)
+	require.False(t, b.Empty())
+	b.Reset()
+	require.True(t, b.Empty())
+
+	b.LogData(nil, nil)
+	require.False(t, b.Empty())
+	b.Reset()
+	require.True(t, b.Empty())
 }
 
 func TestBatchIncrement(t *testing.T) {

--- a/commit.go
+++ b/commit.go
@@ -236,7 +236,7 @@ func (p *commitPipeline) Close() {
 // WAL, and applying the batch to the memtable. Upon successful return the
 // batch's mutations will be visible for reading.
 func (p *commitPipeline) Commit(b *Batch, syncWAL bool) error {
-	if len(b.storage.data) == 0 {
+	if b.Empty() {
 		return nil
 	}
 


### PR DESCRIPTION
Note that `Batch.Empty()` is not the same as `Batch.Count() == 0`
because log-data records do not increment the count.