### PR TITLE
Add fluctuation option to benchmarks

### DIFF
--- a/cmd/pebble/main.go
+++ b/cmd/pebble/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"log"
-	"math"
 	"os"
 	"time"
 
@@ -19,7 +18,7 @@ var (
 	concurrency     int
 	disableWAL      bool
 	duration        time.Duration
-	maxOpsPerSec    int
+	maxOpsPerSec    string
 	rocksdb         bool
 	verbose         bool
 	waitCompactions bool
@@ -57,8 +56,8 @@ func main() {
 			&disableWAL, "disable-wal", false, "disable the WAL (voiding persistence guarantees)")
 		cmd.Flags().DurationVarP(
 			&duration, "duration", "d", 10*time.Second, "the duration to run (0, run forever)")
-		cmd.Flags().IntVarP(
-			&maxOpsPerSec, "max-ops-per-sec", "m", math.MaxInt32, "max ops per second")
+		cmd.Flags().StringVarP(
+			&maxOpsPerSec, "rate", "m", "1000000", "max ops per second [{zipf,uniform}:]min[-max][/period (sec)]")
 		cmd.Flags().BoolVar(
 			&rocksdb, "rocksdb", false,
 			"use rocksdb storage engine instead of pebble")

--- a/cmd/pebble/scan.go
+++ b/cmd/pebble/scan.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/petermattis/pebble"
-	"github.com/petermattis/pebble/internal/rate"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/rand"
 )
@@ -96,7 +95,11 @@ func runScan(cmd *cobra.Command, args []string) {
 				log.Fatal(err)
 			}
 
-			limiter := rate.NewLimiter(rate.Limit(maxOpsPerSec), 1)
+			limiter, err := newFluctuatingRateLimiter(maxOpsPerSec)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
 			wg.Add(concurrency)
 			for i := 0; i < concurrency; i++ {
 				go func(i int) {

--- a/cmd/pebble/sync.go
+++ b/cmd/pebble/sync.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/petermattis/pebble"
-	"github.com/petermattis/pebble/internal/rate"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/rand"
 )
@@ -66,7 +65,11 @@ func runSync(cmd *cobra.Command, args []string) {
 
 	runTest(args[0], test{
 		init: func(d DB, wg *sync.WaitGroup) {
-			limiter := rate.NewLimiter(rate.Limit(maxOpsPerSec), 1)
+			limiter, err := newFluctuatingRateLimiter(maxOpsPerSec)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
 			wg.Add(concurrency)
 			for i := 0; i < concurrency; i++ {
 				latency := reg.Register("ops")

--- a/cmd/pebble/ycsb.go
+++ b/cmd/pebble/ycsb.go
@@ -324,8 +324,13 @@ func (y *ycsb) init(db DB, wg *sync.WaitGroup) {
 			1+ycsbConfig.prepopulatedKeys+ycsbConfig.initialKeys)
 	}
 	y.keyNum = ackseq.New(uint64(ycsbConfig.initialKeys + ycsbConfig.prepopulatedKeys))
-	y.limiter = rate.NewLimiter(rate.Limit(maxOpsPerSec), 1)
 
+	var err error
+	y.limiter, err = newFluctuatingRateLimiter(maxOpsPerSec)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {
 		go y.run(db, wg)


### PR DESCRIPTION
Add option to fluctuate ops per second in the benchmarks.

This would be useful for testing how Pebble/RocksDB behaves when the read/write rates fluctuate.