### PR TITLE
Enhance `sstable layout` output

### DIFF
--- a/tool/sstable.go
+++ b/tool/sstable.go
@@ -98,6 +98,10 @@ order which means the records will be printed in that order.
 			"verbose output")
 	}
 
+	s.Layout.Flags().Var(
+		&s.fmtKey, "key", "key formatter")
+	s.Layout.Flags().Var(
+		&s.fmtValue, "value", "value formatter")
 	s.Scan.Flags().Var(
 		&s.fmtKey, "key", "key formatter")
 	s.Scan.Flags().Var(
@@ -168,7 +172,13 @@ func (s *sstableT) runLayout(cmd *cobra.Command, args []string) {
 				fmt.Fprintf(stderr, "%s\n", err)
 				return
 			}
-			l.Describe(stdout, s.verbose, r)
+			fmtRecord := func(key *base.InternalKey, value []byte) {
+				formatKeyValue(stdout, s.fmtKey, s.fmtValue, key, value)
+			}
+			if s.fmtKey.spec == "null" && s.fmtValue.spec == "null" {
+				fmtRecord = nil
+			}
+			l.Describe(stdout, s.verbose, r, fmtRecord)
 		}()
 	}
 }

--- a/tool/testdata/sstable_layout
+++ b/tool/testdata/sstable_layout
@@ -104,139 +104,269 @@ sstable layout
 
 sstable layout
 -v
+--value=null
 ../sstable/testdata/h.no-compression.two_level_index.sst
 ----
 ../sstable/testdata/h.no-compression.two_level_index.sst
          0  data (2041)
          0    record (14 = 3 [0] + 9 + 2) [restart]
+              a#0,1
         14    record (17 = 3 [1] + 13 + 1)
+              aboard#0,1
         31    record (14 = 3 [3] + 10 + 1)
+              about#0,1
         45    record (14 = 3 [3] + 10 + 1)
+              above#0,1
         59    record (16 = 3 [2] + 12 + 1)
+              abroad#0,1
         75    record (16 = 3 [2] + 12 + 1)
+              absurd#0,1
         91    record (16 = 3 [2] + 12 + 1)
+              abused#0,1
        107    record (17 = 3 [1] + 13 + 1)
+              accord#0,1
        124    record (15 = 3 [4] + 11 + 1)
+              account#0,1
        139    record (22 = 3 [2] + 18 + 1)
+              achievements#0,1
        161    record (18 = 3 [2] + 14 + 1)
+              acquaint#0,1
        179    record (13 = 3 [2] + 9 + 1)
+              act#0,1
        192    record (15 = 3 [3] + 11 + 1)
+              action#0,1
        207    record (13 = 3 [6] + 9 + 1)
+              actions#0,1
        220    record (19 = 3 [1] + 15 + 1)
+              addition#0,1
        239    record (16 = 3 [3] + 12 + 1)
+              address#0,1
        255    record (17 = 3 [0] + 13 + 1) [restart]
+              adieu#0,1
        272    record (20 = 3 [2] + 16 + 1)
+              admiration#0,1
        292    record (18 = 3 [2] + 14 + 1)
+              adoption#0,1
        310    record (20 = 3 [2] + 16 + 1)
+              adulterate#0,1
        330    record (19 = 3 [2] + 15 + 1)
+              advantage#0,1
        349    record (15 = 3 [3] + 11 + 1)
+              advice#0,1
        364    record (17 = 3 [1] + 13 + 1)
+              affair#0,1
        381    record (18 = 3 [3] + 14 + 1)
+              affection#0,1
        399    record (15 = 3 [2] + 11 + 1)
+              after#0,1
        414    record (16 = 3 [5] + 12 + 1)
+              afternoon#0,1
        430    record (17 = 3 [1] + 12 + 2)
+              again#0,1
        447    record (14 = 3 [5] + 10 + 1)
+              against#0,1
        461    record (13 = 3 [1] + 9 + 1)
+              ah#0,1
        474    record (14 = 3 [1] + 10 + 1)
+              air#0,1
        488    record (13 = 3 [3] + 9 + 1)
+              airs#0,1
        501    record (15 = 3 [1] + 11 + 1)
+              alas#0,1
        516    record (16 = 3 [0] + 11 + 2) [restart]
+              all#0,1
        532    record (15 = 3 [3] + 11 + 1)
+              alleys#0,1
        547    record (14 = 3 [3] + 10 + 1)
+              allow#0,1
        561    record (16 = 3 [2] + 12 + 1)
+              almost#0,1
        577    record (15 = 3 [2] + 11 + 1)
+              alone#0,1
        592    record (13 = 3 [4] + 9 + 1)
+              along#0,1
        605    record (17 = 3 [2] + 13 + 1)
+              already#0,1
        622    record (16 = 3 [2] + 12 + 1)
+              always#0,1
        638    record (13 = 3 [1] + 9 + 1)
+              am#0,1
        651    record (16 = 3 [2] + 12 + 1)
+              amazed#0,1
        667    record (19 = 3 [2] + 15 + 1)
+              ambiguous#0,1
        686    record (17 = 3 [4] + 13 + 1)
+              ambitious#0,1
        703    record (14 = 3 [1] + 9 + 2)
+              an#0,1
        717    record (15 = 3 [2] + 9 + 3)
+              and#0,1
        732    record (15 = 3 [2] + 11 + 1)
+              angel#0,1
        747    record (13 = 3 [5] + 9 + 1)
+              angels#0,1
        760    record (17 = 3 [0] + 13 + 1) [restart]
+              anger#0,1
        777    record (14 = 3 [3] + 10 + 1)
+              angry#0,1
        791    record (17 = 3 [2] + 13 + 1)
+              another#0,1
        808    record (16 = 3 [2] + 12 + 1)
+              answer#0,1
        824    record (15 = 3 [2] + 11 + 1)
+              antic#0,1
        839    record (13 = 3 [2] + 9 + 1)
+              any#0,1
        852    record (18 = 3 [1] + 14 + 1)
+              apparel#0,1
        870    record (17 = 3 [5] + 13 + 1)
+              apparition#0,1
        887    record (15 = 3 [3] + 11 + 1)
+              appear#0,1
        902    record (13 = 3 [6] + 9 + 1)
+              appears#0,1
        915    record (16 = 3 [4] + 12 + 1)
+              appetite#0,1
        931    record (16 = 3 [3] + 12 + 1)
+              approve#0,1
        947    record (13 = 3 [2] + 9 + 1)
+              apt#0,1
        960    record (15 = 3 [1] + 10 + 2)
+              are#0,1
        975    record (13 = 3 [2] + 9 + 1)
+              arm#0,1
        988    record (14 = 3 [3] + 10 + 1)
+              armed#0,1
       1002    record (18 = 3 [0] + 14 + 1) [restart]
+              armour#0,1
       1020    record (13 = 3 [3] + 9 + 1)
+              arms#0,1
       1033    record (16 = 3 [2] + 12 + 1)
+              arrant#0,1
       1049    record (13 = 3 [2] + 9 + 1)
+              art#0,1
       1062    record (15 = 3 [3] + 11 + 1)
+              artery#0,1
       1077    record (16 = 3 [3] + 12 + 1)
+              article#0,1
       1093    record (13 = 3 [7] + 9 + 1)
+              articles#0,1
       1106    record (14 = 3 [1] + 9 + 2)
+              as#0,1
       1120    record (15 = 3 [2] + 11 + 1)
+              aside#0,1
       1135    record (16 = 3 [2] + 12 + 1)
+              asking#0,1
       1151    record (16 = 3 [2] + 12 + 1)
+              assail#0,1
       1167    record (18 = 3 [3] + 14 + 1)
+              assistant#0,1
       1185    record (15 = 3 [3] + 11 + 1)
+              assume#0,1
       1200    record (14 = 3 [1] + 9 + 2)
+              at#0,1
       1214    record (20 = 3 [2] + 16 + 1)
+              attendants#0,1
       1234    record (13 = 3 [5] + 9 + 1)
+              attent#0,1
       1247    record (21 = 3 [0] + 17 + 1) [restart]
+              attribute#0,1
       1268    record (19 = 3 [1] + 15 + 1)
+              audience#0,1
       1287    record (15 = 3 [2] + 11 + 1)
+              aught#0,1
       1302    record (20 = 3 [2] + 16 + 1)
+              auspicious#0,1
       1322    record (16 = 3 [1] + 12 + 1)
+              avoid#0,1
       1338    record (15 = 3 [3] + 11 + 1)
+              avouch#0,1
       1353    record (16 = 3 [1] + 12 + 1)
+              awake#0,1
       1369    record (13 = 3 [3] + 9 + 1)
+              away#0,1
       1382    record (16 = 3 [2] + 12 + 1)
+              awhile#0,1
       1398    record (13 = 3 [1] + 9 + 1)
+              ay#0,1
       1411    record (16 = 3 [0] + 12 + 1)
+              baby#0,1
       1427    record (14 = 3 [2] + 10 + 1)
+              back#0,1
       1441    record (15 = 3 [2] + 11 + 1)
+              baked#0,1
       1456    record (14 = 3 [2] + 10 + 1)
+              bark#0,1
       1470    record (13 = 3 [3] + 9 + 1)
+              barr#0,1
       1483    record (14 = 3 [2] + 10 + 1)
+              base#0,1
       1497    record (17 = 3 [0] + 13 + 1) [restart]
+              baser#0,1
       1514    record (15 = 3 [2] + 11 + 1)
+              bawds#0,1
       1529    record (14 = 3 [1] + 9 + 2)
+              be#0,1
       1543    record (14 = 3 [2] + 10 + 1)
+              bear#0,1
       1557    record (13 = 3 [4] + 9 + 1)
+              beard#0,1
       1570    record (15 = 3 [4] + 11 + 1)
+              bearers#0,1
       1585    record (13 = 3 [4] + 9 + 1)
+              bears#0,1
       1598    record (14 = 3 [3] + 10 + 1)
+              beast#0,1
       1612    record (16 = 3 [3] + 12 + 1)
+              beating#0,1
       1628    record (15 = 3 [3] + 11 + 1)
+              beauty#0,1
       1643    record (15 = 3 [3] + 11 + 1)
+              beaver#0,1
       1658    record (17 = 3 [2] + 13 + 1)
+              beckons#0,1
       1675    record (13 = 3 [2] + 9 + 1)
+              bed#0,1
       1688    record (14 = 3 [2] + 10 + 1)
+              been#0,1
       1702    record (16 = 3 [3] + 12 + 1)
+              beetles#0,1
       1718    record (18 = 3 [2] + 14 + 1)
+              befitted#0,1
       1736    record (18 = 3 [0] + 14 + 1) [restart]
+              before#0,1
       1754    record (13 = 3 [2] + 9 + 1)
+              beg#0,1
       1767    record (16 = 3 [3] + 12 + 1)
+              beguile#0,1
       1783    record (16 = 3 [2] + 12 + 1)
+              behold#0,1
       1799    record (15 = 3 [4] + 11 + 1)
+              behoves#0,1
       1814    record (15 = 3 [2] + 11 + 1)
+              being#0,1
       1829    record (16 = 3 [2] + 12 + 1)
+              belief#0,1
       1845    record (14 = 3 [5] + 10 + 1)
+              believe#0,1
       1859    record (13 = 3 [3] + 9 + 1)
+              bell#0,1
       1872    record (14 = 3 [2] + 10 + 1)
+              bend#0,1
       1886    record (16 = 3 [3] + 12 + 1)
+              beneath#0,1
       1902    record (15 = 3 [4] + 11 + 1)
+              benefit#0,1
       1917    record (19 = 3 [2] + 14 + 2)
+              bernardo#0,1
       1936    record (17 = 3 [2] + 13 + 1)
+              beseech#0,1
       1953    record (17 = 3 [3] + 13 + 1)
+              besmirch#0,1
       1970    record (13 = 3 [3] + 9 + 1)
+              best#0,1
       1983    record (18 = 3 [0] + 14 + 1) [restart]
+              beteem#0,1
       2001    [restart 0]
       2005    [restart 255]
       2009    [restart 516]
@@ -248,134 +378,263 @@ sstable layout
       2033    [restart 1983]
       2046  data (2044)
       2046    record (21 = 3 [0] + 17 + 1) [restart]
+              bethought#0,1
       2067    record (15 = 3 [3] + 11 + 1)
+              better#0,1
       2082    record (16 = 3 [3] + 12 + 1)
+              between#0,1
       2098    record (16 = 3 [2] + 12 + 1)
+              beware#0,1
       2114    record (16 = 3 [2] + 12 + 1)
+              beyond#0,1
       2130    record (14 = 3 [1] + 10 + 1)
+              bid#0,1
       2144    record (14 = 3 [2] + 10 + 1)
+              bird#0,1
       2158    record (14 = 3 [3] + 10 + 1)
+              birth#0,1
       2172    record (15 = 3 [2] + 11 + 1)
+              bites#0,1
       2187    record (15 = 3 [3] + 11 + 1)
+              bitter#0,1
       2202    record (16 = 3 [1] + 12 + 1)
+              black#0,1
       2218    record (14 = 3 [3] + 10 + 1)
+              blast#0,1
       2232    record (17 = 3 [5] + 13 + 1)
+              blastments#0,1
       2249    record (13 = 3 [5] + 9 + 1)
+              blasts#0,1
       2262    record (15 = 3 [3] + 11 + 1)
+              blazes#0,1
       2277    record (14 = 3 [4] + 10 + 1)
+              blazon#0,1
       2291    record (20 = 3 [0] + 16 + 1) [restart]
+              blessing#0,1
       2311    record (15 = 3 [2] + 11 + 1)
+              blood#0,1
       2326    record (17 = 3 [3] + 13 + 1)
+              blossoms#0,1
       2343    record (14 = 3 [3] + 10 + 1)
+              blows#0,1
       2357    record (16 = 3 [1] + 12 + 1)
+              bodes#0,1
       2373    record (13 = 3 [3] + 9 + 1)
+              body#0,1
       2386    record (15 = 3 [2] + 11 + 1)
+              bonds#0,1
       2401    record (14 = 3 [3] + 10 + 1)
+              bones#0,1
       2415    record (14 = 3 [2] + 10 + 1)
+              book#0,1
       2429    record (13 = 3 [4] + 9 + 1)
+              books#0,1
       2442    record (14 = 3 [2] + 10 + 1)
+              born#0,1
       2456    record (17 = 3 [3] + 13 + 1)
+              borrower#0,1
       2473    record (15 = 3 [6] + 11 + 1)
+              borrowing#0,1
       2488    record (15 = 3 [2] + 11 + 1)
+              bosom#0,1
       2503    record (14 = 3 [2] + 10 + 1)
+              both#0,1
       2517    record (15 = 3 [2] + 11 + 1)
+              bound#0,1
       2532    record (21 = 3 [0] + 17 + 1) [restart]
+              bounteous#0,1
       2553    record (13 = 3 [2] + 9 + 1)
+              bow#0,1
       2566    record (13 = 3 [2] + 9 + 1)
+              boy#0,1
       2579    record (16 = 3 [1] + 12 + 1)
+              brain#0,1
       2595    record (13 = 3 [3] + 9 + 1)
+              bray#0,1
       2608    record (15 = 3 [3] + 11 + 1)
+              brazen#0,1
       2623    record (16 = 3 [2] + 12 + 1)
+              breach#0,1
       2639    record (13 = 3 [4] + 9 + 1)
+              break#0,1
       2652    record (15 = 3 [5] + 11 + 1)
+              breaking#0,1
       2667    record (14 = 3 [4] + 10 + 1)
+              breath#0,1
       2681    record (15 = 3 [6] + 11 + 1)
+              breathing#0,1
       2696    record (15 = 3 [2] + 11 + 1)
+              brief#0,1
       2711    record (14 = 3 [3] + 10 + 1)
+              bring#0,1
       2725    record (17 = 3 [2] + 13 + 1)
+              brokers#0,1
       2742    record (16 = 3 [3] + 12 + 1)
+              brother#0,1
       2758    record (13 = 3 [3] + 9 + 1)
+              brow#0,1
       2771    record (17 = 3 [0] + 13 + 1) [restart]
+              bruit#0,1
       2788    record (15 = 3 [1] + 11 + 1)
+              bulk#0,1
       2803    record (16 = 3 [2] + 12 + 1)
+              buried#0,1
       2819    record (14 = 3 [3] + 10 + 1)
+              burns#0,1
       2833    record (13 = 3 [4] + 9 + 1)
+              burnt#0,1
       2846    record (14 = 3 [3] + 10 + 1)
+              burst#0,1
       2860    record (18 = 3 [2] + 14 + 1)
+              business#0,1
       2878    record (14 = 3 [2] + 9 + 2)
+              but#0,1
       2892    record (16 = 3 [3] + 12 + 1)
+              buttons#0,1
       2908    record (13 = 3 [2] + 9 + 1)
+              buy#0,1
       2921    record (14 = 3 [1] + 9 + 2)
+              by#0,1
       2935    record (16 = 3 [0] + 12 + 1)
+              call#0,1
       2951    record (19 = 3 [3] + 15 + 1)
+              calumnious#0,1
       2970    record (14 = 3 [2] + 10 + 1)
+              came#0,1
       2984    record (13 = 3 [2] + 9 + 1)
+              can#0,1
       2997    record (15 = 3 [3] + 11 + 1)
+              canker#0,1
       3012    record (18 = 3 [0] + 14 + 1) [restart]
+              cannon#0,1
       3030    record (13 = 3 [5] + 9 + 1)
+              cannot#0,1
       3043    record (14 = 3 [3] + 10 + 1)
+              canon#0,1
       3057    record (16 = 3 [5] + 12 + 1)
+              canonized#0,1
       3073    record (14 = 3 [3] + 10 + 1)
+              canst#0,1
       3087    record (13 = 3 [2] + 9 + 1)
+              cap#0,1
       3100    record (19 = 3 [2] + 15 + 1)
+              carefully#0,1
       3119    record (17 = 3 [3] + 13 + 1)
+              carriage#0,1
       3136    record (16 = 3 [4] + 12 + 1)
+              carrying#0,1
       3152    record (14 = 3 [3] + 10 + 1)
+              carve#0,1
       3166    record (14 = 3 [2] + 10 + 1)
+              cast#0,1
       3180    record (14 = 3 [4] + 10 + 1)
+              castle#0,1
       3194    record (15 = 3 [2] + 11 + 1)
+              catch#0,1
       3209    record (16 = 3 [2] + 12 + 1)
+              cautel#0,1
       3225    record (15 = 3 [4] + 11 + 1)
+              caution#0,1
       3240    record (21 = 3 [1] + 17 + 1)
+              celebrated#0,1
       3261    record (21 = 3 [0] + 17 + 1) [restart]
+              celestial#0,1
       3282    record (18 = 3 [3] + 14 + 1)
+              cellarage#0,1
       3300    record (17 = 3 [2] + 13 + 1)
+              censure#0,1
       3317    record (19 = 3 [2] + 15 + 1)
+              cerements#0,1
       3336    record (16 = 3 [3] + 12 + 1)
+              certain#0,1
       3352    record (18 = 3 [1] + 14 + 1)
+              chances#0,1
       3370    record (14 = 3 [4] + 10 + 1)
+              change#0,1
       3384    record (18 = 3 [3] + 14 + 1)
+              character#0,1
       3402    record (14 = 3 [4] + 10 + 1)
+              charge#0,1
       3416    record (16 = 3 [4] + 12 + 1)
+              chariest#0,1
       3432    record (17 = 3 [5] + 13 + 1)
+              charitable#0,1
       3449    record (13 = 3 [4] + 9 + 1)
+              charm#0,1
       3462    record (15 = 3 [3] + 11 + 1)
+              chaste#0,1
       3477    record (15 = 3 [2] + 11 + 1)
+              cheer#0,1
       3492    record (15 = 3 [2] + 11 + 1)
+              chief#0,1
       3507    record (15 = 3 [5] + 11 + 1)
+              chiefest#0,1
       3522    record (18 = 3 [0] + 14 + 1) [restart]
+              choice#0,1
       3540    record (15 = 3 [3] + 11 + 1)
+              choose#0,1
       3555    record (24 = 3 [1] + 20 + 1)
+              circumscribed#0,1
       3579    record (17 = 3 [7] + 13 + 1)
+              circumstance#0,1
       3596    record (15 = 3 [1] + 11 + 1)
+              clad#0,1
       3611    record (17 = 3 [3] + 13 + 1)
+              claudius#0,1
       3628    record (17 = 3 [2] + 13 + 1)
+              clearly#0,1
       3645    record (14 = 3 [3] + 10 + 1)
+              clepe#0,1
       3659    record (15 = 3 [2] + 11 + 1)
+              cliff#0,1
       3674    record (19 = 3 [3] + 15 + 1)
+              climatures#0,1
       3693    record (15 = 3 [2] + 11 + 1)
+              cloak#0,1
       3708    record (15 = 3 [3] + 11 + 1)
+              clouds#0,1
       3723    record (15 = 3 [1] + 11 + 1)
+              cock#0,1
       3738    record (14 = 3 [2] + 10 + 1)
+              cold#0,1
       3752    record (14 = 3 [4] + 10 + 1)
+              coldly#0,1
       3766    record (19 = 3 [3] + 15 + 1)
+              colleagued#0,1
       3785    record (18 = 3 [0] + 14 + 1) [restart]
+              colour#0,1
       3803    record (16 = 3 [2] + 12 + 1)
+              combat#0,1
       3819    record (14 = 3 [6] + 10 + 1)
+              combated#0,1
       3833    record (16 = 3 [4] + 12 + 1)
+              combined#0,1
       3849    record (14 = 3 [3] + 9 + 2)
+              come#0,1
       3863    record (13 = 3 [4] + 9 + 1)
+              comes#0,1
       3876    record (13 = 3 [5] + 9 + 1)
+              comest#0,1
       3889    record (16 = 3 [3] + 12 + 1)
+              comfort#0,1
       3905    record (15 = 3 [3] + 11 + 1)
+              coming#0,1
       3920    record (16 = 3 [3] + 12 + 1)
+              command#0,1
       3936    record (16 = 3 [7] + 12 + 1)
+              commandment#0,1
       3952    record (15 = 3 [4] + 11 + 1)
+              commend#0,1
       3967    record (16 = 3 [7] + 12 + 1)
+              commendable#0,1
       3983    record (14 = 3 [4] + 10 + 1)
+              common#0,1
       3997    record (16 = 3 [3] + 12 + 1)
+              compact#0,1
       4013    record (17 = 3 [4] + 13 + 1)
+              competent#0,1
       4030    record (20 = 3 [0] + 16 + 1) [restart]
+              complete#0,1
       4050    [restart 2046]
       4054    [restart 2291]
       4058    [restart 2532]
@@ -387,131 +646,257 @@ sstable layout
       4082    [restart 4030]
       4095  data (2039)
       4095    record (22 = 3 [0] + 18 + 1) [restart]
+              complexion#0,1
       4117    record (20 = 3 [4] + 16 + 1)
+              compulsatory#0,1
       4137    record (16 = 3 [3] + 12 + 1)
+              comrade#0,1
       4153    record (17 = 3 [2] + 13 + 1)
+              conceal#0,1
       4170    record (20 = 3 [3] + 16 + 1)
+              condolement#0,1
       4190    record (16 = 3 [3] + 12 + 1)
+              confess#0,1
       4206    record (15 = 3 [4] + 11 + 1)
+              confine#0,1
       4221    record (13 = 3 [7] + 9 + 1)
+              confined#0,1
       4234    record (18 = 3 [3] + 14 + 1)
+              conqueror#0,1
       4252    record (16 = 3 [3] + 12 + 1)
+              consent#0,1
       4268    record (18 = 3 [4] + 14 + 1)
+              constantly#0,1
       4286    record (19 = 3 [3] + 15 + 1)
+              contagious#0,1
       4305    record (18 = 3 [4] + 14 + 1)
+              contracted#0,1
       4323    record (15 = 3 [5] + 11 + 1)
+              contrive#0,1
       4338    record (21 = 3 [3] + 17 + 1)
+              conveniently#0,1
       4359    record (14 = 3 [4] + 10 + 1)
+              convoy#0,1
       4373    record (18 = 3 [0] + 14 + 1) [restart]
+              copied#0,1
       4391    record (19 = 3 [2] + 15 + 1)
+              cornelius#0,1
       4410    record (19 = 3 [3] + 15 + 1)
+              coronation#0,1
       4429    record (19 = 3 [3] + 15 + 1)
+              corruption#0,1
       4448    record (14 = 3 [3] + 10 + 1)
+              corse#0,1
       4462    record (16 = 3 [2] + 12 + 1)
+              costly#0,1
       4478    record (15 = 3 [2] + 11 + 1)
+              couch#0,1
       4493    record (14 = 3 [3] + 10 + 1)
+              could#0,1
       4507    record (20 = 3 [3] + 16 + 1)
+              countenance#0,1
       4527    record (14 = 3 [5] + 10 + 1)
+              country#0,1
       4541    record (15 = 3 [7] + 11 + 1)
+              countrymen#0,1
       4556    record (15 = 3 [3] + 11 + 1)
+              couple#0,1
       4571    record (15 = 3 [3] + 11 + 1)
+              course#0,1
       4586    record (13 = 3 [6] + 9 + 1)
+              courses#0,1
       4599    record (13 = 3 [4] + 9 + 1)
+              court#0,1
       4612    record (16 = 3 [5] + 12 + 1)
+              courteous#0,1
       4628    record (20 = 3 [0] + 16 + 1) [restart]
+              courtier#0,1
       4648    record (15 = 3 [3] + 11 + 1)
+              cousin#0,1
       4663    record (18 = 3 [2] + 14 + 1)
+              covenant#0,1
       4681    record (16 = 3 [1] + 12 + 1)
+              crack#0,1
       4697    record (17 = 3 [2] + 13 + 1)
+              credent#0,1
       4714    record (17 = 3 [3] + 13 + 1)
+              crescent#0,1
       4731    record (13 = 3 [3] + 9 + 1)
+              crew#0,1
       4744    record (15 = 3 [2] + 11 + 1)
+              cried#0,1
       4759    record (13 = 3 [4] + 9 + 1)
+              cries#0,1
       4772    record (15 = 3 [3] + 11 + 1)
+              crimes#0,1
       4787    record (15 = 3 [2] + 11 + 1)
+              cross#0,1
       4802    record (16 = 3 [3] + 12 + 1)
+              crowing#0,1
       4818    record (13 = 3 [4] + 9 + 1)
+              crown#0,1
       4831    record (13 = 3 [4] + 9 + 1)
+              crows#0,1
       4844    record (15 = 3 [2] + 11 + 1)
+              crust#0,1
       4859    record (15 = 3 [1] + 11 + 1)
+              curd#0,1
       4874    record (18 = 3 [0] + 14 + 1) [restart]
+              cursed#0,1
       4892    record (16 = 3 [2] + 12 + 1)
+              custom#0,1
       4908    record (15 = 3 [6] + 11 + 1)
+              customary#0,1
       4923    record (13 = 3 [2] + 9 + 1)
+              cut#0,1
       4936    record (14 = 3 [0] + 9 + 2)
+              d#0,1
       4950    record (16 = 3 [1] + 12 + 1)
+              daily#0,1
       4966    record (19 = 3 [2] + 15 + 1)
+              dalliance#0,1
       4985    record (14 = 3 [2] + 10 + 1)
+              damn#0,1
       4999    record (14 = 3 [4] + 10 + 1)
+              damned#0,1
       5013    record (14 = 3 [2] + 10 + 1)
+              dane#0,1
       5027    record (15 = 3 [3] + 11 + 1)
+              danger#0,1
       5042    record (15 = 3 [2] + 11 + 1)
+              dared#0,1
       5057    record (13 = 3 [4] + 9 + 1)
+              dares#0,1
       5070    record (18 = 3 [2] + 14 + 1)
+              daughter#0,1
       5088    record (17 = 3 [2] + 13 + 1)
+              dawning#0,1
       5105    record (13 = 3 [2] + 9 + 1)
+              day#0,1
       5118    record (16 = 3 [0] + 12 + 1) [restart]
+              days#0,1
       5134    record (15 = 3 [1] + 11 + 1)
+              dead#0,1
       5149    record (13 = 3 [3] + 9 + 1)
+              dear#0,1
       5162    record (15 = 3 [4] + 11 + 1)
+              dearest#0,1
       5177    record (14 = 3 [4] + 10 + 1)
+              dearly#0,1
       5191    record (14 = 3 [3] + 10 + 1)
+              death#0,1
       5205    record (17 = 3 [2] + 13 + 1)
+              decline#0,1
       5222    record (14 = 3 [2] + 10 + 1)
+              deed#0,1
       5236    record (13 = 3 [4] + 9 + 1)
+              deeds#0,1
       5249    record (13 = 3 [3] + 9 + 1)
+              deep#0,1
       5262    record (18 = 3 [2] + 14 + 1)
+              defeated#0,1
       5280    record (14 = 3 [4] + 10 + 1)
+              defect#0,1
       5294    record (14 = 3 [4] + 10 + 1)
+              defend#0,1
       5308    record (18 = 3 [2] + 14 + 1)
+              dejected#0,1
       5326    record (17 = 3 [2] + 13 + 1)
+              delated#0,1
       5343    record (16 = 3 [3] + 12 + 1)
+              delight#0,1
       5359    record (19 = 3 [0] + 15 + 1) [restart]
+              deliver#0,1
       5378    record (22 = 3 [2] + 18 + 1)
+              demonstrated#0,1
       5400    record (18 = 3 [2] + 13 + 2)
+              denmark#0,1
       5418    record (15 = 3 [3] + 11 + 1)
+              denote#0,1
       5433    record (16 = 3 [2] + 12 + 1)
+              depart#0,1
       5449    record (16 = 3 [3] + 12 + 1)
+              depends#0,1
       5465    record (16 = 3 [3] + 12 + 1)
+              deprive#0,1
       5481    record (16 = 3 [2] + 12 + 1)
+              design#0,1
       5497    record (14 = 3 [4] + 10 + 1)
+              desire#0,1
       5511    record (18 = 3 [3] + 14 + 1)
+              desperate#0,1
       5529    record (15 = 3 [8] + 11 + 1)
+              desperation#0,1
       5544    record (13 = 3 [2] + 9 + 1)
+              dew#0,1
       5557    record (13 = 3 [3] + 9 + 1)
+              dews#0,1
       5570    record (19 = 3 [2] + 15 + 1)
+              dexterity#0,1
       5589    record (15 = 3 [1] + 10 + 2)
+              did#0,1
       5604    record (14 = 3 [3] + 10 + 1)
+              didst#0,1
       5618    record (15 = 3 [0] + 11 + 1) [restart]
+              die#0,1
       5633    record (13 = 3 [3] + 9 + 1)
+              died#0,1
       5646    record (13 = 3 [3] + 9 + 1)
+              diet#0,1
       5659    record (17 = 3 [2] + 13 + 1)
+              dignity#0,1
       5676    record (16 = 3 [2] + 12 + 1)
+              direct#0,1
       5692    record (14 = 3 [3] + 10 + 1)
+              dirge#0,1
       5706    record (22 = 3 [2] + 18 + 1)
+              disappointed#0,1
       5728    record (17 = 3 [4] + 13 + 1)
+              disasters#0,1
       5745    record (18 = 3 [3] + 14 + 1)
+              disclosed#0,1
       5763    record (17 = 3 [4] + 13 + 1)
+              discourse#0,1
       5780    record (18 = 3 [4] + 14 + 1)
+              discretion#0,1
       5798    record (17 = 3 [3] + 13 + 1)
+              disjoint#0,1
       5815    record (17 = 3 [3] + 13 + 1)
+              dispatch#0,1
       5832    record (19 = 3 [4] + 15 + 1)
+              disposition#0,1
       5851    record (18 = 3 [3] + 14 + 1)
+              distilled#0,1
       5869    record (16 = 3 [6] + 12 + 1)
+              distilment#0,1
       5885    record (22 = 3 [0] + 18 + 1) [restart]
+              distracted#0,1
       5907    record (16 = 3 [2] + 12 + 1)
+              divide#0,1
       5923    record (14 = 3 [1] + 9 + 2)
+              do#0,1
       5937    record (14 = 3 [2] + 10 + 1)
+              does#0,1
       5951    record (14 = 3 [2] + 10 + 1)
+              dole#0,1
       5965    record (14 = 3 [2] + 10 + 1)
+              done#0,1
       5979    record (14 = 3 [2] + 10 + 1)
+              doom#0,1
       5993    record (16 = 3 [4] + 12 + 1)
+              doomsday#0,1
       6009    record (14 = 3 [2] + 10 + 1)
+              doth#0,1
       6023    record (16 = 3 [2] + 12 + 1)
+              double#0,1
       6039    record (13 = 3 [4] + 9 + 1)
+              doubt#0,1
       6052    record (15 = 3 [5] + 11 + 1)
+              doubtful#0,1
       6067    record (14 = 3 [2] + 10 + 1)
+              down#0,1
       6081    record (17 = 3 [1] + 13 + 1)
+              drains#0,1
       6098    [restart 4095]
       6102    [restart 4373]
       6106    [restart 4628]
@@ -522,136 +907,267 @@ sstable layout
       6126    [restart 5885]
       6139  data (2036)
       6139    record (16 = 3 [0] + 12 + 1) [restart]
+              dram#0,1
       6155    record (17 = 3 [3] + 13 + 1)
+              draughts#0,1
       6172    record (13 = 3 [3] + 9 + 1)
+              draw#0,1
       6185    record (13 = 3 [4] + 9 + 1)
+              draws#0,1
       6198    record (15 = 3 [2] + 11 + 1)
+              dread#0,1
       6213    record (14 = 3 [5] + 10 + 1)
+              dreaded#0,1
       6227    record (15 = 3 [5] + 11 + 1)
+              dreadful#0,1
       6242    record (13 = 3 [4] + 9 + 1)
+              dream#0,1
       6255    record (13 = 3 [5] + 9 + 1)
+              dreamt#0,1
       6268    record (15 = 3 [2] + 11 + 1)
+              drink#0,1
       6283    record (13 = 3 [5] + 9 + 1)
+              drinks#0,1
       6296    record (18 = 3 [2] + 14 + 1)
+              dropping#0,1
       6314    record (13 = 3 [8] + 9 + 1)
+              droppings#0,1
       6327    record (14 = 3 [2] + 10 + 1)
+              drum#0,1
       6341    record (18 = 3 [3] + 14 + 1)
+              drunkards#0,1
       6359    record (15 = 3 [1] + 11 + 1)
+              dull#0,1
       6374    record (18 = 3 [0] + 14 + 1) [restart]
+              duller#0,1
       6392    record (13 = 3 [4] + 9 + 1)
+              dulls#0,1
       6405    record (14 = 3 [2] + 10 + 1)
+              dumb#0,1
       6419    record (14 = 3 [2] + 10 + 1)
+              dust#0,1
       6433    record (16 = 3 [2] + 12 + 1)
+              duties#0,1
       6449    record (13 = 3 [3] + 9 + 1)
+              duty#0,1
       6462    record (19 = 3 [1] + 15 + 1)
+              dwelling#0,1
       6481    record (14 = 3 [1] + 10 + 1)
+              dye#0,1
       6495    record (13 = 3 [0] + 9 + 1)
+              e#0,1
       6508    record (15 = 3 [1] + 11 + 1)
+              each#0,1
       6523    record (15 = 3 [2] + 11 + 1)
+              eager#0,1
       6538    record (14 = 3 [2] + 10 + 1)
+              eale#0,1
       6552    record (13 = 3 [2] + 9 + 1)
+              ear#0,1
       6565    record (13 = 3 [3] + 9 + 1)
+              ears#0,1
       6578    record (14 = 3 [3] + 10 + 1)
+              earth#0,1
       6592    record (14 = 3 [5] + 10 + 1)
+              earthly#0,1
       6606    record (16 = 3 [0] + 12 + 1) [restart]
+              ease#0,1
       6622    record (13 = 3 [3] + 9 + 1)
+              east#0,1
       6635    record (16 = 3 [4] + 12 + 1)
+              eastward#0,1
       6651    record (18 = 3 [1] + 14 + 1)
+              eclipse#0,1
       6669    record (15 = 3 [1] + 11 + 1)
+              edge#0,1
       6684    record (17 = 3 [1] + 13 + 1)
+              effect#0,1
       6701    record (17 = 3 [1] + 13 + 1)
+              eleven#0,1
       6718    record (14 = 3 [2] + 10 + 1)
+              else#0,1
       6732    record (17 = 3 [3] + 13 + 1)
+              elsinore#0,1
       6749    record (17 = 3 [1] + 13 + 1)
+              embark#0,1
       6766    record (16 = 3 [2] + 12 + 1)
+              empire#0,1
       6782    record (17 = 3 [2] + 13 + 1)
+              emulate#0,1
       6799    record (13 = 3 [1] + 9 + 1)
+              en#0,1
       6812    record (19 = 3 [2] + 15 + 1)
+              encounter#0,1
       6831    record (17 = 3 [3] + 13 + 1)
+              encumber#0,1
       6848    record (13 = 3 [2] + 9 + 1)
+              end#0,1
       6861    record (17 = 3 [0] + 13 + 1) [restart]
+              enemy#0,1
       6878    record (16 = 3 [2] + 12 + 1)
+              enmity#0,1
       6894    record (16 = 3 [2] + 12 + 1)
+              enough#0,1
       6910    record (16 = 3 [2] + 11 + 2)
+              enter#0,1
       6926    record (17 = 3 [5] + 13 + 1)
+              enterprise#0,1
       6943    record (20 = 3 [5] + 16 + 1)
+              entertainment#0,1
       6963    record (17 = 3 [3] + 13 + 1)
+              entrance#0,1
       6980    record (17 = 3 [4] + 13 + 1)
+              entreated#0,1
       6997    record (17 = 3 [7] + 13 + 1)
+              entreatments#0,1
       7014    record (16 = 3 [1] + 12 + 1)
+              equal#0,1
       7030    record (13 = 3 [1] + 9 + 1)
+              er#0,1
       7043    record (13 = 3 [2] + 9 + 1)
+              ere#0,1
       7056    record (18 = 3 [2] + 14 + 1)
+              ergrowth#0,1
       7074    record (18 = 3 [2] + 14 + 1)
+              ermaster#0,1
       7092    record (16 = 3 [2] + 12 + 1)
+              erring#0,1
       7108    record (18 = 3 [2] + 14 + 1)
+              eruption#0,1
       7126    record (19 = 3 [0] + 15 + 1) [restart]
+              erwhelm#0,1
       7145    record (17 = 3 [1] + 13 + 1)
+              esteem#0,1
       7162    record (13 = 3 [1] + 9 + 1)
+              et#0,1
       7175    record (17 = 3 [2] + 13 + 1)
+              eternal#0,1
       7192    record (15 = 3 [5] + 11 + 1)
+              eternity#0,1
       7207    record (15 = 3 [1] + 11 + 1)
+              even#0,1
       7222    record (14 = 3 [4] + 10 + 1)
+              events#0,1
       7236    record (13 = 3 [3] + 9 + 1)
+              ever#0,1
       7249    record (19 = 3 [4] + 15 + 1)
+              everlasting#0,1
       7268    record (13 = 3 [4] + 9 + 1)
+              every#0,1
       7281    record (18 = 3 [1] + 14 + 1)
+              exactly#0,1
       7299    record (19 = 3 [2] + 15 + 1)
+              excellent#0,1
       7318    record (16 = 3 [2] + 12 + 1)
+              exeunt#0,1
       7334    record (14 = 3 [2] + 10 + 1)
+              exit#0,1
       7348    record (17 = 3 [2] + 13 + 1)
+              express#0,1
       7365    record (17 = 3 [2] + 13 + 1)
+              extinct#0,1
       7382    record (20 = 3 [0] + 16 + 1) [restart]
+              extorted#0,1
       7402    record (20 = 3 [3] + 16 + 1)
+              extravagant#0,1
       7422    record (14 = 3 [1] + 10 + 1)
+              eye#0,1
       7436    record (13 = 3 [3] + 9 + 1)
+              eyes#0,1
       7449    record (16 = 3 [0] + 12 + 1)
+              face#0,1
       7465    record (15 = 3 [2] + 11 + 1)
+              faded#0,1
       7480    record (14 = 3 [2] + 10 + 1)
+              fail#0,1
       7494    record (13 = 3 [3] + 9 + 1)
+              fair#0,1
       7507    record (13 = 3 [4] + 9 + 1)
+              fairy#0,1
       7520    record (14 = 3 [3] + 10 + 1)
+              faith#0,1
       7534    record (17 = 3 [2] + 13 + 1)
+              falling#0,1
       7551    record (14 = 3 [3] + 10 + 1)
+              false#0,1
       7565    record (18 = 3 [2] + 14 + 1)
+              familiar#0,1
       7583    record (15 = 3 [2] + 11 + 1)
+              fancy#0,1
       7598    record (16 = 3 [3] + 12 + 1)
+              fantasy#0,1
       7614    record (13 = 3 [2] + 9 + 1)
+              far#0,1
       7627    record (16 = 3 [0] + 12 + 1) [restart]
+              fare#0,1
       7643    record (16 = 3 [4] + 12 + 1)
+              farewell#0,1
       7659    record (17 = 3 [2] + 13 + 1)
+              fashion#0,1
       7676    record (13 = 3 [3] + 9 + 1)
+              fast#0,1
       7689    record (13 = 3 [2] + 9 + 1)
+              fat#0,1
       7702    record (13 = 3 [3] + 9 + 1)
+              fate#0,1
       7715    record (13 = 3 [4] + 9 + 1)
+              fates#0,1
       7728    record (16 = 3 [3] + 11 + 2)
+              father#0,1
       7744    record (13 = 3 [6] + 9 + 1)
+              fathers#0,1
       7757    record (15 = 3 [4] + 11 + 1)
+              fathoms#0,1
       7772    record (15 = 3 [2] + 11 + 1)
+              fault#0,1
       7787    record (16 = 3 [2] + 12 + 1)
+              favour#0,1
       7803    record (15 = 3 [1] + 11 + 1)
+              fear#0,1
       7818    record (15 = 3 [4] + 11 + 1)
+              fearful#0,1
       7833    record (13 = 3 [2] + 9 + 1)
+              fed#0,1
       7846    record (13 = 3 [2] + 9 + 1)
+              fee#0,1
       7859    record (16 = 3 [0] + 12 + 1) [restart]
+              fell#0,1
       7875    record (14 = 3 [4] + 10 + 1)
+              fellow#0,1
       7889    record (13 = 3 [2] + 9 + 1)
+              few#0,1
       7902    record (14 = 3 [1] + 10 + 1)
+              fie#0,1
       7916    record (15 = 3 [3] + 11 + 1)
+              fierce#0,1
       7931    record (16 = 3 [2] + 12 + 1)
+              figure#0,1
       7947    record (16 = 3 [2] + 12 + 1)
+              filial#0,1
       7963    record (14 = 3 [2] + 10 + 1)
+              find#0,1
       7977    record (16 = 3 [3] + 12 + 1)
+              fingers#0,1
       7993    record (14 = 3 [2] + 10 + 1)
+              fire#0,1
       8007    record (13 = 3 [4] + 9 + 1)
+              fires#0,1
       8020    record (14 = 3 [3] + 10 + 1)
+              first#0,1
       8034    record (13 = 3 [2] + 9 + 1)
+              fit#0,1
       8047    record (13 = 3 [3] + 9 + 1)
+              fits#0,1
       8060    record (16 = 3 [3] + 12 + 1)
+              fitting#0,1
       8076    record (13 = 3 [2] + 9 + 1)
+              fix#0,1
       8089    record (18 = 3 [0] + 14 + 1) [restart]
+              flames#0,1
       8107    record (13 = 3 [3] + 9 + 1)
+              flat#0,1
       8120    record (15 = 3 [2] + 11 + 1)
+              flesh#0,1
       8135    [restart 6139]
       8139    [restart 6374]
       8143    [restart 6606]
@@ -663,137 +1179,269 @@ sstable layout
       8167    [restart 8089]
       8180  data (2032)
       8180    record (17 = 3 [0] + 13 + 1) [restart]
+              flood#0,1
       8197    record (17 = 3 [3] + 13 + 1)
+              flourish#0,1
       8214    record (18 = 3 [2] + 14 + 1)
+              flushing#0,1
       8232    record (14 = 3 [1] + 10 + 1)
+              foe#0,1
       8246    record (16 = 3 [2] + 12 + 1)
+              follow#0,1
       8262    record (13 = 3 [6] + 9 + 1)
+              follows#0,1
       8275    record (14 = 3 [2] + 10 + 1)
+              fond#0,1
       8289    record (14 = 3 [2] + 10 + 1)
+              food#0,1
       8303    record (13 = 3 [3] + 9 + 1)
+              fool#0,1
       8316    record (13 = 3 [4] + 9 + 1)
+              fools#0,1
       8329    record (13 = 3 [3] + 9 + 1)
+              foot#0,1
       8342    record (14 = 3 [2] + 9 + 2)
+              for#0,1
       8356    record (15 = 3 [3] + 11 + 1)
+              forbid#0,1
       8371    record (15 = 3 [3] + 11 + 1)
+              forced#0,1
       8386    record (16 = 3 [3] + 12 + 1)
+              foreign#0,1
       8402    record (19 = 3 [4] + 15 + 1)
+              foreknowing#0,1
       8421    record (20 = 3 [0] + 16 + 1) [restart]
+              foresaid#0,1
       8441    record (16 = 3 [3] + 12 + 1)
+              forfeit#0,1
       8457    record (15 = 3 [3] + 11 + 1)
+              forged#0,1
       8472    record (13 = 3 [5] + 9 + 1)
+              forget#0,1
       8485    record (13 = 3 [3] + 9 + 1)
+              form#0,1
       8498    record (13 = 3 [4] + 9 + 1)
+              forms#0,1
       8511    record (14 = 3 [3] + 10 + 1)
+              forth#0,1
       8525    record (17 = 3 [4] + 13 + 1)
+              fortified#0,1
       8542    record (17 = 3 [5] + 13 + 1)
+              fortinbras#0,1
       8559    record (13 = 3 [4] + 9 + 1)
+              forts#0,1
       8572    record (15 = 3 [4] + 11 + 1)
+              fortune#0,1
       8587    record (16 = 3 [3] + 12 + 1)
+              forward#0,1
       8603    record (16 = 3 [2] + 12 + 1)
+              fought#0,1
       8619    record (13 = 3 [3] + 9 + 1)
+              foul#0,1
       8632    record (18 = 3 [1] + 14 + 1)
+              frailty#0,1
       8650    record (14 = 3 [3] + 10 + 1)
+              frame#0,1
       8664    record (18 = 3 [0] + 14 + 1) [restart]
+              france#0,1
       8682    record (17 = 3 [5] + 12 + 2)
+              francisco#0,1
       8699    record (14 = 3 [2] + 10 + 1)
+              free#0,1
       8713    record (14 = 3 [4] + 10 + 1)
+              freely#0,1
       8727    record (14 = 3 [4] + 10 + 1)
+              freeze#0,1
       8741    record (16 = 3 [3] + 12 + 1)
+              fretful#0,1
       8757    record (16 = 3 [2] + 12 + 1)
+              friend#0,1
       8773    record (15 = 3 [6] + 11 + 1)
+              friending#0,1
       8788    record (13 = 3 [6] + 9 + 1)
+              friends#0,1
       8801    record (15 = 3 [2] + 10 + 2)
+              from#0,1
       8816    record (14 = 3 [3] + 10 + 1)
+              frown#0,1
       8830    record (17 = 3 [5] + 13 + 1)
+              frowningly#0,1
       8847    record (18 = 3 [2] + 14 + 1)
+              fruitful#0,1
       8865    record (15 = 3 [1] + 11 + 1)
+              full#0,1
       8880    record (17 = 3 [2] + 13 + 1)
+              funeral#0,1
       8897    record (17 = 3 [2] + 13 + 1)
+              furnish#0,1
       8914    record (19 = 3 [0] + 15 + 1) [restart]
+              further#0,1
       8933    record (17 = 3 [0] + 13 + 1)
+              gaged#0,1
       8950    record (16 = 3 [2] + 12 + 1)
+              gainst#0,1
       8966    record (13 = 3 [3] + 9 + 1)
+              gait#0,1
       8979    record (16 = 3 [2] + 12 + 1)
+              galled#0,1
       8995    record (13 = 3 [4] + 9 + 1)
+              galls#0,1
       9008    record (14 = 3 [2] + 10 + 1)
+              gape#0,1
       9022    record (17 = 3 [2] + 13 + 1)
+              garbage#0,1
       9039    record (15 = 3 [3] + 11 + 1)
+              garden#0,1
       9054    record (15 = 3 [2] + 11 + 1)
+              gates#0,1
       9069    record (15 = 3 [2] + 11 + 1)
+              gaudy#0,1
       9084    record (18 = 3 [1] + 14 + 1)
+              general#0,1
       9102    record (15 = 3 [5] + 11 + 1)
+              generous#0,1
       9117    record (15 = 3 [3] + 11 + 1)
+              gentle#0,1
       9132    record (15 = 3 [6] + 11 + 1)
+              gentlemen#0,1
       9147    record (18 = 3 [2] + 14 + 1)
+              gertrude#0,1
       9165    record (15 = 3 [0] + 11 + 1) [restart]
+              get#0,1
       9180    record (17 = 3 [1] + 12 + 2)
+              ghost#0,1
       9197    record (17 = 3 [1] + 13 + 1)
+              gibber#0,1
       9214    record (15 = 3 [2] + 11 + 1)
+              gifts#0,1
       9229    record (14 = 3 [2] + 10 + 1)
+              gins#0,1
       9243    record (14 = 3 [2] + 10 + 1)
+              girl#0,1
       9257    record (15 = 3 [2] + 10 + 2)
+              give#0,1
       9272    record (13 = 3 [4] + 9 + 1)
+              given#0,1
       9285    record (15 = 3 [3] + 11 + 1)
+              giving#0,1
       9300    record (15 = 3 [1] + 11 + 1)
+              glad#0,1
       9315    record (18 = 3 [2] + 14 + 1)
+              glimpses#0,1
       9333    record (15 = 3 [2] + 11 + 1)
+              globe#0,1
       9348    record (13 = 3 [3] + 9 + 1)
+              glow#0,1
       9361    record (14 = 3 [1] + 9 + 2)
+              go#0,1
       9375    record (16 = 3 [2] + 12 + 1)
+              goblin#0,1
       9391    record (13 = 3 [2] + 9 + 1)
+              god#0,1
       9404    record (16 = 3 [0] + 12 + 1) [restart]
+              goes#0,1
       9420    record (15 = 3 [2] + 11 + 1)
+              going#0,1
       9435    record (14 = 3 [2] + 10 + 1)
+              gone#0,1
       9449    record (15 = 3 [2] + 10 + 2)
+              good#0,1
       9464    record (14 = 3 [4] + 10 + 1)
+              goodly#0,1
       9478    record (16 = 3 [1] + 12 + 1)
+              grace#0,1
       9494    record (13 = 3 [5] + 9 + 1)
+              graces#0,1
       9507    record (16 = 3 [4] + 12 + 1)
+              gracious#0,1
       9523    record (16 = 3 [3] + 12 + 1)
+              grapple#0,1
       9539    record (14 = 3 [3] + 10 + 1)
+              grave#0,1
       9553    record (13 = 3 [5] + 9 + 1)
+              graves#0,1
       9566    record (15 = 3 [2] + 11 + 1)
+              great#0,1
       9581    record (16 = 3 [5] + 12 + 1)
+              greatness#0,1
       9597    record (14 = 3 [3] + 10 + 1)
+              green#0,1
       9611    record (16 = 3 [4] + 12 + 1)
+              greeting#0,1
       9627    record (15 = 3 [2] + 11 + 1)
+              grief#0,1
       9642    record (20 = 3 [0] + 16 + 1) [restart]
+              grizzled#0,1
       9662    record (15 = 3 [2] + 11 + 1)
+              gross#0,1
       9677    record (15 = 3 [3] + 11 + 1)
+              ground#0,1
       9692    record (13 = 3 [3] + 9 + 1)
+              grow#0,1
       9705    record (13 = 3 [4] + 9 + 1)
+              grown#0,1
       9718    record (13 = 3 [4] + 9 + 1)
+              grows#0,1
       9731    record (16 = 3 [1] + 12 + 1)
+              guard#0,1
       9747    record (16 = 3 [2] + 12 + 1)
+              guilty#0,1
       9763    record (14 = 3 [0] + 10 + 1)
+              ha#0,1
       9777    record (15 = 3 [2] + 11 + 1)
+              habit#0,1
       9792    record (14 = 3 [2] + 9 + 2)
+              had#0,1
       9806    record (14 = 3 [2] + 10 + 1)
+              hail#0,1
       9820    record (13 = 3 [3] + 9 + 1)
+              hair#0,1
       9833    record (16 = 3 [2] + 12 + 1)
+              hallow#0,1
       9849    record (18 = 3 [2] + 12 + 3)
+              hamlet#0,1
       9867    record (14 = 3 [2] + 10 + 1)
+              hand#0,1
       9881    record (17 = 3 [0] + 13 + 1) [restart]
+              hands#0,1
       9898    record (13 = 3 [3] + 9 + 1)
+              hang#0,1
       9911    record (13 = 3 [2] + 9 + 1)
+              hap#0,1
       9924    record (16 = 3 [3] + 12 + 1)
+              happily#0,1
       9940    record (20 = 3 [2] + 16 + 1)
+              harbingers#0,1
       9960    record (13 = 3 [3] + 9 + 1)
+              hard#0,1
       9973    record (13 = 3 [4] + 9 + 1)
+              hardy#0,1
       9986    record (15 = 3 [3] + 11 + 1)
+              harrow#0,1
      10001    record (13 = 3 [6] + 9 + 1)
+              harrows#0,1
      10014    record (13 = 3 [2] + 9 + 1)
+              has#0,1
      10027    record (13 = 3 [3] + 9 + 1)
+              hast#0,1
      10040    record (13 = 3 [4] + 9 + 1)
+              haste#0,1
      10053    record (15 = 3 [2] + 11 + 1)
+              hatch#0,1
      10068    record (14 = 3 [3] + 9 + 2)
+              hath#0,1
      10082    record (15 = 3 [2] + 10 + 2)
+              have#0,1
      10097    record (15 = 3 [3] + 11 + 1)
+              havior#0,1
      10112    record (15 = 3 [0] + 10 + 2) [restart]
+              he#0,1
      10127    record (14 = 3 [2] + 10 + 1)
+              head#0,1
      10141    record (14 = 3 [4] + 10 + 1)
+              headed#0,1
      10155    record (17 = 3 [4] + 13 + 1)
+              headshake#0,1
      10172    [restart 8180]
      10176    [restart 8421]
      10180    [restart 8664]
@@ -805,133 +1453,261 @@ sstable layout
      10204    [restart 10112]
      10217  data (2042)
      10217    record (18 = 3 [0] + 14 + 1) [restart]
+              health#0,1
      10235    record (13 = 3 [3] + 9 + 1)
+              hear#0,1
      10248    record (13 = 3 [4] + 9 + 1)
+              heard#0,1
      10261    record (15 = 3 [4] + 11 + 1)
+              hearing#0,1
      10276    record (13 = 3 [4] + 9 + 1)
+              hears#0,1
      10289    record (14 = 3 [5] + 10 + 1)
+              hearsed#0,1
      10303    record (14 = 3 [4] + 9 + 2)
+              heart#0,1
      10317    record (15 = 3 [5] + 11 + 1)
+              heartily#0,1
      10332    record (13 = 3 [5] + 9 + 1)
+              hearts#0,1
      10345    record (13 = 3 [3] + 9 + 1)
+              heat#0,1
      10358    record (16 = 3 [3] + 11 + 2)
+              heaven#0,1
      10374    record (13 = 3 [6] + 9 + 1)
+              heavens#0,1
      10387    record (13 = 3 [4] + 9 + 1)
+              heavy#0,1
      10400    record (17 = 3 [2] + 13 + 1)
+              hebenon#0,1
      10417    record (16 = 3 [2] + 12 + 1)
+              height#0,1
      10433    record (14 = 3 [2] + 10 + 1)
+              held#0,1
      10447    record (16 = 3 [0] + 12 + 1) [restart]
+              hell#0,1
      10463    record (13 = 3 [3] + 9 + 1)
+              help#0,1
      10476    record (13 = 3 [2] + 9 + 1)
+              her#0,1
      10489    record (17 = 3 [3] + 13 + 1)
+              heraldry#0,1
      10506    record (17 = 3 [3] + 13 + 1)
+              hercules#0,1
      10523    record (14 = 3 [3] + 9 + 2)
+              here#0,1
      10537    record (17 = 3 [4] + 13 + 1)
+              hereafter#0,1
      10554    record (14 = 3 [4] + 10 + 1)
+              herein#0,1
      10568    record (14 = 3 [1] + 10 + 1)
+              hic#0,1
      10582    record (17 = 3 [2] + 13 + 1)
+              hideous#0,1
      10599    record (14 = 3 [2] + 10 + 1)
+              hies#0,1
      10613    record (14 = 3 [2] + 10 + 1)
+              high#0,1
      10627    record (14 = 3 [4] + 10 + 1)
+              higher#0,1
      10641    record (14 = 3 [2] + 10 + 1)
+              hill#0,1
      10655    record (13 = 3 [4] + 9 + 1)
+              hillo#0,1
      10668    record (14 = 3 [2] + 9 + 2)
+              him#0,1
      10682    record (19 = 3 [0] + 15 + 1) [restart]
+              himself#0,1
      10701    record (14 = 3 [2] + 9 + 2)
+              his#0,1
      10715    record (16 = 3 [2] + 12 + 1)
+              hither#0,1
      10731    record (14 = 3 [6] + 10 + 1)
+              hitherto#0,1
      10745    record (13 = 3 [1] + 9 + 1)
+              ho#0,1
      10758    record (14 = 3 [2] + 10 + 1)
+              hold#0,1
      10772    record (15 = 3 [4] + 11 + 1)
+              holding#0,1
      10787    record (13 = 3 [4] + 9 + 1)
+              holds#0,1
      10800    record (14 = 3 [3] + 10 + 1)
+              holla#0,1
      10814    record (13 = 3 [3] + 9 + 1)
+              holy#0,1
      10827    record (16 = 3 [2] + 12 + 1)
+              honest#0,1
      10843    record (15 = 3 [3] + 11 + 1)
+              honour#0,1
      10858    record (16 = 3 [6] + 12 + 1)
+              honourable#0,1
      10874    record (15 = 3 [2] + 11 + 1)
+              hoops#0,1
      10889    record (18 = 3 [2] + 13 + 2)
+              horatio#0,1
      10907    record (17 = 3 [3] + 13 + 1)
+              horrible#0,1
      10924    record (20 = 3 [0] + 16 + 1) [restart]
+              horridly#0,1
      10944    record (14 = 3 [2] + 10 + 1)
+              host#0,1
      10958    record (13 = 3 [2] + 9 + 1)
+              hot#0,1
      10971    record (14 = 3 [2] + 10 + 1)
+              hour#0,1
      10985    record (14 = 3 [3] + 10 + 1)
+              house#0,1
      10999    record (13 = 3 [2] + 9 + 1)
+              how#0,1
      11012    record (18 = 3 [3] + 14 + 1)
+              howsoever#0,1
      11030    record (17 = 3 [1] + 13 + 1)
+              humbly#0,1
      11047    record (17 = 3 [2] + 13 + 1)
+              hundred#0,1
      11064    record (19 = 3 [2] + 15 + 1)
+              husbandry#0,1
      11083    record (19 = 3 [1] + 15 + 1)
+              hyperion#0,1
      11102    record (15 = 3 [0] + 9 + 3)
+              i#0,1
      11117    record (14 = 3 [1] + 10 + 1)
+              ice#0,1
      11131    record (14 = 3 [1] + 9 + 2)
+              if#0,1
      11145    record (20 = 3 [1] + 16 + 1)
+              ignorance#0,1
      11165    record (13 = 3 [1] + 9 + 1)
+              ii#0,1
      11178    record (15 = 3 [0] + 11 + 1) [restart]
+              iii#0,1
      11193    record (17 = 3 [1] + 13 + 1)
+              illume#0,1
      11210    record (16 = 3 [4] + 12 + 1)
+              illusion#0,1
      11226    record (16 = 3 [1] + 12 + 1)
+              image#0,1
      11242    record (19 = 3 [4] + 15 + 1)
+              imagination#0,1
      11261    record (19 = 3 [2] + 15 + 1)
+              immediate#0,1
      11280    record (17 = 3 [3] + 13 + 1)
+              imminent#0,1
      11297    record (17 = 3 [3] + 13 + 1)
+              immortal#0,1
      11314    record (16 = 3 [2] + 12 + 1)
+              impart#0,1
      11330    record (16 = 3 [6] + 12 + 1)
+              impartment#0,1
      11346    record (17 = 3 [4] + 13 + 1)
+              impatient#0,1
      11363    record (22 = 3 [3] + 18 + 1)
+              imperfections#0,1
      11385    record (15 = 3 [5] + 11 + 1)
+              imperial#0,1
      11400    record (16 = 3 [3] + 12 + 1)
+              impious#0,1
      11416    record (19 = 3 [3] + 15 + 1)
+              implements#0,1
      11435    record (19 = 3 [4] + 15 + 1)
+              implorators#0,1
      11454    record (21 = 3 [0] + 17 + 1) [restart]
+              importing#0,1
      11475    record (16 = 3 [6] + 12 + 1)
+              importuned#0,1
      11491    record (15 = 3 [8] + 11 + 1)
+              importunity#0,1
      11506    record (16 = 3 [4] + 12 + 1)
+              impotent#0,1
      11522    record (16 = 3 [3] + 12 + 1)
+              impress#0,1
      11538    record (15 = 3 [1] + 9 + 3)
+              in#0,1
      11553    record (16 = 3 [2] + 12 + 1)
+              incest#0,1
      11569    record (16 = 3 [6] + 12 + 1)
+              incestuous#0,1
      11585    record (18 = 3 [3] + 14 + 1)
+              incorrect#0,1
      11603    record (17 = 3 [3] + 13 + 1)
+              increase#0,1
      11620    record (16 = 3 [2] + 12 + 1)
+              indeed#0,1
      11636    record (17 = 3 [2] + 13 + 1)
+              infants#0,1
      11653    record (17 = 3 [3] + 13 + 1)
+              infinite#0,1
      11670    record (18 = 3 [3] + 14 + 1)
+              influence#0,1
      11688    record (15 = 3 [3] + 11 + 1)
+              inform#0,1
      11703    record (21 = 3 [2] + 17 + 1)
+              inheritance#0,1
      11724    record (16 = 3 [0] + 12 + 1) [restart]
+              inky#0,1
      11740    record (17 = 3 [2] + 13 + 1)
+              instant#0,1
      11757    record (20 = 3 [4] + 16 + 1)
+              instrumental#0,1
      11777    record (16 = 3 [2] + 12 + 1)
+              intent#0,1
      11793    record (13 = 3 [6] + 9 + 1)
+              intents#0,1
      11806    record (13 = 3 [3] + 9 + 1)
+              into#0,1
      11819    record (15 = 3 [2] + 11 + 1)
+              inurn#0,1
      11834    record (21 = 3 [2] + 17 + 1)
+              investments#0,1
      11855    record (16 = 3 [3] + 12 + 1)
+              invites#0,1
      11871    record (21 = 3 [3] + 17 + 1)
+              invulnerable#0,1
      11892    record (16 = 3 [2] + 12 + 1)
+              inward#0,1
      11908    record (14 = 3 [1] + 9 + 2)
+              is#0,1
      11922    record (15 = 3 [2] + 11 + 1)
+              issue#0,1
      11937    record (15 = 3 [1] + 9 + 3)
+              it#0,1
      11952    record (13 = 3 [2] + 9 + 1)
+              its#0,1
      11965    record (15 = 3 [3] + 11 + 1)
+              itself#0,1
      11980    record (14 = 3 [0] + 10 + 1) [restart]
+              iv#0,1
      11994    record (16 = 3 [0] + 12 + 1)
+              jaws#0,1
      12010    record (16 = 3 [1] + 12 + 1)
+              jelly#0,1
      12026    record (17 = 3 [1] + 13 + 1)
+              jocund#0,1
      12043    record (15 = 3 [2] + 11 + 1)
+              joint#0,1
      12058    record (16 = 3 [5] + 12 + 1)
+              jointress#0,1
      12074    record (13 = 3 [2] + 9 + 1)
+              joy#0,1
      12087    record (19 = 3 [1] + 15 + 1)
+              judgment#0,1
      12106    record (15 = 3 [2] + 11 + 1)
+              juice#0,1
      12121    record (16 = 3 [2] + 12 + 1)
+              julius#0,1
      12137    record (14 = 3 [2] + 10 + 1)
+              jump#0,1
      12151    record (16 = 3 [0] + 12 + 1)
+              keep#0,1
      12167    record (13 = 3 [4] + 9 + 1)
+              keeps#0,1
      12180    record (14 = 3 [2] + 10 + 1)
+              kept#0,1
      12194    record (16 = 3 [2] + 12 + 1)
+              kettle#0,1
      12210    record (13 = 3 [2] + 9 + 1)
+              key#0,1
      12223    [restart 10217]
      12227    [restart 10447]
      12231    [restart 10682]
@@ -942,140 +1718,275 @@ sstable layout
      12251    [restart 11980]
      12264  data (2039)
      12264    record (15 = 3 [0] + 11 + 1) [restart]
+              kin#0,1
      12279    record (13 = 3 [3] + 9 + 1)
+              kind#0,1
      12292    record (14 = 3 [3] + 9 + 2)
+              king#0,1
      12306    record (15 = 3 [4] + 11 + 1)
+              kingdom#0,1
      12321    record (16 = 3 [1] + 12 + 1)
+              knave#0,1
      12337    record (14 = 3 [2] + 10 + 1)
+              knew#0,1
      12351    record (17 = 3 [2] + 13 + 1)
+              knotted#0,1
      12368    record (14 = 3 [3] + 9 + 2)
+              know#0,1
      12382    record (13 = 3 [4] + 9 + 1)
+              known#0,1
      12395    record (13 = 3 [4] + 9 + 1)
+              knows#0,1
      12408    record (20 = 3 [0] + 16 + 1)
+              labourer#0,1
      12428    record (16 = 3 [6] + 12 + 1)
+              laboursome#0,1
      12444    record (14 = 3 [2] + 10 + 1)
+              lack#0,1
      12458    record (13 = 3 [4] + 9 + 1)
+              lacks#0,1
      12471    record (18 = 3 [2] + 13 + 2)
+              laertes#0,1
      12489    record (14 = 3 [2] + 10 + 1)
+              land#0,1
      12503    record (17 = 3 [0] + 13 + 1) [restart]
+              lands#0,1
      12520    record (16 = 3 [2] + 12 + 1)
+              larger#0,1
      12536    record (14 = 3 [2] + 10 + 1)
+              last#0,1
      12550    record (15 = 3 [4] + 11 + 1)
+              lasting#0,1
      12565    record (14 = 3 [2] + 10 + 1)
+              late#0,1
      12579    record (13 = 3 [2] + 9 + 1)
+              law#0,1
      12592    record (16 = 3 [3] + 12 + 1)
+              lawless#0,1
      12608    record (13 = 3 [2] + 9 + 1)
+              lay#0,1
      12621    record (15 = 3 [2] + 11 + 1)
+              lazar#0,1
      12636    record (15 = 3 [1] + 11 + 1)
+              lead#0,1
      12651    record (14 = 3 [3] + 10 + 1)
+              least#0,1
      12665    record (14 = 3 [3] + 10 + 1)
+              leave#0,1
      12679    record (14 = 3 [5] + 10 + 1)
+              leavens#0,1
      12693    record (14 = 3 [2] + 10 + 1)
+              left#0,1
      12707    record (17 = 3 [2] + 13 + 1)
+              leisure#0,1
      12724    record (14 = 3 [2] + 10 + 1)
+              lend#0,1
      12738    record (18 = 3 [0] + 14 + 1) [restart]
+              lender#0,1
      12756    record (13 = 3 [4] + 9 + 1)
+              lends#0,1
      12769    record (15 = 3 [3] + 11 + 1)
+              length#0,1
      12784    record (18 = 3 [2] + 14 + 1)
+              leperous#0,1
      12802    record (14 = 3 [2] + 10 + 1)
+              less#0,1
      12816    record (14 = 3 [4] + 10 + 1)
+              lesson#0,1
      12830    record (14 = 3 [2] + 9 + 2)
+              let#0,1
      12844    record (14 = 3 [3] + 10 + 1)
+              lethe#0,1
      12858    record (13 = 3 [3] + 9 + 1)
+              lets#0,1
      12871    record (16 = 3 [2] + 12 + 1)
+              levies#0,1
      12887    record (18 = 3 [2] + 14 + 1)
+              lewdness#0,1
      12905    record (20 = 3 [1] + 16 + 1)
+              libertine#0,1
      12925    record (14 = 3 [2] + 10 + 1)
+              lids#0,1
      12939    record (18 = 3 [2] + 14 + 1)
+              liegemen#0,1
      12957    record (13 = 3 [3] + 9 + 1)
+              lies#0,1
      12970    record (14 = 3 [2] + 10 + 1)
+              life#0,1
      12984    record (18 = 3 [0] + 14 + 1) [restart]
+              lifted#0,1
      13002    record (15 = 3 [2] + 11 + 1)
+              light#0,1
      13017    record (15 = 3 [5] + 11 + 1)
+              lightest#0,1
      13032    record (15 = 3 [2] + 10 + 2)
+              like#0,1
      13047    record (14 = 3 [2] + 10 + 1)
+              link#0,1
      13061    record (14 = 3 [2] + 10 + 1)
+              lion#0,1
      13075    record (14 = 3 [2] + 10 + 1)
+              lips#0,1
      13089    record (16 = 3 [2] + 12 + 1)
+              liquid#0,1
      13105    record (14 = 3 [2] + 10 + 1)
+              list#0,1
      13119    record (13 = 3 [4] + 9 + 1)
+              lists#0,1
      13132    record (16 = 3 [2] + 12 + 1)
+              little#0,1
      13148    record (14 = 3 [2] + 10 + 1)
+              live#0,1
      13162    record (14 = 3 [4] + 10 + 1)
+              livery#0,1
      13176    record (13 = 3 [4] + 9 + 1)
+              lives#0,1
      13189    record (14 = 3 [1] + 9 + 2)
+              ll#0,1
      13203    record (13 = 3 [1] + 9 + 1)
+              lo#0,1
      13216    record (16 = 3 [0] + 12 + 1) [restart]
+              loan#0,1
      13232    record (18 = 3 [3] + 14 + 1)
+              loathsome#0,1
      13250    record (14 = 3 [2] + 10 + 1)
+              lock#0,1
      13264    record (13 = 3 [4] + 9 + 1)
+              locks#0,1
      13277    record (15 = 3 [2] + 11 + 1)
+              lodge#0,1
      13292    record (15 = 3 [2] + 11 + 1)
+              lofty#0,1
      13307    record (14 = 3 [2] + 10 + 1)
+              long#0,1
      13321    record (14 = 3 [4] + 10 + 1)
+              longer#0,1
      13335    record (15 = 3 [2] + 10 + 2)
+              look#0,1
      13350    record (13 = 3 [4] + 9 + 1)
+              looks#0,1
      13363    record (14 = 3 [3] + 10 + 1)
+              loose#0,1
      13377    record (15 = 3 [2] + 10 + 2)
+              lord#0,1
      13392    record (13 = 3 [4] + 9 + 1)
+              lords#0,1
      13405    record (15 = 3 [5] + 11 + 1)
+              lordship#0,1
      13420    record (14 = 3 [2] + 10 + 1)
+              lose#0,1
      13434    record (13 = 3 [4] + 9 + 1)
+              loses#0,1
      13447    record (16 = 3 [0] + 12 + 1) [restart]
+              loss#0,1
      13463    record (13 = 3 [3] + 9 + 1)
+              lost#0,1
      13476    record (14 = 3 [2] + 10 + 1)
+              loud#0,1
      13490    record (14 = 3 [2] + 10 + 1)
+              love#0,1
      13504    record (13 = 3 [4] + 9 + 1)
+              loves#0,1
      13517    record (15 = 3 [3] + 11 + 1)
+              loving#0,1
      13532    record (15 = 3 [1] + 11 + 1)
+              lust#0,1
      13547    record (16 = 3 [2] + 12 + 1)
+              luxury#0,1
      13563    record (13 = 3 [0] + 9 + 1)
+              m#0,1
      13576    record (16 = 3 [1] + 12 + 1)
+              madam#0,1
      13592    record (13 = 3 [3] + 9 + 1)
+              made#0,1
      13605    record (16 = 3 [3] + 12 + 1)
+              madness#0,1
      13621    record (14 = 3 [2] + 10 + 1)
+              maid#0,1
      13635    record (14 = 3 [4] + 10 + 1)
+              maiden#0,1
      13649    record (13 = 3 [3] + 9 + 1)
+              main#0,1
      13662    record (20 = 3 [2] + 16 + 1)
+              majestical#0,1
      13682    record (19 = 3 [0] + 15 + 1) [restart]
+              majesty#0,1
      13701    record (14 = 3 [2] + 10 + 1)
+              make#0,1
      13715    record (13 = 3 [4] + 9 + 1)
+              makes#0,1
      13728    record (15 = 3 [3] + 11 + 1)
+              making#0,1
      13743    record (19 = 3 [2] + 15 + 1)
+              malicious#0,1
      13762    record (14 = 3 [2] + 9 + 2)
+              man#0,1
      13776    record (15 = 3 [3] + 11 + 1)
+              manner#0,1
      13791    record (13 = 3 [6] + 9 + 1)
+              manners#0,1
      13804    record (15 = 3 [3] + 11 + 1)
+              mantle#0,1
      13819    record (13 = 3 [3] + 9 + 1)
+              many#0,1
      13832    record (16 = 3 [2] + 12 + 1)
+              marble#0,1
      13848    record (19 = 3 [3] + 14 + 2)
+              marcellus#0,1
      13867    record (13 = 3 [4] + 9 + 1)
+              march#0,1
      13880    record (13 = 3 [3] + 9 + 1)
+              mark#0,1
      13893    record (17 = 3 [3] + 13 + 1)
+              marriage#0,1
      13910    record (14 = 3 [5] + 10 + 1)
+              married#0,1
      13924    record (18 = 3 [0] + 14 + 1) [restart]
+              marrow#0,1
      13942    record (13 = 3 [4] + 9 + 1)
+              marry#0,1
      13955    record (13 = 3 [3] + 9 + 1)
+              mart#0,1
      13968    record (15 = 3 [4] + 11 + 1)
+              martial#0,1
      13983    record (15 = 3 [3] + 11 + 1)
+              marvel#0,1
      13998    record (15 = 3 [2] + 11 + 1)
+              matin#0,1
      14013    record (15 = 3 [3] + 11 + 1)
+              matter#0,1
      14028    record (14 = 3 [2] + 9 + 2)
+              may#0,1
      14042    record (14 = 3 [1] + 9 + 2)
+              me#0,1
      14056    record (14 = 3 [2] + 10 + 1)
+              mean#0,1
      14070    record (13 = 3 [4] + 9 + 1)
+              means#0,1
      14083    record (14 = 3 [3] + 10 + 1)
+              meats#0,1
      14097    record (20 = 3 [2] + 16 + 1)
+              meditation#0,1
      14117    record (14 = 3 [2] + 10 + 1)
+              meet#0,1
      14131    record (15 = 3 [4] + 11 + 1)
+              meeting#0,1
      14146    record (14 = 3 [2] + 10 + 1)
+              melt#0,1
      14160    record (18 = 3 [0] + 14 + 1) [restart]
+              memory#0,1
      14178    record (13 = 3 [2] + 9 + 1)
+              men#0,1
      14191    record (15 = 3 [2] + 11 + 1)
+              mercy#0,1
      14206    record (13 = 3 [3] + 9 + 1)
+              mere#0,1
      14219    record (14 = 3 [4] + 10 + 1)
+              merely#0,1
      14233    record (17 = 3 [2] + 13 + 1)
+              message#0,1
      14250    record (13 = 3 [2] + 9 + 1)
+              met#0,1
      14263    [restart 12264]
      14267    [restart 12503]
      14271    [restart 12738]
@@ -1087,136 +1998,267 @@ sstable layout
      14295    [restart 14160]
      14308  data (2037)
      14308    record (20 = 3 [0] + 16 + 1) [restart]
+              methinks#0,1
      14328    record (17 = 3 [4] + 13 + 1)
+              methought#0,1
      14345    record (15 = 3 [3] + 11 + 1)
+              mettle#0,1
      14360    record (17 = 3 [1] + 13 + 1)
+              middle#0,1
      14377    record (15 = 3 [2] + 11 + 1)
+              might#0,1
      14392    record (16 = 3 [5] + 12 + 1)
+              mightiest#0,1
      14408    record (14 = 3 [2] + 10 + 1)
+              milk#0,1
      14422    record (14 = 3 [2] + 10 + 1)
+              mind#0,1
      14436    record (13 = 3 [3] + 9 + 1)
+              mine#0,1
      14449    record (18 = 3 [3] + 14 + 1)
+              ministers#0,1
      14467    record (15 = 3 [3] + 11 + 1)
+              minute#0,1
      14482    record (13 = 3 [6] + 9 + 1)
+              minutes#0,1
      14495    record (15 = 3 [2] + 11 + 1)
+              mirth#0,1
      14510    record (15 = 3 [1] + 11 + 1)
+              mock#0,1
      14525    record (15 = 3 [4] + 11 + 1)
+              mockery#0,1
      14540    record (18 = 3 [2] + 14 + 1)
+              moderate#0,1
      14558    record (18 = 3 [0] + 14 + 1) [restart]
+              moiety#0,1
      14576    record (14 = 3 [3] + 10 + 1)
+              moist#0,1
      14590    record (14 = 3 [2] + 10 + 1)
+              mole#0,1
      14604    record (16 = 3 [2] + 12 + 1)
+              moment#0,1
      14620    record (15 = 3 [2] + 11 + 1)
+              month#0,1
      14635    record (13 = 3 [5] + 9 + 1)
+              months#0,1
      14648    record (15 = 3 [2] + 11 + 1)
+              moods#0,1
      14663    record (13 = 3 [3] + 9 + 1)
+              moon#0,1
      14676    record (15 = 3 [2] + 10 + 2)
+              more#0,1
      14691    record (13 = 3 [3] + 9 + 1)
+              morn#0,1
      14704    record (15 = 3 [4] + 11 + 1)
+              morning#0,1
      14719    record (15 = 3 [2] + 10 + 2)
+              most#0,1
      14734    record (14 = 3 [2] + 10 + 1)
+              mote#0,1
      14748    record (15 = 3 [3] + 11 + 1)
+              mother#0,1
      14763    record (15 = 3 [3] + 11 + 1)
+              motion#0,1
      14778    record (14 = 3 [4] + 10 + 1)
+              motive#0,1
      14792    record (17 = 3 [0] + 13 + 1) [restart]
+              mourn#0,1
      14809    record (15 = 3 [5] + 11 + 1)
+              mourning#0,1
      14824    record (14 = 3 [3] + 10 + 1)
+              mouse#0,1
      14838    record (14 = 3 [3] + 10 + 1)
+              mouth#0,1
      14852    record (15 = 3 [2] + 11 + 1)
+              moved#0,1
      14867    record (15 = 3 [1] + 11 + 1)
+              much#0,1
      14882    record (16 = 3 [2] + 12 + 1)
+              murder#0,1
      14898    record (15 = 3 [2] + 10 + 2)
+              must#0,1
      14913    record (15 = 3 [1] + 9 + 3)
+              my#0,1
      14928    record (16 = 3 [2] + 12 + 1)
+              myself#0,1
      14944    record (16 = 3 [0] + 12 + 1)
+              name#0,1
      14960    record (17 = 3 [2] + 13 + 1)
+              nations#0,1
      14977    record (14 = 3 [4] + 10 + 1)
+              native#0,1
      14991    record (16 = 3 [3] + 12 + 1)
+              natural#0,1
      15007    record (14 = 3 [5] + 9 + 2)
+              nature#0,1
      15021    record (13 = 3 [2] + 9 + 1)
+              nay#0,1
      15034    record (14 = 3 [0] + 10 + 1) [restart]
+              ne#0,1
      15048    record (14 = 3 [2] + 10 + 1)
+              near#0,1
      15062    record (21 = 3 [2] + 17 + 1)
+              necessaries#0,1
      15083    record (14 = 3 [2] + 10 + 1)
+              need#0,1
      15097    record (15 = 3 [4] + 11 + 1)
+              needful#0,1
      15112    record (13 = 3 [4] + 9 + 1)
+              needs#0,1
      15125    record (17 = 3 [2] + 13 + 1)
+              neither#0,1
      15142    record (16 = 3 [2] + 12 + 1)
+              nemean#0,1
      15158    record (16 = 3 [2] + 12 + 1)
+              nephew#0,1
      15174    record (16 = 3 [3] + 12 + 1)
+              neptune#0,1
      15190    record (15 = 3 [2] + 11 + 1)
+              nerve#0,1
      15205    record (15 = 3 [2] + 11 + 1)
+              never#0,1
      15220    record (13 = 3 [2] + 9 + 1)
+              new#0,1
      15233    record (13 = 3 [3] + 9 + 1)
+              news#0,1
      15246    record (17 = 3 [1] + 12 + 2)
+              night#0,1
      15263    record (14 = 3 [5] + 10 + 1)
+              nighted#0,1
      15277    record (19 = 3 [0] + 15 + 1) [restart]
+              nightly#0,1
      15296    record (13 = 3 [5] + 9 + 1)
+              nights#0,1
      15309    record (15 = 3 [2] + 11 + 1)
+              niobe#0,1
      15324    record (17 = 3 [2] + 13 + 1)
+              nipping#0,1
      15341    record (14 = 3 [1] + 9 + 2)
+              no#0,1
      15355    record (18 = 3 [2] + 14 + 1)
+              nobility#0,1
      15373    record (14 = 3 [3] + 10 + 1)
+              noble#0,1
      15387    record (14 = 3 [2] + 10 + 1)
+              none#0,1
      15401    record (14 = 3 [2] + 9 + 2)
+              nor#0,1
      15415    record (15 = 3 [3] + 11 + 1)
+              norway#0,1
      15430    record (14 = 3 [2] + 9 + 2)
+              not#0,1
      15444    record (13 = 3 [3] + 9 + 1)
+              note#0,1
      15457    record (16 = 3 [3] + 12 + 1)
+              nothing#0,1
      15473    record (14 = 3 [2] + 9 + 2)
+              now#0,1
      15487    record (14 = 3 [0] + 9 + 2)
+              o#0,1
      15501    record (15 = 3 [1] + 11 + 1)
+              oath#0,1
      15516    record (16 = 3 [0] + 12 + 1) [restart]
+              obey#0,1
      15532    record (16 = 3 [2] + 12 + 1)
+              object#0,1
      15548    record (20 = 3 [2] + 16 + 1)
+              obligation#0,1
      15568    record (20 = 3 [2] + 16 + 1)
+              obsequious#0,1
      15588    record (18 = 3 [4] + 14 + 1)
+              observance#0,1
      15606    record (13 = 3 [8] + 9 + 1)
+              observant#0,1
      15619    record (16 = 3 [7] + 12 + 1)
+              observation#0,1
      15635    record (18 = 3 [3] + 14 + 1)
+              obstinate#0,1
      15653    record (19 = 3 [1] + 15 + 1)
+              occasion#0,1
      15672    record (14 = 3 [1] + 10 + 1)
+              odd#0,1
      15686    record (15 = 3 [1] + 9 + 3)
+              of#0,1
      15701    record (13 = 3 [2] + 9 + 1)
+              off#0,1
      15714    record (16 = 3 [3] + 12 + 1)
+              offence#0,1
      15730    record (13 = 3 [5] + 9 + 1)
+              offend#0,1
      15743    record (14 = 3 [6] + 10 + 1)
+              offended#0,1
      15757    record (13 = 3 [4] + 9 + 1)
+              offer#0,1
      15770    record (15 = 3 [0] + 11 + 1) [restart]
+              oft#0,1
      15785    record (14 = 3 [1] + 10 + 1)
+              old#0,1
      15799    record (15 = 3 [1] + 11 + 1)
+              omen#0,1
      15814    record (14 = 3 [1] + 9 + 2)
+              on#0,1
      15828    record (14 = 3 [2] + 10 + 1)
+              once#0,1
      15842    record (13 = 3 [2] + 9 + 1)
+              one#0,1
      15855    record (15 = 3 [1] + 11 + 1)
+              oped#0,1
      15870    record (13 = 3 [3] + 9 + 1)
+              open#0,1
      15883    record (18 = 3 [2] + 13 + 2)
+              ophelia#0,1
      15901    record (17 = 3 [2] + 13 + 1)
+              opinion#0,1
      15918    record (17 = 3 [2] + 13 + 1)
+              opposed#0,1
      15935    record (17 = 3 [5] + 13 + 1)
+              opposition#0,1
      15952    record (16 = 3 [3] + 12 + 1)
+              oppress#0,1
      15968    record (14 = 3 [1] + 9 + 2)
+              or#0,1
      15982    record (17 = 3 [2] + 13 + 1)
+              orchard#0,1
      15999    record (18 = 3 [2] + 14 + 1)
+              ordnance#0,1
      16017    record (18 = 3 [0] + 14 + 1) [restart]
+              origin#0,1
      16035    record (16 = 3 [1] + 12 + 1)
+              other#0,1
      16051    record (15 = 3 [1] + 10 + 2)
+              our#0,1
      16066    record (16 = 3 [3] + 12 + 1)
+              ourself#0,1
      16082    record (15 = 3 [6] + 11 + 1)
+              ourselves#0,1
      16097    record (13 = 3 [2] + 9 + 1)
+              out#0,1
      16110    record (14 = 3 [1] + 10 + 1)
+              own#0,1
      16124    record (16 = 3 [3] + 12 + 1)
+              ownself#0,1
      16140    record (16 = 3 [0] + 12 + 1)
+              pale#0,1
      16156    record (13 = 3 [4] + 9 + 1)
+              pales#0,1
      16169    record (13 = 3 [3] + 9 + 1)
+              palm#0,1
      16182    record (13 = 3 [4] + 9 + 1)
+              palmy#0,1
      16195    record (16 = 3 [2] + 12 + 1)
+              pardon#0,1
      16211    record (14 = 3 [3] + 10 + 1)
+              parle#0,1
      16225    record (13 = 3 [5] + 9 + 1)
+              parley#0,1
      16238    record (13 = 3 [3] + 9 + 1)
+              part#0,1
      16251    record (22 = 3 [0] + 18 + 1) [restart]
+              particular#0,1
      16273    record (15 = 3 [5] + 11 + 1)
+              partisan#0,1
      16288    record (17 = 3 [2] + 13 + 1)
+              passeth#0,1
      16305    [restart 14308]
      16309    [restart 14558]
      16313    [restart 14792]
@@ -1228,131 +2270,257 @@ sstable layout
      16337    [restart 16251]
      16350  data (2029)
      16350    record (19 = 3 [0] + 15 + 1) [restart]
+              passing#0,1
      16369    record (13 = 3 [3] + 9 + 1)
+              past#0,1
      16382    record (15 = 3 [4] + 11 + 1)
+              pastors#0,1
      16397    record (14 = 3 [2] + 10 + 1)
+              path#0,1
      16411    record (16 = 3 [3] + 12 + 1)
+              patrick#0,1
      16427    record (13 = 3 [2] + 9 + 1)
+              pay#0,1
      16440    record (13 = 3 [1] + 9 + 1)
+              pe#0,1
      16453    record (15 = 3 [2] + 11 + 1)
+              peace#0,1
      16468    record (17 = 3 [2] + 13 + 1)
+              peevish#0,1
      16485    record (19 = 3 [2] + 15 + 1)
+              perchance#0,1
      16504    record (16 = 3 [3] + 12 + 1)
+              perform#0,1
      16520    record (15 = 3 [4] + 11 + 1)
+              perfume#0,1
      16535    record (16 = 3 [3] + 12 + 1)
+              perhaps#0,1
      16551    record (17 = 3 [3] + 13 + 1)
+              perilous#0,1
      16568    record (18 = 3 [3] + 14 + 1)
+              permanent#0,1
      16586    record (19 = 3 [3] + 15 + 1)
+              pernicious#0,1
      16605    record (20 = 3 [0] + 16 + 1) [restart]
+              persever#0,1
      16625    record (14 = 3 [4] + 10 + 1)
+              person#0,1
      16639    record (14 = 3 [6] + 10 + 1)
+              personal#0,1
      16653    record (13 = 3 [6] + 9 + 1)
+              persons#0,1
      16666    record (18 = 3 [3] + 14 + 1)
+              perturbed#0,1
      16684    record (16 = 3 [2] + 12 + 1)
+              pester#0,1
      16700    record (18 = 3 [2] + 14 + 1)
+              petition#0,1
      16718    record (14 = 3 [3] + 10 + 1)
+              petty#0,1
      16732    record (21 = 3 [1] + 17 + 1)
+              philosophy#0,1
      16753    record (16 = 3 [2] + 12 + 1)
+              phrase#0,1
      16769    record (16 = 3 [1] + 12 + 1)
+              piece#0,1
      16785    record (13 = 3 [2] + 9 + 1)
+              pin#0,1
      16798    record (16 = 3 [2] + 12 + 1)
+              pioner#0,1
      16814    record (14 = 3 [3] + 10 + 1)
+              pious#0,1
      16828    record (14 = 3 [2] + 10 + 1)
+              pith#0,1
      16842    record (13 = 3 [3] + 9 + 1)
+              pity#0,1
      16855    record (17 = 3 [0] + 13 + 1) [restart]
+              place#0,1
      16872    record (14 = 3 [3] + 10 + 1)
+              plain#0,1
      16886    record (16 = 3 [3] + 12 + 1)
+              planets#0,1
      16902    record (17 = 3 [3] + 13 + 1)
+              platform#0,1
      16919    record (17 = 3 [3] + 13 + 1)
+              plausive#0,1
      16936    record (13 = 3 [3] + 9 + 1)
+              play#0,1
      16949    record (16 = 3 [2] + 12 + 1)
+              please#0,1
      16965    record (15 = 3 [3] + 11 + 1)
+              pledge#0,1
      16980    record (16 = 3 [1] + 12 + 1)
+              point#0,1
      16996    record (17 = 3 [2] + 13 + 1)
+              polacks#0,1
      17013    record (13 = 3 [3] + 9 + 1)
+              pole#0,1
      17026    record (18 = 3 [3] + 13 + 2)
+              polonius#0,1
      17044    record (19 = 3 [2] + 15 + 1)
+              ponderous#0,1
      17063    record (14 = 3 [2] + 10 + 1)
+              pooh#0,1
      17077    record (13 = 3 [3] + 9 + 1)
+              poor#0,1
      17090    record (17 = 3 [2] + 13 + 1)
+              porches#0,1
      17107    record (22 = 3 [0] + 18 + 1) [restart]
+              porpentine#0,1
      17129    record (19 = 3 [3] + 15 + 1)
+              portentous#0,1
      17148    record (17 = 3 [2] + 13 + 1)
+              possess#0,1
      17165    record (13 = 3 [5] + 9 + 1)
+              posset#0,1
      17178    record (13 = 3 [3] + 9 + 1)
+              post#0,1
      17191    record (14 = 3 [2] + 10 + 1)
+              pour#0,1
      17205    record (15 = 3 [2] + 11 + 1)
+              power#0,1
      17220    record (15 = 3 [1] + 11 + 1)
+              pray#0,1
      17235    record (15 = 3 [4] + 11 + 1)
+              prayers#0,1
      17250    record (19 = 3 [2] + 15 + 1)
+              preceding#0,1
      17269    record (15 = 3 [5] + 11 + 1)
+              precepts#0,1
      17284    record (16 = 3 [4] + 12 + 1)
+              precurse#0,1
      17300    record (21 = 3 [3] + 17 + 1)
+              preparations#0,1
      17321    record (17 = 3 [3] + 13 + 1)
+              presence#0,1
      17338    record (13 = 3 [6] + 9 + 1)
+              present#0,1
      17351    record (17 = 3 [4] + 13 + 1)
+              pressures#0,1
      17368    record (16 = 3 [0] + 12 + 1) [restart]
+              prey#0,1
      17384    record (15 = 3 [2] + 11 + 1)
+              prick#0,1
      17399    record (14 = 3 [3] + 10 + 1)
+              pride#0,1
      17413    record (17 = 3 [3] + 13 + 1)
+              primrose#0,1
      17430    record (13 = 3 [4] + 9 + 1)
+              primy#0,1
      17443    record (15 = 3 [3] + 11 + 1)
+              prince#0,1
      17458    record (15 = 3 [3] + 11 + 1)
+              prison#0,1
      17473    record (16 = 3 [3] + 12 + 1)
+              private#0,1
      17489    record (13 = 3 [4] + 9 + 1)
+              privy#0,1
      17502    record (19 = 3 [2] + 15 + 1)
+              probation#0,1
      17521    record (16 = 3 [3] + 12 + 1)
+              process#0,1
      17537    record (17 = 3 [4] + 13 + 1)
+              proclaims#0,1
      17554    record (17 = 3 [3] + 13 + 1)
+              prodigal#0,1
      17571    record (17 = 3 [3] + 13 + 1)
+              prologue#0,1
      17588    record (16 = 3 [3] + 12 + 1)
+              promise#0,1
      17604    record (20 = 3 [3] + 16 + 1)
+              pronouncing#0,1
      17624    record (21 = 3 [0] + 17 + 1) [restart]
+              prophetic#0,1
      17645    record (19 = 3 [4] + 15 + 1)
+              proportions#0,1
      17664    record (14 = 3 [5] + 10 + 1)
+              propose#0,1
      17678    record (15 = 3 [1] + 11 + 1)
+              puff#0,1
      17693    record (14 = 3 [2] + 10 + 1)
+              pure#0,1
      17707    record (15 = 3 [3] + 11 + 1)
+              purged#0,1
      17722    record (16 = 3 [3] + 12 + 1)
+              purpose#0,1
      17738    record (14 = 3 [3] + 10 + 1)
+              purse#0,1
      17752    record (16 = 3 [4] + 12 + 1)
+              pursuest#0,1
      17768    record (13 = 3 [2] + 9 + 1)
+              put#0,1
      17781    record (13 = 3 [3] + 9 + 1)
+              puts#0,1
      17794    record (19 = 3 [0] + 15 + 1)
+              quarrel#0,1
      17813    record (15 = 3 [2] + 11 + 1)
+              queen#0,1
      17828    record (17 = 3 [3] + 13 + 1)
+              question#0,1
      17845    record (16 = 3 [8] + 12 + 1)
+              questionable#0,1
      17861    record (21 = 3 [2] + 17 + 1)
+              quicksilver#0,1
      17882    record (17 = 3 [0] + 13 + 1) [restart]
+              quiet#0,1
      17899    record (14 = 3 [5] + 10 + 1)
+              quietly#0,1
      17913    record (15 = 3 [3] + 11 + 1)
+              quills#0,1
      17928    record (19 = 3 [0] + 15 + 1)
+              radiant#0,1
      17947    record (14 = 3 [2] + 10 + 1)
+              rank#0,1
      17961    record (14 = 3 [4] + 10 + 1)
+              rankly#0,1
      17975    record (14 = 3 [2] + 10 + 1)
+              rate#0,1
      17989    record (17 = 3 [3] + 13 + 1)
+              ratified#0,1
      18006    record (13 = 3 [1] + 9 + 1)
+              re#0,1
      18019    record (17 = 3 [2] + 13 + 1)
+              reaches#0,1
      18036    record (13 = 3 [3] + 9 + 1)
+              rear#0,1
      18049    record (15 = 3 [3] + 11 + 1)
+              reason#0,1
      18064    record (16 = 3 [2] + 12 + 1)
+              rebels#0,1
      18080    record (18 = 3 [2] + 14 + 1)
+              reckless#0,1
      18098    record (17 = 3 [4] + 13 + 1)
+              reckoning#0,1
      18115    record (13 = 3 [4] + 9 + 1)
+              recks#0,1
      18128    record (19 = 3 [0] + 15 + 1) [restart]
+              records#0,1
      18147    record (15 = 3 [4] + 11 + 1)
+              recover#0,1
      18162    record (13 = 3 [2] + 9 + 1)
+              red#0,1
      18175    record (13 = 3 [3] + 9 + 1)
+              rede#0,1
      18188    record (15 = 3 [2] + 11 + 1)
+              reels#0,1
      18203    record (16 = 3 [2] + 12 + 1)
+              relief#0,1
      18219    record (15 = 3 [5] + 11 + 1)
+              relieved#0,1
      18234    record (16 = 3 [2] + 12 + 1)
+              remain#0,1
      18250    record (17 = 3 [3] + 13 + 1)
+              remember#0,1
      18267    record (17 = 3 [6] + 13 + 1)
+              remembrance#0,1
      18284    record (15 = 3 [3] + 11 + 1)
+              remove#0,1
      18299    record (13 = 3 [6] + 9 + 1)
+              removed#0,1
      18312    record (16 = 3 [2] + 12 + 1)
+              render#0,1
      18328    record (15 = 3 [2] + 11 + 1)
+              reply#0,1
      18343    [restart 16350]
      18347    [restart 16605]
      18351    [restart 16855]
@@ -1363,138 +2531,271 @@ sstable layout
      18371    [restart 18128]
      18384  data (2040)
      18384    record (18 = 3 [0] + 14 + 1) [restart]
+              report#0,1
      18402    record (17 = 3 [2] + 13 + 1)
+              request#0,1
      18419    record (15 = 3 [4] + 11 + 1)
+              requite#0,1
      18434    record (17 = 3 [2] + 13 + 1)
+              reserve#0,1
      18451    record (18 = 3 [3] + 14 + 1)
+              resolutes#0,1
      18469    record (14 = 3 [5] + 10 + 1)
+              resolve#0,1
      18483    record (13 = 3 [3] + 9 + 1)
+              rest#0,1
      18496    record (20 = 3 [2] + 16 + 1)
+              retrograde#0,1
      18516    record (15 = 3 [3] + 11 + 1)
+              return#0,1
      18531    record (16 = 3 [2] + 12 + 1)
+              reveal#0,1
      18547    record (13 = 3 [4] + 9 + 1)
+              revel#0,1
      18560    record (15 = 3 [4] + 11 + 1)
+              revenge#0,1
      18575    record (16 = 3 [3] + 12 + 1)
+              revisit#0,1
      18591    record (18 = 3 [1] + 14 + 1)
+              rhenish#0,1
      18609    record (15 = 3 [1] + 11 + 1)
+              rich#0,1
      18624    record (13 = 3 [2] + 9 + 1)
+              rid#0,1
      18637    record (17 = 3 [0] + 13 + 1) [restart]
+              right#0,1
      18654    record (14 = 3 [2] + 10 + 1)
+              rise#0,1
      18668    record (16 = 3 [2] + 12 + 1)
+              rivals#0,1
      18684    record (14 = 3 [3] + 10 + 1)
+              river#0,1
      18698    record (15 = 3 [1] + 11 + 1)
+              roar#0,1
      18713    record (16 = 3 [2] + 12 + 1)
+              romage#0,1
      18729    record (13 = 3 [4] + 9 + 1)
+              roman#0,1
      18742    record (13 = 3 [3] + 9 + 1)
+              rome#0,1
      18755    record (14 = 3 [2] + 10 + 1)
+              room#0,1
      18769    record (14 = 3 [3] + 10 + 1)
+              roots#0,1
      18783    record (16 = 3 [2] + 12 + 1)
+              rotten#0,1
      18799    record (17 = 3 [2] + 13 + 1)
+              roughly#0,1
      18816    record (14 = 3 [3] + 10 + 1)
+              rouse#0,1
      18830    record (15 = 3 [2] + 11 + 1)
+              royal#0,1
      18845    record (16 = 3 [1] + 12 + 1)
+              ruled#0,1
      18861    record (17 = 3 [2] + 13 + 1)
+              running#0,1
      18878    record (18 = 3 [0] + 14 + 1) [restart]
+              russet#0,1
      18896    record (14 = 3 [0] + 9 + 2)
+              s#0,1
      18910    record (16 = 3 [1] + 12 + 1)
+              sable#0,1
      18926    record (16 = 3 [2] + 12 + 1)
+              safety#0,1
      18942    record (14 = 3 [2] + 10 + 1)
+              said#0,1
      18956    record (13 = 3 [3] + 9 + 1)
+              sail#0,1
      18969    record (14 = 3 [3] + 10 + 1)
+              saint#0,1
      18983    record (14 = 3 [2] + 10 + 1)
+              salt#0,1
      18997    record (14 = 3 [2] + 10 + 1)
+              same#0,1
      19011    record (20 = 3 [2] + 16 + 1)
+              sanctified#0,1
      19031    record (14 = 3 [2] + 10 + 1)
+              sate#0,1
      19045    record (14 = 3 [3] + 10 + 1)
+              satyr#0,1
      19059    record (17 = 3 [2] + 13 + 1)
+              saviour#0,1
      19076    record (13 = 3 [2] + 9 + 1)
+              saw#0,1
      19089    record (13 = 3 [3] + 9 + 1)
+              saws#0,1
      19102    record (14 = 3 [2] + 9 + 2)
+              say#0,1
      19116    record (18 = 3 [0] + 14 + 1) [restart]
+              saying#0,1
      19134    record (13 = 3 [3] + 9 + 1)
+              says#0,1
      19147    record (16 = 3 [1] + 12 + 1)
+              scale#0,1
      19163    record (16 = 3 [3] + 12 + 1)
+              scandal#0,1
      19179    record (15 = 3 [4] + 11 + 1)
+              scanter#0,1
      19194    record (15 = 3 [3] + 11 + 1)
+              scapes#0,1
      19209    record (17 = 3 [3] + 13 + 1)
+              scarcely#0,1
      19226    record (15 = 3 [2] + 11 + 1)
+              scene#0,1
      19241    record (13 = 3 [4] + 9 + 1)
+              scent#0,1
      19254    record (17 = 3 [2] + 13 + 1)
+              scholar#0,1
      19271    record (13 = 3 [7] + 9 + 1)
+              scholars#0,1
      19284    record (14 = 3 [4] + 10 + 1)
+              school#0,1
      19298    record (15 = 3 [2] + 11 + 1)
+              scope#0,1
      19313    record (14 = 3 [1] + 10 + 1)
+              sea#0,1
      19327    record (13 = 3 [3] + 9 + 1)
+              seal#0,1
      19340    record (15 = 3 [3] + 11 + 1)
+              season#0,1
      19355    record (16 = 3 [0] + 12 + 1) [restart]
+              seat#0,1
      19371    record (16 = 3 [2] + 12 + 1)
+              second#0,1
      19387    record (16 = 3 [3] + 12 + 1)
+              secrecy#0,1
      19403    record (13 = 3 [5] + 9 + 1)
+              secret#0,1
      19416    record (13 = 3 [6] + 9 + 1)
+              secrets#0,1
      19429    record (15 = 3 [3] + 11 + 1)
+              secure#0,1
      19444    record (16 = 3 [2] + 12 + 1)
+              seduce#0,1
      19460    record (13 = 3 [2] + 9 + 1)
+              see#0,1
      19473    record (13 = 3 [3] + 9 + 1)
+              seed#0,1
      19486    record (15 = 3 [3] + 11 + 1)
+              seeing#0,1
      19501    record (13 = 3 [3] + 9 + 1)
+              seek#0,1
      19514    record (13 = 3 [3] + 9 + 1)
+              seem#0,1
      19527    record (15 = 3 [4] + 11 + 1)
+              seeming#0,1
      19542    record (13 = 3 [4] + 9 + 1)
+              seems#0,1
      19555    record (13 = 3 [3] + 9 + 1)
+              seen#0,1
      19568    record (16 = 3 [2] + 12 + 1)
+              seized#0,1
      19584    record (18 = 3 [0] + 14 + 1) [restart]
+              select#0,1
      19602    record (13 = 3 [3] + 9 + 1)
+              self#0,1
      19615    record (15 = 3 [2] + 11 + 1)
+              sense#0,1
      19630    record (16 = 3 [4] + 12 + 1)
+              sensible#0,1
      19646    record (13 = 3 [3] + 9 + 1)
+              sent#0,1
      19659    record (19 = 3 [2] + 15 + 1)
+              sepulchre#0,1
      19678    record (17 = 3 [2] + 13 + 1)
+              serious#0,1
      19695    record (16 = 3 [3] + 12 + 1)
+              serpent#0,1
      19711    record (16 = 3 [3] + 12 + 1)
+              servant#0,1
      19727    record (13 = 3 [7] + 9 + 1)
+              servants#0,1
      19740    record (15 = 3 [4] + 11 + 1)
+              service#0,1
      19755    record (13 = 3 [2] + 9 + 1)
+              set#0,1
      19768    record (16 = 3 [1] + 12 + 1)
+              shake#0,1
      19784    record (15 = 3 [3] + 10 + 2)
+              shall#0,1
      19799    record (13 = 3 [4] + 9 + 1)
+              shalt#0,1
      19812    record (14 = 3 [3] + 10 + 1)
+              shame#0,1
      19826    record (20 = 3 [0] + 16 + 1) [restart]
+              shameful#0,1
      19846    record (14 = 3 [3] + 10 + 1)
+              shape#0,1
      19860    record (13 = 3 [5] + 9 + 1)
+              shapes#0,1
      19873    record (14 = 3 [3] + 10 + 1)
+              shark#0,1
      19887    record (13 = 3 [2] + 9 + 1)
+              she#0,1
      19900    record (16 = 3 [3] + 12 + 1)
+              sheeted#0,1
      19916    record (13 = 3 [5] + 9 + 1)
+              sheets#0,1
      19929    record (15 = 3 [2] + 11 + 1)
+              shift#0,1
      19944    record (20 = 3 [3] + 16 + 1)
+              shipwrights#0,1
      19964    record (15 = 3 [2] + 11 + 1)
+              shoes#0,1
      19979    record (13 = 3 [3] + 9 + 1)
+              shot#0,1
      19992    record (15 = 3 [3] + 11 + 1)
+              should#0,1
      20007    record (14 = 3 [6] + 10 + 1)
+              shoulder#0,1
      20021    record (14 = 3 [6] + 10 + 1)
+              shouldst#0,1
      20035    record (13 = 3 [3] + 9 + 1)
+              show#0,1
      20048    record (13 = 3 [4] + 9 + 1)
+              shows#0,1
      20061    record (20 = 3 [0] + 16 + 1) [restart]
+              shrewdly#0,1
      20081    record (15 = 3 [3] + 11 + 1)
+              shrill#0,1
      20096    record (15 = 3 [3] + 11 + 1)
+              shrunk#0,1
      20111    record (15 = 3 [1] + 11 + 1)
+              sick#0,1
      20126    record (14 = 3 [2] + 10 + 1)
+              side#0,1
      20140    record (15 = 3 [2] + 11 + 1)
+              sight#0,1
      20155    record (17 = 3 [2] + 13 + 1)
+              silence#0,1
      20172    record (15 = 3 [3] + 11 + 1)
+              silver#0,1
      20187    record (16 = 3 [2] + 12 + 1)
+              simple#0,1
      20203    record (13 = 3 [2] + 9 + 1)
+              sin#0,1
      20216    record (14 = 3 [3] + 10 + 1)
+              since#0,1
      20230    record (15 = 3 [3] + 11 + 1)
+              sinews#0,1
      20245    record (16 = 3 [3] + 12 + 1)
+              singeth#0,1
      20261    record (13 = 3 [2] + 9 + 1)
+              sir#0,1
      20274    record (13 = 3 [3] + 9 + 1)
+              sirs#0,1
      20287    record (16 = 3 [2] + 12 + 1)
+              sister#0,1
      20303    record (15 = 3 [0] + 11 + 1) [restart]
+              sit#0,1
      20318    record (13 = 3 [3] + 9 + 1)
+              sits#0,1
      20331    record (17 = 3 [1] + 13 + 1)
+              skirts#0,1
      20348    record (18 = 3 [1] + 14 + 1)
+              slander#0,1
      20366    record (18 = 3 [3] + 14 + 1)
+              slaughter#0,1
      20384    [restart 18384]
      20388    [restart 18637]
      20392    [restart 18878]
@@ -1506,137 +2807,269 @@ sstable layout
      20416    [restart 20303]
      20429  data (2030)
      20429    record (16 = 3 [0] + 12 + 1) [restart]
+              slay#0,1
      20445    record (17 = 3 [2] + 13 + 1)
+              sledded#0,1
      20462    record (14 = 3 [3] + 10 + 1)
+              sleep#0,1
      20476    record (15 = 3 [5] + 11 + 1)
+              sleeping#0,1
      20491    record (14 = 3 [2] + 10 + 1)
+              slow#0,1
      20505    record (16 = 3 [1] + 12 + 1)
+              smile#0,1
      20521    record (13 = 3 [5] + 9 + 1)
+              smiles#0,1
      20534    record (15 = 3 [4] + 11 + 1)
+              smiling#0,1
      20549    record (16 = 3 [2] + 12 + 1)
+              smooth#0,1
      20565    record (14 = 3 [3] + 10 + 1)
+              smote#0,1
      20579    record (14 = 3 [1] + 9 + 2)
+              so#0,1
      20593    record (13 = 3 [2] + 9 + 1)
+              soe#0,1
      20606    record (14 = 3 [2] + 10 + 1)
+              soft#0,1
      20620    record (14 = 3 [2] + 10 + 1)
+              soil#0,1
      20634    record (17 = 3 [2] + 13 + 1)
+              soldier#0,1
      20651    record (13 = 3 [7] + 9 + 1)
+              soldiers#0,1
      20664    record (18 = 3 [0] + 14 + 1) [restart]
+              solemn#0,1
      20682    record (14 = 3 [3] + 10 + 1)
+              solid#0,1
      20696    record (15 = 3 [2] + 10 + 2)
+              some#0,1
      20711    record (17 = 3 [4] + 13 + 1)
+              something#0,1
      20728    record (15 = 3 [5] + 11 + 1)
+              sometime#0,1
      20743    record (13 = 3 [8] + 9 + 1)
+              sometimes#0,1
      20756    record (16 = 3 [4] + 12 + 1)
+              somewhat#0,1
      20772    record (13 = 3 [2] + 9 + 1)
+              son#0,1
      20785    record (14 = 3 [3] + 10 + 1)
+              songs#0,1
      20799    record (14 = 3 [2] + 10 + 1)
+              sore#0,1
      20813    record (15 = 3 [3] + 11 + 1)
+              sorrow#0,1
      20828    record (13 = 3 [4] + 9 + 1)
+              sorry#0,1
      20841    record (13 = 3 [3] + 9 + 1)
+              sort#0,1
      20854    record (14 = 3 [2] + 10 + 1)
+              soul#0,1
      20868    record (13 = 3 [4] + 9 + 1)
+              souls#0,1
      20881    record (14 = 3 [3] + 10 + 1)
+              sound#0,1
      20895    record (20 = 3 [0] + 16 + 1) [restart]
+              sounding#0,1
      20915    record (15 = 3 [3] + 11 + 1)
+              source#0,1
      20930    record (21 = 3 [2] + 17 + 1)
+              sovereignty#0,1
      20951    record (17 = 3 [1] + 12 + 2)
+              speak#0,1
      20968    record (15 = 3 [5] + 11 + 1)
+              speaking#0,1
      20983    record (15 = 3 [3] + 11 + 1)
+              speech#0,1
      20998    record (13 = 3 [4] + 9 + 1)
+              speed#0,1
      21011    record (14 = 3 [3] + 10 + 1)
+              spend#0,1
      21025    record (17 = 3 [2] + 13 + 1)
+              spheres#0,1
      21042    record (16 = 3 [2] + 12 + 1)
+              spirit#0,1
      21058    record (13 = 3 [6] + 9 + 1)
+              spirits#0,1
      21071    record (14 = 3 [3] + 10 + 1)
+              spite#0,1
      21085    record (15 = 3 [2] + 11 + 1)
+              spoke#0,1
      21100    record (16 = 3 [2] + 12 + 1)
+              spring#0,1
      21116    record (14 = 3 [6] + 10 + 1)
+              springes#0,1
      21130    record (17 = 3 [1] + 13 + 1)
+              squeak#0,1
      21147    record (14 = 3 [0] + 10 + 1) [restart]
+              st#0,1
      21161    record (15 = 3 [2] + 11 + 1)
+              stale#0,1
      21176    record (13 = 3 [4] + 9 + 1)
+              stalk#0,1
      21189    record (13 = 3 [5] + 9 + 1)
+              stalks#0,1
      21202    record (14 = 3 [3] + 10 + 1)
+              stamp#0,1
      21216    record (14 = 3 [3] + 10 + 1)
+              stand#0,1
      21230    record (13 = 3 [5] + 9 + 1)
+              stands#0,1
      21243    record (13 = 3 [3] + 9 + 1)
+              star#0,1
      21256    record (13 = 3 [4] + 9 + 1)
+              stars#0,1
      21269    record (13 = 3 [4] + 9 + 1)
+              start#0,1
      21282    record (14 = 3 [5] + 10 + 1)
+              started#0,1
      21296    record (14 = 3 [3] + 10 + 1)
+              state#0,1
      21310    record (14 = 3 [5] + 10 + 1)
+              stately#0,1
      21324    record (15 = 3 [4] + 11 + 1)
+              station#0,1
      21339    record (13 = 3 [3] + 9 + 1)
+              stay#0,1
      21352    record (15 = 3 [2] + 11 + 1)
+              steel#0,1
      21367    record (17 = 3 [0] + 13 + 1) [restart]
+              steep#0,1
      21384    record (17 = 3 [3] + 13 + 1)
+              sterling#0,1
      21401    record (17 = 3 [2] + 13 + 1)
+              stiffly#0,1
      21418    record (14 = 3 [3] + 10 + 1)
+              still#0,1
      21432    record (14 = 3 [3] + 10 + 1)
+              sting#0,1
      21446    record (13 = 3 [3] + 9 + 1)
+              stir#0,1
      21459    record (16 = 3 [4] + 12 + 1)
+              stirring#0,1
      21475    record (15 = 3 [2] + 11 + 1)
+              stole#0,1
      21490    record (16 = 3 [3] + 12 + 1)
+              stomach#0,1
      21506    record (14 = 3 [3] + 10 + 1)
+              stood#0,1
      21520    record (13 = 3 [3] + 9 + 1)
+              stop#0,1
      21533    record (14 = 3 [3] + 10 + 1)
+              story#0,1
      21547    record (17 = 3 [2] + 13 + 1)
+              strange#0,1
      21564    record (13 = 3 [7] + 9 + 1)
+              stranger#0,1
      21577    record (16 = 3 [3] + 12 + 1)
+              streets#0,1
      21593    record (15 = 3 [3] + 11 + 1)
+              strict#0,1
      21608    record (18 = 3 [0] + 14 + 1) [restart]
+              strike#0,1
      21626    record (16 = 3 [3] + 12 + 1)
+              strokes#0,1
      21642    record (14 = 3 [4] + 10 + 1)
+              strong#0,1
      21656    record (15 = 3 [3] + 11 + 1)
+              struck#0,1
      21671    record (22 = 3 [2] + 18 + 1)
+              stubbornness#0,1
      21693    record (16 = 3 [3] + 12 + 1)
+              student#0,1
      21709    record (14 = 3 [3] + 10 + 1)
+              stung#0,1
      21723    record (18 = 3 [1] + 14 + 1)
+              subject#0,1
      21741    record (18 = 3 [3] + 14 + 1)
+              substance#0,1
      21759    record (15 = 3 [2] + 10 + 2)
+              such#0,1
      21774    record (16 = 3 [2] + 12 + 1)
+              sudden#0,1
      21790    record (14 = 3 [2] + 10 + 1)
+              suit#0,1
      21804    record (13 = 3 [4] + 9 + 1)
+              suits#0,1
      21817    record (20 = 3 [2] + 16 + 1)
+              sulphurous#0,1
      21837    record (16 = 3 [2] + 12 + 1)
+              summit#0,1
      21853    record (15 = 3 [4] + 11 + 1)
+              summons#0,1
      21868    record (15 = 3 [0] + 11 + 1) [restart]
+              sun#0,1
      21883    record (15 = 3 [3] + 11 + 1)
+              sunday#0,1
      21898    record (20 = 3 [2] + 16 + 1)
+              suppliance#0,1
      21918    record (16 = 3 [4] + 12 + 1)
+              supposal#0,1
      21934    record (16 = 3 [4] + 12 + 1)
+              suppress#0,1
      21950    record (14 = 3 [2] + 10 + 1)
+              sure#0,1
      21964    record (18 = 3 [3] + 14 + 1)
+              surprised#0,1
      21982    record (18 = 3 [3] + 14 + 1)
+              surrender#0,1
      22000    record (17 = 3 [3] + 13 + 1)
+              survivor#0,1
      22017    record (21 = 3 [2] + 17 + 1)
+              suspiration#0,1
      22038    record (16 = 3 [3] + 12 + 1)
+              sustain#0,1
      22054    record (21 = 3 [1] + 17 + 1)
+              swaggering#0,1
      22075    record (16 = 3 [2] + 11 + 2)
+              swear#0,1
      22091    record (14 = 3 [4] + 10 + 1)
+              sweaty#0,1
      22105    record (14 = 3 [3] + 10 + 1)
+              sweep#0,1
      22119    record (13 = 3 [4] + 9 + 1)
+              sweet#0,1
      22132    record (17 = 3 [0] + 13 + 1) [restart]
+              swift#0,1
      22149    record (16 = 3 [3] + 12 + 1)
+              swinish#0,1
      22165    record (15 = 3 [2] + 11 + 1)
+              sword#0,1
      22180    record (13 = 3 [4] + 9 + 1)
+              sworn#0,1
      22193    record (14 = 3 [0] + 9 + 2)
+              t#0,1
      22207    record (13 = 3 [1] + 9 + 1)
+              ta#0,1
      22220    record (15 = 3 [2] + 11 + 1)
+              table#0,1
      22235    record (13 = 3 [5] + 9 + 1)
+              tables#0,1
      22248    record (15 = 3 [2] + 11 + 1)
+              taint#0,1
      22263    record (15 = 3 [2] + 10 + 2)
+              take#0,1
      22278    record (13 = 3 [4] + 9 + 1)
+              taken#0,1
      22291    record (13 = 3 [4] + 9 + 1)
+              takes#0,1
      22304    record (14 = 3 [2] + 10 + 1)
+              tale#0,1
      22318    record (13 = 3 [3] + 9 + 1)
+              talk#0,1
      22331    record (14 = 3 [2] + 10 + 1)
+              task#0,1
      22345    record (13 = 3 [2] + 9 + 1)
+              tax#0,1
      22358    record (17 = 3 [0] + 13 + 1) [restart]
+              teach#0,1
      22375    record (14 = 3 [3] + 10 + 1)
+              tears#0,1
      22389    record (14 = 3 [2] + 10 + 1)
+              tell#0,1
      22403    record (16 = 3 [2] + 12 + 1)
+              temple#0,1
      22419    [restart 20429]
      22423    [restart 20664]
      22427    [restart 20895]
@@ -1648,133 +3081,261 @@ sstable layout
      22451    [restart 22358]
      22464  data (2035)
      22464    record (17 = 3 [0] + 13 + 1) [restart]
+              tempt#0,1
      22481    record (17 = 3 [2] + 13 + 1)
+              tenable#0,1
      22498    record (18 = 3 [4] + 14 + 1)
+              tenantless#0,1
      22516    record (13 = 3 [3] + 9 + 1)
+              tend#0,1
      22529    record (14 = 3 [4] + 10 + 1)
+              tender#0,1
      22543    record (13 = 3 [6] + 9 + 1)
+              tenders#0,1
      22556    record (14 = 3 [2] + 10 + 1)
+              term#0,1
      22570    record (13 = 3 [4] + 9 + 1)
+              terms#0,1
      22583    record (16 = 3 [2] + 12 + 1)
+              tether#0,1
      22599    record (15 = 3 [3] + 11 + 1)
+              tetter#0,1
      22614    record (16 = 3 [1] + 11 + 2)
+              than#0,1
      22630    record (14 = 3 [4] + 10 + 1)
+              thanks#0,1
      22644    record (14 = 3 [3] + 9 + 2)
+              that#0,1
      22658    record (13 = 3 [3] + 9 + 1)
+              thaw#0,1
      22671    record (15 = 3 [2] + 9 + 3)
+              the#0,1
      22686    record (14 = 3 [3] + 9 + 2)
+              thee#0,1
      22700    record (18 = 3 [0] + 13 + 2) [restart]
+              their#0,1
      22718    record (14 = 3 [3] + 9 + 2)
+              them#0,1
      22732    record (13 = 3 [4] + 9 + 1)
+              theme#0,1
      22745    record (14 = 3 [3] + 9 + 2)
+              then#0,1
      22759    record (15 = 3 [3] + 10 + 2)
+              there#0,1
      22774    record (16 = 3 [5] + 12 + 1)
+              therefore#0,1
      22790    record (14 = 3 [5] + 10 + 1)
+              thereto#0,1
      22804    record (15 = 3 [3] + 10 + 2)
+              these#0,1
      22819    record (14 = 3 [3] + 10 + 1)
+              thews#0,1
      22833    record (14 = 3 [3] + 9 + 2)
+              they#0,1
      22847    record (14 = 3 [2] + 10 + 1)
+              thin#0,1
      22861    record (13 = 3 [4] + 9 + 1)
+              thine#0,1
      22874    record (13 = 3 [4] + 9 + 1)
+              thing#0,1
      22887    record (13 = 3 [5] + 9 + 1)
+              things#0,1
      22900    record (14 = 3 [4] + 9 + 2)
+              think#0,1
      22914    record (15 = 3 [5] + 11 + 1)
+              thinking#0,1
      22929    record (17 = 3 [0] + 13 + 1) [restart]
+              third#0,1
      22946    record (14 = 3 [3] + 9 + 2)
+              this#0,1
      22960    record (16 = 3 [2] + 12 + 1)
+              thorns#0,1
      22976    record (13 = 3 [5] + 9 + 1)
+              thorny#0,1
      22989    record (14 = 3 [3] + 10 + 1)
+              those#0,1
      23003    record (14 = 3 [3] + 9 + 2)
+              thou#0,1
      23017    record (15 = 3 [4] + 10 + 2)
+              though#0,1
      23032    record (13 = 3 [6] + 9 + 1)
+              thought#0,1
      23045    record (13 = 3 [7] + 9 + 1)
+              thoughts#0,1
      23058    record (16 = 3 [2] + 12 + 1)
+              thrice#0,1
      23074    record (14 = 3 [4] + 10 + 1)
+              thrift#0,1
      23088    record (15 = 3 [3] + 11 + 1)
+              throat#0,1
      23103    record (14 = 3 [4] + 10 + 1)
+              throne#0,1
      23117    record (15 = 3 [4] + 11 + 1)
+              through#0,1
      23132    record (13 = 3 [4] + 9 + 1)
+              throw#0,1
      23145    record (17 = 3 [2] + 13 + 1)
+              thunder#0,1
      23162    record (16 = 3 [0] + 12 + 1) [restart]
+              thus#0,1
      23178    record (14 = 3 [2] + 9 + 2)
+              thy#0,1
      23192    record (16 = 3 [3] + 12 + 1)
+              thyself#0,1
      23208    record (15 = 3 [1] + 11 + 1)
+              till#0,1
      23223    record (15 = 3 [2] + 10 + 2)
+              time#0,1
      23238    record (13 = 3 [4] + 9 + 1)
+              times#0,1
      23251    record (14 = 3 [2] + 9 + 2)
+              tis#0,1
      23265    record (15 = 3 [1] + 9 + 3)
+              to#0,1
      23280    record (13 = 3 [2] + 9 + 1)
+              toe#0,1
      23293    record (18 = 3 [2] + 14 + 1)
+              together#0,1
      23311    record (15 = 3 [2] + 11 + 1)
+              toils#0,1
      23326    record (14 = 3 [2] + 10 + 1)
+              told#0,1
      23340    record (16 = 3 [2] + 12 + 1)
+              tongue#0,1
      23356    record (13 = 3 [2] + 9 + 1)
+              too#0,1
      23369    record (13 = 3 [2] + 9 + 1)
+              top#0,1
      23382    record (20 = 3 [2] + 16 + 1)
+              tormenting#0,1
      23402    record (20 = 3 [0] + 16 + 1) [restart]
+              touching#0,1
      23422    record (16 = 3 [2] + 12 + 1)
+              toward#0,1
      23438    record (13 = 3 [2] + 9 + 1)
+              toy#0,1
      23451    record (13 = 3 [3] + 9 + 1)
+              toys#0,1
      23464    record (19 = 3 [1] + 15 + 1)
+              traduced#0,1
      23483    record (16 = 3 [3] + 12 + 1)
+              tragedy#0,1
      23499    record (15 = 3 [3] + 11 + 1)
+              trains#0,1
      23514    record (18 = 3 [4] + 14 + 1)
+              traitorous#0,1
      23532    record (18 = 3 [3] + 14 + 1)
+              trappings#0,1
      23550    record (16 = 3 [2] + 12 + 1)
+              treads#0,1
      23566    record (16 = 3 [4] + 12 + 1)
+              treasure#0,1
      23582    record (16 = 3 [3] + 12 + 1)
+              tremble#0,1
      23598    record (15 = 3 [2] + 11 + 1)
+              tried#0,1
      23613    record (17 = 3 [3] + 13 + 1)
+              trifling#0,1
      23630    record (16 = 3 [3] + 12 + 1)
+              triumph#0,1
      23646    record (16 = 3 [3] + 12 + 1)
+              trivial#0,1
      23662    record (19 = 3 [0] + 15 + 1) [restart]
+              trouble#0,1
      23681    record (13 = 3 [7] + 9 + 1)
+              troubles#0,1
      23694    record (16 = 3 [2] + 12 + 1)
+              truant#0,1
      23710    record (13 = 3 [3] + 9 + 1)
+              true#0,1
      23723    record (17 = 3 [4] + 13 + 1)
+              truepenny#0,1
      23740    record (14 = 3 [3] + 10 + 1)
+              truly#0,1
      23754    record (16 = 3 [3] + 12 + 1)
+              trumpet#0,1
      23770    record (13 = 3 [7] + 9 + 1)
+              trumpets#0,1
      23783    record (18 = 3 [3] + 14 + 1)
+              truncheon#0,1
      23801    record (16 = 3 [3] + 12 + 1)
+              truster#0,1
      23817    record (14 = 3 [3] + 10 + 1)
+              truth#0,1
      23831    record (15 = 3 [1] + 11 + 1)
+              tush#0,1
      23846    record (17 = 3 [1] + 13 + 1)
+              twelve#0,1
      23863    record (14 = 3 [3] + 10 + 1)
+              twere#0,1
      23877    record (15 = 3 [2] + 11 + 1)
+              twice#0,1
      23892    record (14 = 3 [3] + 10 + 1)
+              twill#0,1
      23906    record (17 = 3 [0] + 13 + 1) [restart]
+              twixt#0,1
      23923    record (13 = 3 [2] + 9 + 1)
+              two#0,1
      23936    record (18 = 3 [0] + 14 + 1)
+              ubique#0,1
      23954    record (17 = 3 [1] + 13 + 1)
+              unanel#0,1
      23971    record (15 = 3 [2] + 11 + 1)
+              uncle#0,1
      23986    record (17 = 3 [2] + 13 + 1)
+              undergo#0,1
      24003    record (17 = 3 [5] + 13 + 1)
+              understand#0,1
      24020    record (15 = 3 [10] + 11 + 1)
+              understanding#0,1
      24035    record (21 = 3 [2] + 17 + 1)
+              uneffectual#0,1
      24056    record (19 = 3 [2] + 15 + 1)
+              unfledged#0,1
      24075    record (15 = 3 [3] + 11 + 1)
+              unfold#0,1
      24090    record (16 = 3 [4] + 12 + 1)
+              unforced#0,1
      24106    record (18 = 3 [5] + 14 + 1)
+              unfortified#0,1
      24124    record (20 = 3 [2] + 16 + 1)
+              ungracious#0,1
      24144    record (16 = 3 [2] + 12 + 1)
+              unhand#0,1
      24160    record (15 = 3 [3] + 11 + 1)
+              unholy#0,1
      24175    record (20 = 3 [0] + 16 + 1) [restart]
+              unhousel#0,1
      24195    record (20 = 3 [2] + 16 + 1)
+              unimproved#0,1
      24215    record (17 = 3 [2] + 13 + 1)
+              unmanly#0,1
      24232    record (14 = 3 [4] + 10 + 1)
+              unmask#0,1
      24246    record (15 = 3 [5] + 11 + 1)
+              unmaster#0,1
      24261    record (14 = 3 [3] + 10 + 1)
+              unmix#0,1
      24275    record (19 = 3 [2] + 15 + 1)
+              unnatural#0,1
      24294    record (22 = 3 [2] + 18 + 1)
+              unprevailing#0,1
      24316    record (20 = 3 [4] + 16 + 1)
+              unprofitable#0,1
      24336    record (21 = 3 [5] + 17 + 1)
+              unproportioned#0,1
      24357    record (21 = 3 [2] + 17 + 1)
+              unrighteous#0,1
      24378    record (18 = 3 [2] + 14 + 1)
+              unschool#0,1
      24396    record (17 = 3 [3] + 13 + 1)
+              unsifted#0,1
      24413    record (14 = 3 [2] + 10 + 1)
+              unto#0,1
      24427    record (18 = 3 [2] + 14 + 1)
+              unvalued#0,1
      24445    record (18 = 3 [2] + 14 + 1)
+              unweeded#0,1
      24463    [restart 22464]
      24467    [restart 22700]
      24471    [restart 22929]
@@ -1785,139 +3346,273 @@ sstable layout
      24491    [restart 24175]
      24504  data (2036)
      24504    record (15 = 3 [0] + 10 + 2) [restart]
+              up#0,1
      24519    record (19 = 3 [2] + 15 + 1)
+              uphoarded#0,1
      24538    record (15 = 3 [2] + 10 + 2)
+              upon#0,1
      24553    record (14 = 3 [1] + 9 + 2)
+              us#0,1
      24567    record (13 = 3 [2] + 9 + 1)
+              use#0,1
      24580    record (13 = 3 [3] + 9 + 1)
+              uses#0,1
      24593    record (15 = 3 [2] + 11 + 1)
+              usurp#0,1
      24608    record (13 = 3 [0] + 9 + 1)
+              v#0,1
      24621    record (17 = 3 [1] + 13 + 1)
+              vailed#0,1
      24638    record (13 = 3 [3] + 9 + 1)
+              vain#0,1
      24651    record (17 = 3 [2] + 13 + 1)
+              valiant#0,1
      24668    record (16 = 3 [2] + 12 + 1)
+              vanish#0,1
      24684    record (19 = 3 [3] + 15 + 1)
+              vanquisher#0,1
      24703    record (14 = 3 [2] + 10 + 1)
+              vast#0,1
      24717    record (15 = 3 [1] + 11 + 1)
+              very#0,1
      24732    record (15 = 3 [1] + 11 + 1)
+              vial#0,1
      24747    record (19 = 3 [0] + 15 + 1) [restart]
+              vicious#0,1
      24766    record (16 = 3 [2] + 12 + 1)
+              vigour#0,1
      24782    record (14 = 3 [2] + 10 + 1)
+              vile#0,1
      24796    record (16 = 3 [3] + 12 + 1)
+              villain#0,1
      24812    record (18 = 3 [2] + 14 + 1)
+              violence#0,1
      24830    record (13 = 3 [5] + 9 + 1)
+              violet#0,1
      24843    record (16 = 3 [2] + 12 + 1)
+              virtue#0,1
      24859    record (13 = 3 [6] + 9 + 1)
+              virtues#0,1
      24872    record (15 = 3 [5] + 11 + 1)
+              virtuous#0,1
      24887    record (16 = 3 [2] + 12 + 1)
+              visage#0,1
      24903    record (15 = 3 [3] + 11 + 1)
+              vision#0,1
      24918    record (13 = 3 [4] + 9 + 1)
+              visit#0,1
      24931    record (16 = 3 [1] + 12 + 1)
+              voice#0,1
      24947    record (19 = 3 [2] + 15 + 1)
+              voltimand#0,1
      24966    record (15 = 3 [3] + 11 + 1)
+              volume#0,1
      24981    record (13 = 3 [2] + 9 + 1)
+              vow#0,1
      24994    record (16 = 3 [0] + 12 + 1) [restart]
+              vows#0,1
      25010    record (17 = 3 [1] + 13 + 1)
+              vulgar#0,1
      25027    record (16 = 3 [0] + 12 + 1)
+              wake#0,1
      25043    record (14 = 3 [2] + 10 + 1)
+              walk#0,1
      25057    record (13 = 3 [4] + 9 + 1)
+              walks#0,1
      25070    record (15 = 3 [2] + 11 + 1)
+              wants#0,1
      25085    record (13 = 3 [2] + 9 + 1)
+              war#0,1
      25098    record (16 = 3 [3] + 12 + 1)
+              warlike#0,1
      25114    record (16 = 3 [3] + 12 + 1)
+              warning#0,1
      25130    record (16 = 3 [3] + 12 + 1)
+              warrant#0,1
      25146    record (13 = 3 [3] + 9 + 1)
+              wars#0,1
      25159    record (13 = 3 [3] + 9 + 1)
+              wary#0,1
      25172    record (14 = 3 [2] + 9 + 2)
+              was#0,1
      25186    record (16 = 3 [3] + 12 + 1)
+              wassail#0,1
      25202    record (16 = 3 [2] + 11 + 2)
+              watch#0,1
      25218    record (15 = 3 [5] + 11 + 1)
+              watchman#0,1
      25233    record (17 = 3 [0] + 13 + 1) [restart]
+              waves#0,1
      25250    record (15 = 3 [2] + 11 + 1)
+              waxes#0,1
      25265    record (13 = 3 [2] + 9 + 1)
+              way#0,1
      25278    record (13 = 3 [3] + 9 + 1)
+              ways#0,1
      25291    record (14 = 3 [1] + 9 + 2)
+              we#0,1
      25305    record (14 = 3 [2] + 10 + 1)
+              weak#0,1
      25319    record (14 = 3 [3] + 10 + 1)
+              wears#0,1
      25333    record (13 = 3 [4] + 9 + 1)
+              weary#0,1
      25346    record (17 = 3 [2] + 13 + 1)
+              wedding#0,1
      25363    record (14 = 3 [2] + 10 + 1)
+              weed#0,1
      25377    record (13 = 3 [3] + 9 + 1)
+              week#0,1
      25390    record (15 = 3 [2] + 11 + 1)
+              weigh#0,1
      25405    record (15 = 3 [5] + 11 + 1)
+              weighing#0,1
      25420    record (17 = 3 [2] + 13 + 1)
+              welcome#0,1
      25437    record (14 = 3 [3] + 9 + 2)
+              well#0,1
      25451    record (14 = 3 [2] + 10 + 1)
+              went#0,1
      25465    record (16 = 3 [0] + 12 + 1) [restart]
+              were#0,1
      25481    record (14 = 3 [2] + 10 + 1)
+              west#0,1
      25495    record (16 = 3 [4] + 12 + 1)
+              westward#0,1
      25511    record (16 = 3 [1] + 12 + 1)
+              wharf#0,1
      25527    record (14 = 3 [3] + 9 + 2)
+              what#0,1
      25541    record (18 = 3 [4] + 14 + 1)
+              whatsoever#0,1
      25559    record (14 = 3 [2] + 10 + 1)
+              when#0,1
      25573    record (14 = 3 [4] + 10 + 1)
+              whence#0,1
      25587    record (14 = 3 [3] + 10 + 1)
+              where#0,1
      25601    record (16 = 3 [5] + 12 + 1)
+              wherefore#0,1
      25617    record (14 = 3 [5] + 10 + 1)
+              wherein#0,1
      25631    record (14 = 3 [5] + 10 + 1)
+              whereof#0,1
      25645    record (16 = 3 [3] + 12 + 1)
+              whether#0,1
      25661    record (16 = 3 [2] + 11 + 2)
+              which#0,1
      25677    record (14 = 3 [3] + 10 + 1)
+              while#0,1
      25691    record (13 = 3 [5] + 9 + 1)
+              whiles#0,1
      25704    record (18 = 3 [0] + 14 + 1) [restart]
+              whilst#0,1
      25722    record (17 = 3 [3] + 13 + 1)
+              whirling#0,1
      25739    record (16 = 3 [3] + 12 + 1)
+              whisper#0,1
      25755    record (13 = 3 [2] + 9 + 1)
+              who#0,1
      25768    record (14 = 3 [3] + 10 + 1)
+              whole#0,1
      25782    record (16 = 3 [5] + 12 + 1)
+              wholesome#0,1
      25798    record (14 = 3 [3] + 10 + 1)
+              whose#0,1
      25812    record (14 = 3 [2] + 9 + 2)
+              why#0,1
      25826    record (17 = 3 [1] + 13 + 1)
+              wicked#0,1
      25843    record (14 = 3 [2] + 10 + 1)
+              wide#0,1
      25857    record (14 = 3 [2] + 10 + 1)
+              wife#0,1
      25871    record (14 = 3 [2] + 10 + 1)
+              wild#0,1
      25885    record (14 = 3 [3] + 9 + 2)
+              will#0,1
      25899    record (15 = 3 [4] + 11 + 1)
+              willing#0,1
      25914    record (14 = 3 [7] + 10 + 1)
+              willingly#0,1
      25928    record (13 = 3 [3] + 9 + 1)
+              wilt#0,1
      25941    record (16 = 3 [0] + 12 + 1) [restart]
+              wind#0,1
      25957    record (13 = 3 [4] + 9 + 1)
+              winds#0,1
      25970    record (13 = 3 [4] + 9 + 1)
+              windy#0,1
      25983    record (14 = 3 [3] + 10 + 1)
+              wings#0,1
      25997    record (14 = 3 [2] + 10 + 1)
+              wipe#0,1
      26011    record (16 = 3 [2] + 12 + 1)
+              wisdom#0,1
      26027    record (13 = 3 [6] + 9 + 1)
+              wisdoms#0,1
      26040    record (15 = 3 [3] + 11 + 1)
+              wisest#0,1
      26055    record (15 = 3 [3] + 11 + 1)
+              wishes#0,1
      26070    record (13 = 3 [2] + 9 + 1)
+              wit#0,1
      26083    record (14 = 3 [3] + 10 + 1)
+              witch#0,1
      26097    record (17 = 3 [5] + 13 + 1)
+              witchcraft#0,1
      26114    record (14 = 3 [3] + 9 + 2)
+              with#0,1
      26128    record (14 = 3 [4] + 10 + 1)
+              withal#0,1
      26142    record (15 = 3 [4] + 10 + 2)
+              within#0,1
      26157    record (15 = 3 [4] + 11 + 1)
+              without#0,1
      26172    record (19 = 3 [0] + 15 + 1) [restart]
+              witness#0,1
      26191    record (19 = 3 [3] + 15 + 1)
+              wittenberg#0,1
      26210    record (14 = 3 [1] + 10 + 1)
+              woe#0,1
      26224    record (15 = 3 [2] + 11 + 1)
+              woman#0,1
      26239    record (13 = 3 [3] + 9 + 1)
+              womb#0,1
      26252    record (13 = 3 [2] + 9 + 1)
+              won#0,1
      26265    record (15 = 3 [3] + 11 + 1)
+              wonder#0,1
      26280    record (15 = 3 [6] + 11 + 1)
+              wonderful#0,1
      26295    record (16 = 3 [4] + 12 + 1)
+              wondrous#0,1
      26311    record (13 = 3 [3] + 9 + 1)
+              wont#0,1
      26324    record (19 = 3 [2] + 15 + 1)
+              woodcocks#0,1
      26343    record (14 = 3 [2] + 10 + 1)
+              word#0,1
      26357    record (13 = 3 [4] + 9 + 1)
+              words#0,1
      26370    record (13 = 3 [3] + 9 + 1)
+              wore#0,1
      26383    record (13 = 3 [3] + 9 + 1)
+              work#0,1
      26396    record (14 = 3 [3] + 10 + 1)
+              world#0,1
      26410    record (16 = 3 [0] + 12 + 1) [restart]
+              worm#0,1
      26426    record (14 = 3 [3] + 10 + 1)
+              worth#0,1
      26440    record (13 = 3 [5] + 9 + 1)
+              worthy#0,1
      26453    record (16 = 3 [2] + 11 + 2)
+              would#0,1
      26469    record (14 = 3 [5] + 10 + 1)
+              wouldst#0,1
      26483    record (17 = 3 [1] + 13 + 1)
+              wretch#0,1
      26500    [restart 24504]
      26504    [restart 24747]
      26508    [restart 24994]
@@ -1929,21 +3624,37 @@ sstable layout
      26532    [restart 26410]
      26545  data (249)
      26545    record (16 = 3 [0] + 12 + 1) [restart]
+              writ#0,1
      26561    record (15 = 3 [4] + 11 + 1)
+              writing#0,1
      26576    record (15 = 3 [2] + 11 + 1)
+              wrong#0,1
      26591    record (15 = 3 [2] + 11 + 1)
+              wrung#0,1
      26606    record (15 = 3 [0] + 11 + 1)
+              yea#0,1
      26621    record (13 = 3 [2] + 9 + 1)
+              yes#0,1
      26634    record (20 = 3 [3] + 16 + 1)
+              yesternight#0,1
      26654    record (13 = 3 [2] + 9 + 1)
+              yet#0,1
      26667    record (19 = 3 [1] + 15 + 1)
+              yielding#0,1
      26686    record (14 = 3 [1] + 10 + 1)
+              yon#0,1
      26700    record (13 = 3 [3] + 9 + 1)
+              yond#0,1
      26713    record (15 = 3 [2] + 9 + 3)
+              you#0,1
      26728    record (14 = 3 [3] + 10 + 1)
+              young#0,1
      26742    record (14 = 3 [3] + 9 + 2)
+              your#0,1
      26756    record (16 = 3 [4] + 12 + 1)
+              yourself#0,1
      26772    record (14 = 3 [3] + 10 + 1)
+              youth#0,1
      26786    [restart 26545]
      26799  index (120)
      26799    block:0/2041 [restart]
@@ -1984,6 +3695,57 @@ sstable layout
      27205    [restart 27166]
      27209    [restart 27185]
      27222  range-del (421)
+     27222    record (13 = 3 [0] + 9 + 1) [restart]
+              a-a#0,15
+     27235    record (23 = 3 [0] + 13 + 7) [restart]
+              beard-bearers#0,15
+     27258    record (24 = 3 [0] + 16 + 5) [restart]
+              carriage-carve#0,15
+     27282    record (21 = 3 [0] + 13 + 5) [restart]
+              cross-crows#0,15
+     27303    record (23 = 3 [0] + 14 + 6) [restart]
+              duller-duties#0,15
+     27326    record (21 = 3 [0] + 14 + 4) [restart]
+              fierce-fire#0,15
+     27347    record (21 = 3 [0] + 13 + 5) [restart]
+              grace-great#0,15
+     27368    record (17 = 3 [0] + 11 + 3) [restart]
+              how-ice#0,15
+     27385    record (20 = 3 [0] + 12 + 5) [restart]
+              lead-lends#0,15
+     27405    record (18 = 3 [0] + 12 + 3) [restart]
+              meet-met#0,15
+     27423    record (17 = 3 [0] + 10 + 4) [restart]
+              of-once#0,15
+     27440    record (25 = 3 [0] + 16 + 6) [restart]
+              precurse-prison#0,15
+     27465    record (15 = 3 [0] + 9 + 3) [restart]
+              s-saw#0,15
+     27480    record (19 = 3 [0] + 12 + 4) [restart]
+              slay-soil#0,15
+     27499    record (24 = 3 [0] + 16 + 5) [restart]
+              suppress-sword#0,15
+     27523    record (23 = 3 [0] + 16 + 4) [restart]
+              traduced-true#0,15
+     27546    record (25 = 3 [0] + 15 + 7) [restart]
+              warning-wedding#0,15
+     27571    [restart 27222]
+     27575    [restart 27235]
+     27579    [restart 27258]
+     27583    [restart 27282]
+     27587    [restart 27303]
+     27591    [restart 27326]
+     27595    [restart 27347]
+     27599    [restart 27368]
+     27603    [restart 27385]
+     27607    [restart 27405]
+     27611    [restart 27423]
+     27615    [restart 27440]
+     27619    [restart 27465]
+     27623    [restart 27480]
+     27627    [restart 27499]
+     27631    [restart 27523]
+     27635    [restart 27546]
      27648  properties (765)
      27648    rocksdb.block.based.table.index.type (43) [restart]
      27691    rocksdb.block.based.table.prefix.filtering (20)

--- a/tool/util.go
+++ b/tool/util.go
@@ -125,12 +125,21 @@ func formatKeyRange(w io.Writer, fmtKey formatter, start, end *base.InternalKey)
 func formatKeyValue(
 	w io.Writer, fmtKey formatter, fmtValue formatter, key *base.InternalKey, value []byte,
 ) {
-	needDelimiter := formatKey(w, fmtKey, key)
-	if fmtValue.spec != "null" {
-		if needDelimiter {
-			w.Write([]byte{' '})
+	if key.Kind() == base.InternalKeyKindRangeDelete {
+		if fmtKey.spec != "null" {
+			fmtKey.fn(w, key.UserKey)
+			w.Write([]byte{'-'})
+			fmtKey.fn(w, value)
+			fmt.Fprintf(w, "#%d,%d", key.SeqNum(), key.Kind())
 		}
-		fmtValue.fn(stdout, value)
+	} else {
+		needDelimiter := formatKey(w, fmtKey, key)
+		if fmtValue.spec != "null" {
+			if needDelimiter {
+				w.Write([]byte{' '})
+			}
+			fmtValue.fn(stdout, value)
+		}
 	}
 	w.Write([]byte{'\n'})
 }


### PR DESCRIPTION
Show layout of range-del blocks.

Optionally display keys and values in data and range-del blocks. This is
useful to see exactly what data has been stored in an sstable, and
provides visibility into the contents of the range-del block.

See #250