### PR TITLE
Don't pace flushes/compactions if there are no user writes

### DIFF
--- a/pacer_test.go
+++ b/pacer_test.go
@@ -65,6 +65,7 @@ func TestCompactionPacerMaybeThrottle(t *testing.T) {
 				}
 
 				burst := uint64(1)
+				dirtyBytes := uint64(1)
 				var bytesIterated uint64
 				var currentTotal uint64
 				var slowdownThreshold uint64
@@ -87,6 +88,8 @@ func TestCompactionPacerMaybeThrottle(t *testing.T) {
 							bytesIterated = varValue
 						case "currentTotal":
 							currentTotal = varValue
+						case "dirtyBytes":
+							dirtyBytes = varValue
 						case "slowdownThreshold":
 							slowdownThreshold = varValue
 						default:
@@ -102,6 +105,7 @@ func TestCompactionPacerMaybeThrottle(t *testing.T) {
 						return compactionPacerInfo{
 							slowdownThreshold:   slowdownThreshold,
 							totalCompactionDebt: currentTotal,
+							totalDirtyBytes:     dirtyBytes,
 						}
 					}
 					compactionPacer := newCompactionPacer(compactionPacerEnv{

--- a/testdata/compaction_pacer_maybe_throttle
+++ b/testdata/compaction_pacer_maybe_throttle
@@ -121,6 +121,15 @@ wait: 2
 
 init compaction
 burst: 10
+bytesIterated: 2
+currentTotal: 12
+dirtyBytes: 0
+slowdownThreshold: 10
+----
+allow: 2
+
+init compaction
+burst: 10
 bytesIterated: 3
 currentTotal: 14
 slowdownThreshold: 10


### PR DESCRIPTION
In the absence of user writes, allow flushes and compactions to proceed
as fast as possible, but lower the pacer recalculation threshold in
order to be nimble to new user writes.

Fixes #248